### PR TITLE
feat(i18n): namespace shell — chrome de la app (sidebar, palette, nav móvil, notificaciones) + MUST-FIX 15

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -7,6 +7,7 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState, type ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
 import { AppSidebar, type SidebarGroup } from '@/components/app-sidebar';
 import { CommandPalette } from '@/components/command-palette';
 import { Icon } from '@/components/icon';
@@ -19,6 +20,7 @@ import { FloatingChat, MessagingProvider } from '@/modules/messaging';
 import { authStorage, type StoredSession } from '@/lib/auth-storage';
 import { clearIntendedPath, rememberIntendedPath } from '@/lib/post-login-redirect';
 import { meApi } from '@/lib/me';
+import { labelOr } from '@/lib/i18n/labels';
 import { formatTenantName } from '@/lib/tenant-name';
 import { useTenantContext } from '@/lib/tenant-context';
 import { mergeExtensionSidebarItems } from '@/lib/sidebar-extensions-merge';
@@ -296,7 +298,14 @@ function Shell({
   // con fallback al slug title-cased.
   const { tenant: hostTenant } = useTenantContext();
   const tenantName = hostTenant?.name?.trim() || formatTenantName(session.user.tenantSlug);
-  const sectionLabel = resolveSectionLabel(mergedGroups, pathname ?? '');
+  // Los `label` del sidebar son TOKENS canónicos en español (ver SidebarContent):
+  // sin resolverlos, con la UI en inglés el `<title>` del navegador mezclaría
+  // idiomas. `labelOr` degrada al token crudo si no hay traducción.
+  const tNav = useTranslations('nav');
+  const rawSectionLabel = resolveSectionLabel(mergedGroups, pathname ?? '');
+  const sectionLabel = rawSectionLabel
+    ? labelOr(tNav, `items.${rawSectionLabel}`, rawSectionLabel)
+    : null;
   useEffect(() => {
     const parts = [sectionLabel, tenantName, 'Didacta'].filter((p): p is string => Boolean(p));
     document.title = parts.join(' | ');

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link';
 import { useEffect, useState, type CSSProperties } from 'react';
 import { useTranslations } from 'next-intl';
 import { Icon, type IconName } from '@/components/icon';
-import { labelOr } from '@/lib/i18n/labels';
+import { labelOr, type TranslatorLike } from '@/lib/i18n/labels';
 import { useTenantTheme } from '@/components/tenant-theme-provider';
 import { VersionUpdateBanner } from '@/components/version-update-banner';
 import type { StoredSession } from '@/lib/auth-storage';
@@ -155,6 +155,9 @@ export function SidebarContent({
   const tNav = useTranslations('nav');
   const groupLabel = (raw: string) => labelOr(tNav, `groups.${raw}`, raw);
   const itemLabel = (raw: string) => labelOr(tNav, `items.${raw}`, raw);
+  // Copy propio del chrome del shell (aria-labels, tooltips, botones): a
+  // diferencia de los labels de nav, esto SÍ son textos, no tokens.
+  const t = useTranslations('shell');
   const theme = useTenantTheme();
   const logoUrl = theme?.logoUrl ?? null;
   // Nombre visible de la organización: el nombre real del tenant (editable en
@@ -188,7 +191,7 @@ export function SidebarContent({
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={logoUrl}
-              alt="Logo"
+              alt={t('sidebar.logoAlt')}
               width={36}
               height={36}
               className="h-9 w-9 rounded-xl object-contain"
@@ -202,8 +205,8 @@ export function SidebarContent({
             <button
               type="button"
               onClick={onToggleCollapsed}
-              aria-label="Expandir menú"
-              title="Expandir menú"
+              aria-label={t('sidebar.expandMenu')}
+              title={t('sidebar.expandMenu')}
               className="grid h-7 w-7 place-items-center rounded-lg text-white/40 transition-colors hover:bg-white/8 hover:text-white/80"
             >
               <svg
@@ -224,8 +227,8 @@ export function SidebarContent({
           <button
             type="button"
             onClick={onOpenSearch}
-            aria-label="Buscar (⌘K)"
-            title="Buscar (⌘K)"
+            aria-label={t('sidebar.searchShortcut')}
+            title={t('sidebar.searchShortcut')}
             className="grid h-9 w-full place-items-center rounded-xl bg-white/8 text-white/40 ring-1 ring-white/5 transition-colors hover:bg-white/12 hover:text-white/70"
           >
             <svg
@@ -366,8 +369,8 @@ export function SidebarContent({
           <Link
             href={'/cuenta' as never}
             onClick={onNavigate}
-            title="Mi perfil"
-            aria-label="Mi perfil"
+            title={t('sidebar.myProfile')}
+            aria-label={t('sidebar.myProfile')}
           >
             {session.user.avatarUrl ? (
               // eslint-disable-next-line @next/next/no-img-element
@@ -393,8 +396,8 @@ export function SidebarContent({
               onNavigate?.();
               onLogout();
             }}
-            aria-label="Cerrar sesión"
-            title="Cerrar sesión"
+            aria-label={t('sidebar.logout')}
+            title={t('sidebar.logout')}
             className="grid h-7 w-7 place-items-center rounded-lg text-white/30 transition-colors hover:bg-white/8 hover:text-white/60"
           >
             <svg
@@ -437,7 +440,9 @@ export function SidebarContent({
               <div className="truncate text-[14px] font-bold leading-tight text-white">
                 {orgName}
               </div>
-              <div className="mt-0.5 text-[11px] text-white/40">Comunidad</div>
+              <div className="mt-0.5 text-[11px] text-white/40">
+                {t('sidebar.communitySubtitle')}
+              </div>
             </div>
           </div>
         )}
@@ -445,8 +450,8 @@ export function SidebarContent({
           <button
             type="button"
             onClick={onToggleCollapsed}
-            aria-label="Plegar menú"
-            title="Plegar menú"
+            aria-label={t('sidebar.collapseMenu')}
+            title={t('sidebar.collapseMenu')}
             className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white/40 transition-colors hover:bg-white/8 hover:text-white/80"
           >
             <svg
@@ -465,7 +470,7 @@ export function SidebarContent({
           <button
             type="button"
             onClick={onClose}
-            aria-label="Cerrar menú"
+            aria-label={t('closeMenu')}
             className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white/40 transition-colors hover:bg-white/8 hover:text-white/80"
           >
             <Icon name="x" size={18} />
@@ -492,7 +497,7 @@ export function SidebarContent({
             <circle cx="11" cy="11" r="8" />
             <path d="m21 21-4.35-4.35" />
           </svg>
-          <span className="flex-1 text-left">Buscar...</span>
+          <span className="flex-1 text-left">{t('sidebar.search')}</span>
           <kbd className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white/25">
             ⌘K
           </kbd>
@@ -688,8 +693,8 @@ export function SidebarContent({
           <Link
             href={'/cuenta' as never}
             onClick={onNavigate}
-            title="Mi perfil"
-            aria-label="Mi perfil"
+            title={t('sidebar.myProfile')}
+            aria-label={t('sidebar.myProfile')}
             className={
               (pathname?.startsWith('/cuenta') ? 'bg-white/8 ' : 'hover:bg-white/5 ') +
               'flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-1.5 py-1 transition-colors'
@@ -717,7 +722,7 @@ export function SidebarContent({
                 {name}
               </div>
               <div className="truncate text-[11px] text-white/40">
-                {humanRole(role)} · {session.user.tenantSlug}
+                {humanRole(role, t)} · {session.user.tenantSlug}
               </div>
             </div>
           </Link>
@@ -727,8 +732,8 @@ export function SidebarContent({
               onNavigate?.();
               onLogout();
             }}
-            aria-label="Cerrar sesión"
-            title="Cerrar sesión"
+            aria-label={t('sidebar.logout')}
+            title={t('sidebar.logout')}
             className="grid h-7 w-7 shrink-0 place-items-center rounded-lg text-white/30 transition-colors hover:bg-white/8 hover:text-white/60"
           >
             <svg
@@ -749,21 +754,11 @@ export function SidebarContent({
   );
 }
 
-function humanRole(role: string): string {
-  switch (role) {
-    case 'super_admin':
-      return 'Super admin';
-    case 'tenant_admin':
-      return 'Administradora';
-    case 'formador':
-      return 'Formador';
-    case 'alumno':
-      return 'Alumno';
-    case 'auditor':
-      return 'Auditor';
-    case 'empresa_manager':
-      return 'Manager';
-    default:
-      return role;
-  }
+/**
+ * Rol → etiqueta legible. El rol llega de la API, así que puede ser uno que el
+ * catálogo aún no conozca: `labelOr` degrada al valor CRUDO (nunca a la key),
+ * que es justo lo que hacía el `default` del switch anterior.
+ */
+function humanRole(role: string, t: TranslatorLike): string {
+  return labelOr(t, `roles.${role}`, role);
 }

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -7,7 +7,9 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useTranslations } from 'next-intl';
 import { Icon } from '@/components/icon';
+import { labelOr } from '@/lib/i18n/labels';
 import { Dialog } from '@/components/ui/dialog';
 import type { SidebarGroup } from '@/components/app-sidebar';
 
@@ -34,6 +36,11 @@ export function CommandPalette({
   groups: SidebarGroup[];
 }) {
   const router = useRouter();
+  const t = useTranslations('shell');
+  // Los `label`/`group` del sidebar son TOKENS canónicos en español (ver
+  // SidebarContent); aquí se resuelven a su PRESENTACIÓN antes de aplanar, para
+  // que la lista se muestre Y se filtre en el idioma activo.
+  const tNav = useTranslations('nav');
   const [q, setQ] = useState('');
   const [active, setActive] = useState(0);
   const listRef = useRef<HTMLUListElement>(null);
@@ -45,20 +52,20 @@ export function CommandPalette({
           .filter((i) => i.href)
           .map((i) => ({
             href: i.href,
-            label: i.label,
-            group: g.label,
+            label: labelOr(tNav, `items.${i.label}`, i.label),
+            group: labelOr(tNav, `groups.${g.label}`, g.label),
             icon: i.icon,
             emoji: i.emoji,
           })),
       ),
-    [groups],
+    [groups, tNav],
   );
 
   const filtered = useMemo(() => {
-    const t = q.trim().toLowerCase();
-    if (!t) return items;
+    const needle = q.trim().toLowerCase();
+    if (!needle) return items;
     return items.filter(
-      (i) => i.label.toLowerCase().includes(t) || i.group.toLowerCase().includes(t),
+      (i) => i.label.toLowerCase().includes(needle) || i.group.toLowerCase().includes(needle),
     );
   }, [q, items]);
 
@@ -104,7 +111,7 @@ export function CommandPalette({
       onOpenChange={(o) => {
         if (!o) onClose();
       }}
-      ariaLabel="Buscar y navegar"
+      ariaLabel={t('palette.ariaLabel')}
       maxWidthClass="max-w-lg"
       contentClassName="p-0 overflow-hidden"
     >
@@ -115,14 +122,16 @@ export function CommandPalette({
           value={q}
           onChange={(e) => setQ(e.target.value)}
           onKeyDown={onKeyDown}
-          placeholder="Buscar secciones…"
+          placeholder={t('palette.placeholder')}
           className="w-full bg-transparent text-sm text-text placeholder:text-text-subtle focus:outline-none"
-          aria-label="Buscar secciones"
+          aria-label={t('palette.inputAriaLabel')}
         />
       </div>
       <ul ref={listRef} className="max-h-80 overflow-y-auto p-2">
         {filtered.length === 0 ? (
-          <li className="px-3 py-6 text-center text-sm text-text-muted">Sin resultados</li>
+          <li className="px-3 py-6 text-center text-sm text-text-muted">
+            {t('palette.noResults')}
+          </li>
         ) : (
           filtered.map((it, idx) => (
             <li key={`${it.group}-${it.href}`}>

--- a/apps/web/src/components/mobile-nav-drawer.tsx
+++ b/apps/web/src/components/mobile-nav-drawer.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { SIDEBAR_BG_STYLE, SidebarContent, type SidebarGroup } from '@/components/app-sidebar';
 import type { StoredSession } from '@/lib/auth-storage';
 
@@ -43,6 +44,8 @@ export function MobileNavDrawer({
   onOpenSearch,
   backLink,
 }: Props) {
+  const t = useTranslations('shell');
+
   // Bloqueo de scroll del body + cierre con Escape mientras el drawer está abierto.
   useEffect(() => {
     if (!open) return;
@@ -67,7 +70,7 @@ export function MobileNavDrawer({
       <button
         type="button"
         tabIndex={open ? 0 : -1}
-        aria-label="Cerrar menú"
+        aria-label={t('closeMenu')}
         onClick={onClose}
         className={`absolute inset-0 bg-[#0d1b2a]/60 transition-opacity duration-300 ease-out ${
           open ? 'opacity-100' : 'opacity-0'
@@ -78,7 +81,7 @@ export function MobileNavDrawer({
       <aside
         role="dialog"
         aria-modal="true"
-        aria-label="Menú de navegación"
+        aria-label={t('drawer.ariaLabel')}
         className={`absolute inset-y-0 left-0 flex w-71 max-w-[85vw] flex-col overflow-hidden text-white shadow-xl transition-transform duration-300 ease-out ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}

--- a/apps/web/src/components/mobile-tab-bar.tsx
+++ b/apps/web/src/components/mobile-tab-bar.tsx
@@ -6,6 +6,7 @@
  */
 
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { Icon, type IconName } from '@/components/icon';
 
 interface Props {
@@ -16,7 +17,8 @@ interface Props {
 
 interface Tab {
   href: string;
-  label: string;
+  /** Sufijo de la key `shell.tabBar.*` con el rótulo de la pestaña. */
+  labelKey: 'feed' | 'cursos' | 'miembros' | 'perfil';
   icon: IconName;
   /** Prefijos de ruta que marcan la pestaña como activa. */
   matches: string[];
@@ -30,10 +32,10 @@ interface Tab {
  * de un espacio de comunidad (`/espacios/...`), que es contenido del feed.
  */
 const TABS: Tab[] = [
-  { href: '/comunidad', label: 'Feed', icon: 'globe', matches: ['/comunidad', '/espacios'] },
-  { href: '/cursos', label: 'Cursos', icon: 'book', matches: ['/cursos'] },
-  { href: '/miembros', label: 'Miembros', icon: 'users', matches: ['/miembros'] },
-  { href: '/cuenta', label: 'Perfil', icon: 'user', matches: ['/cuenta'] },
+  { href: '/comunidad', labelKey: 'feed', icon: 'globe', matches: ['/comunidad', '/espacios'] },
+  { href: '/cursos', labelKey: 'cursos', icon: 'book', matches: ['/cursos'] },
+  { href: '/miembros', labelKey: 'miembros', icon: 'users', matches: ['/miembros'] },
+  { href: '/cuenta', labelKey: 'perfil', icon: 'user', matches: ['/cuenta'] },
 ];
 
 function isActive(pathname: string, matches: string[]): boolean {
@@ -41,6 +43,7 @@ function isActive(pathname: string, matches: string[]): boolean {
 }
 
 export function MobileTabBar({ pathname, onOpenMenu }: Props) {
+  const t = useTranslations('shell');
   const p = pathname ?? '';
 
   const itemClass = (active: boolean) =>
@@ -50,7 +53,7 @@ export function MobileTabBar({ pathname, onOpenMenu }: Props) {
 
   return (
     <nav
-      aria-label="Navegación principal"
+      aria-label={t('tabBar.ariaLabel')}
       className="fixed inset-x-0 bottom-0 z-(--z-sticky) flex items-stretch border-t border-border-soft bg-surface/95 backdrop-blur lg:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
     >
@@ -64,13 +67,13 @@ export function MobileTabBar({ pathname, onOpenMenu }: Props) {
             className={itemClass(active)}
           >
             <Icon name={tab.icon} size={22} strokeWidth={active ? 2 : 1.75} />
-            <span>{tab.label}</span>
+            <span>{t(`tabBar.${tab.labelKey}`)}</span>
           </Link>
         );
       })}
       <button type="button" onClick={onOpenMenu} className={itemClass(false)}>
         <Icon name="menu" size={22} />
-        <span>Menú</span>
+        <span>{t('tabBar.menu')}</span>
       </button>
     </nav>
   );

--- a/apps/web/src/components/notifications-bell.tsx
+++ b/apps/web/src/components/notifications-bell.tsx
@@ -8,6 +8,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { useNotificationsContext } from './notifications-provider';
 
 /**
@@ -16,6 +17,7 @@ import { useNotificationsContext } from './notifications-provider';
  * campana solo lo consume por contexto.
  */
 export function NotificationsBell() {
+  const t = useTranslations('shell');
   const { unreadCount, refresh } = useNotificationsContext();
   const pathname = usePathname();
 
@@ -33,8 +35,16 @@ export function NotificationsBell() {
     <Link
       href="/notificaciones"
       className="relative inline-flex items-center justify-center rounded-md p-2 text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
-      aria-label={unreadCount > 0 ? `${unreadCount} notificaciones sin leer` : 'Notificaciones'}
-      title={unreadCount > 0 ? `${unreadCount} sin leer` : 'Notificaciones'}
+      aria-label={
+        unreadCount > 0
+          ? t('notifications.unreadAria', { count: unreadCount })
+          : t('notifications.title')
+      }
+      title={
+        unreadCount > 0
+          ? t('notifications.unreadShort', { count: unreadCount })
+          : t('notifications.title')
+      }
     >
       <BellIcon />
       {unreadCount > 0 ? (

--- a/apps/web/src/components/notifications-toaster.tsx
+++ b/apps/web/src/components/notifications-toaster.tsx
@@ -7,6 +7,7 @@
 
 import Link from 'next/link';
 import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { notificationLink } from '@/lib/notification-link';
 import { useNotificationsContext, type ToastItem } from './notifications-provider';
 
@@ -45,6 +46,7 @@ export function NotificationsToaster() {
 }
 
 function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: string) => void }) {
+  const t = useTranslations('shell');
   const { id } = toast;
 
   useEffect(() => {
@@ -53,7 +55,7 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: str
   }, [id, onDismiss]);
 
   const link = notificationLink(toast.templateKey, toast.metadata);
-  const title = toast.subject ?? 'Nueva notificación';
+  const title = toast.subject ?? t('notifications.toastDefaultTitle');
 
   return (
     <div
@@ -82,7 +84,7 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: str
       <button
         type="button"
         onClick={() => onDismiss(id)}
-        aria-label="Cerrar notificación"
+        aria-label={t('notifications.toastClose')}
         className="shrink-0 rounded-md p-1 text-text-subtle transition-colors hover:bg-neutral-100 hover:text-text dark:hover:bg-neutral-800"
       >
         <svg

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -8,6 +8,7 @@
 import * as React from 'react';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
 interface DialogContextValue {
@@ -104,6 +105,8 @@ export interface DialogContentProps {
 }
 
 export function DialogContent({ children, className }: DialogContentProps) {
+  // Antes de los early-returns de abajo: el orden de hooks no puede variar.
+  const t = useTranslations('shell');
   const ctx = React.useContext(DialogContext);
   const panelRef = useRef<HTMLDivElement>(null);
   const close = useCallback(() => ctx?.onOpenChange(false), [ctx]);
@@ -146,7 +149,7 @@ export function DialogContent({ children, className }: DialogContentProps) {
         <button
           type="button"
           onClick={close}
-          aria-label="Cerrar"
+          aria-label={t('dialog.close')}
           className="absolute right-3 top-3 z-10 rounded-md p-1 text-text-muted hover:text-text"
         >
           X
@@ -213,6 +216,8 @@ function DialogLegacy({
   maxWidthClass?: string;
   contentClassName?: string;
 }): React.JSX.Element | null {
+  // Antes de los early-returns de abajo: el orden de hooks no puede variar.
+  const t = useTranslations('shell');
   const panelRef = useRef<HTMLDivElement>(null);
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
@@ -245,7 +250,7 @@ function DialogLegacy({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        aria-label={ariaLabel ?? 'Dialog'}
+        aria-label={ariaLabel ?? t('dialog.fallbackLabel')}
         className={cn(
           'relative flex max-h-[85vh] w-full flex-col overflow-hidden rounded-lg border bg-surface shadow-2xl',
           maxWidthClass,
@@ -261,7 +266,7 @@ function DialogLegacy({
         <button
           type="button"
           onClick={close}
-          aria-label="Cerrar"
+          aria-label={t('dialog.close')}
           className="absolute right-3 top-3 z-10 rounded-md p-1 text-text-muted hover:text-text"
         >
           X

--- a/apps/web/src/components/version-update-banner.tsx
+++ b/apps/web/src/components/version-update-banner.tsx
@@ -16,9 +16,11 @@
 /// versión nueva) y "X" para descartar.
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { checkForUpdate, dismissVersion, type VersionCheckResult } from '@/lib/version-check';
 
 export function VersionUpdateBanner() {
+  const t = useTranslations('shell');
   const [check, setCheck] = useState<VersionCheckResult | null>(null);
 
   useEffect(() => {
@@ -42,7 +44,7 @@ export function VersionUpdateBanner() {
     <div className="border-t border-amber-400/20 bg-amber-400/[0.08] px-4 py-2 text-[11px] text-amber-100">
       <div className="flex items-center justify-between gap-2">
         <span className="truncate">
-          <strong>Nueva versión:</strong> <span className="font-mono">{tag}</span>
+          <strong>{t('versionBanner.label')}</strong> <span className="font-mono">{tag}</span>
         </span>
         <div className="flex shrink-0 items-center gap-2">
           <a
@@ -51,7 +53,7 @@ export function VersionUpdateBanner() {
             rel="noreferrer"
             className="rounded bg-amber-400/[0.16] px-1.5 py-0.5 text-amber-100 hover:bg-amber-400/[0.25]"
           >
-            Ver
+            {t('versionBanner.view')}
           </a>
           <button
             type="button"
@@ -59,7 +61,7 @@ export function VersionUpdateBanner() {
               dismissVersion(tag);
               setCheck((c) => (c ? { ...c, hasUpdate: false } : c));
             }}
-            aria-label="Descartar aviso de versión nueva"
+            aria-label={t('versionBanner.dismiss')}
             className="rounded px-1 text-amber-200/60 hover:text-amber-100"
           >
             ✕

--- a/apps/web/src/i18n/messages/en/shell.json
+++ b/apps/web/src/i18n/messages/en/shell.json
@@ -1,1 +1,54 @@
-{}
+{
+  "closeMenu": "Close menu",
+  "sidebar": {
+    "logoAlt": "Logo",
+    "expandMenu": "Expand menu",
+    "collapseMenu": "Collapse menu",
+    "search": "Search...",
+    "searchShortcut": "Search (⌘K)",
+    "communitySubtitle": "Community",
+    "myProfile": "My profile",
+    "logout": "Log out"
+  },
+  "roles": {
+    "super_admin": "Super admin",
+    "tenant_admin": "Administrator",
+    "formador": "Instructor",
+    "alumno": "Student",
+    "auditor": "Auditor",
+    "empresa_manager": "Manager"
+  },
+  "palette": {
+    "ariaLabel": "Search and navigate",
+    "placeholder": "Search sections…",
+    "inputAriaLabel": "Search sections",
+    "noResults": "No results"
+  },
+  "drawer": {
+    "ariaLabel": "Navigation menu"
+  },
+  "tabBar": {
+    "ariaLabel": "Main navigation",
+    "feed": "Feed",
+    "cursos": "Courses",
+    "miembros": "Members",
+    "perfil": "Profile",
+    "menu": "Menu"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "unreadAria": "{count, plural, one {# unread notification} other {# unread notifications}}",
+    "unreadShort": "{count} unread",
+    "toastDefaultTitle": "New notification",
+    "toastClose": "Close notification"
+  },
+  "versionBanner": {
+    "label": "New version:",
+    "view": "View",
+    "dismiss": "Dismiss new version notice"
+  },
+  "dialog": {
+    "close": "Close",
+    "fallbackLabel": "Dialog"
+  }
+}

--- a/apps/web/src/i18n/messages/es/shell.json
+++ b/apps/web/src/i18n/messages/es/shell.json
@@ -1,1 +1,54 @@
-{}
+{
+  "closeMenu": "Cerrar menú",
+  "sidebar": {
+    "logoAlt": "Logo",
+    "expandMenu": "Expandir menú",
+    "collapseMenu": "Plegar menú",
+    "search": "Buscar...",
+    "searchShortcut": "Buscar (⌘K)",
+    "communitySubtitle": "Comunidad",
+    "myProfile": "Mi perfil",
+    "logout": "Cerrar sesión"
+  },
+  "roles": {
+    "super_admin": "Super admin",
+    "tenant_admin": "Administradora",
+    "formador": "Formador",
+    "alumno": "Alumno",
+    "auditor": "Auditor",
+    "empresa_manager": "Manager"
+  },
+  "palette": {
+    "ariaLabel": "Buscar y navegar",
+    "placeholder": "Buscar secciones…",
+    "inputAriaLabel": "Buscar secciones",
+    "noResults": "Sin resultados"
+  },
+  "drawer": {
+    "ariaLabel": "Menú de navegación"
+  },
+  "tabBar": {
+    "ariaLabel": "Navegación principal",
+    "feed": "Feed",
+    "cursos": "Cursos",
+    "miembros": "Miembros",
+    "perfil": "Perfil",
+    "menu": "Menú"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "unreadAria": "{count} notificaciones sin leer",
+    "unreadShort": "{count} sin leer",
+    "toastDefaultTitle": "Nueva notificación",
+    "toastClose": "Cerrar notificación"
+  },
+  "versionBanner": {
+    "label": "Nueva versión:",
+    "view": "Ver",
+    "dismiss": "Descartar aviso de versión nueva"
+  },
+  "dialog": {
+    "close": "Cerrar",
+    "fallbackLabel": "Dialog"
+  }
+}


### PR DESCRIPTION
Unidad **W18** de la migración i18n: namespace `shell` (el chrome de la app autenticada).

## Resumen

**36 keys** con paridad exacta ES/EN en `apps/web/src/i18n/messages/{es,en}/shell.json` (ambos ficheros existían vacíos en el base).

El copy español va **byte-exacto**: verificado key por key contra las líneas eliminadas del diff respecto de `3dab6b3c` (36/36 encontradas literalmente en el fuente original). Ningún texto "mejorado".

Los **labels de navegación no se tocan**: siguen siendo los tokens canónicos de `lib/sidebar-nav.ts` y de los manifests de módulos, resueltos por presentación con `labelOr` contra el namespace `nav` (mecanismo que ya traía el base).

## Ficheros tocados

| Fichero | Qué se migró |
|---|---|
| `apps/web/src/i18n/messages/es/shell.json` | catálogo canónico (36 keys) |
| `apps/web/src/i18n/messages/en/shell.json` | traducción profesional neutra |
| `components/app-sidebar.tsx` | solo copy suelto: `alt`, aria-labels y tooltips de plegar/expandir/cerrar/buscar, "Comunidad", "Buscar...", "Mi perfil", "Cerrar sesión" y el diccionario de roles. **Los labels de nav no se tocaron.** |
| `components/command-palette.tsx` | aria-label del diálogo, placeholder, aria del input, "Sin resultados" |
| `components/mobile-nav-drawer.tsx` | aria del scrim y del panel |
| `components/mobile-tab-bar.tsx` | aria de la nav + rótulos de las 5 pestañas |
| `components/notifications-bell.tsx` | aria-label y title (con plural ICU en EN) |
| `components/notifications-toaster.tsx` | título por defecto del toast + botón de cierre |
| `components/version-update-banner.tsx` | etiqueta, CTA "Ver", aria de descarte |
| `components/ui/dialog.tsx` | los dos `aria-label="Cerrar"` + el fallback del `aria-label` del diálogo legacy |
| `app/(app)/layout.tsx` | **solo MUST-FIX 15** (ver más abajo) |

### Dos arreglos de fondo, no solo extracción

1. **`humanRole`** era un `switch` con `default: return role`. Pasa a `labelOr(t, \`roles.${role}\`, role)`: el rol viene de la API, así que uno desconocido sigue degradando al valor **crudo**, nunca a la key.
2. **El command palette renderizaba y filtraba por `label`/`group` crudos.** Con la UI en inglés habría mostrado la lista en español *y* la búsqueda solo habría casado contra texto español. Ahora se resuelven antes de aplanar, así lista y filtro van en el idioma activo.

## Ficheros dejados intactos a propósito

- **`components/app-header.tsx`** — cero literales: título, descripción y acciones entran como props.
- **`components/notifications-provider.tsx`**, **`components/tenant-theme-provider.tsx`**, **`components/tenant-title.tsx`** — sin copy visible (solo lógica, contexto y comentarios). En `tenant-title.tsx` la constante `BRAND = 'Didacta'` y el sufijo `powered by` son marca de producto, no copy traducible.
- **`components/ui/**` (12 de 13 ficheros)** — soy el único worker que toca esta carpeta y la he barrido entera: `alert-dialog`, `badge`, `button`, `card`, `input`, `label`, `progress`, `select`, `skeleton`, `switch`, `tabs`, `textarea` son **primitivas shadcn sin copy**; todo su texto en español está en comentarios de código y JSDoc. El único con copy real era `dialog.tsx`. No hay paginación ni empty states en esta carpeta.
- **`lib/module-registry.ts`** — solo tipos y comentarios. Ojo: la unión `group` (`'Aprendizaje' | 'Personas' | …`) son los **tokens canónicos de grupo del sidebar**, mismo contrato que `sidebar-nav.ts`: son keys, no copy. Se quedan en español.
- **`lib/module-runtime.ts`** y **`lib/module-loader.ts`** — ver HALLAZGOS #1: tienen mensajes de `Error` en español, pero no son componentes (no pueden usar hooks) y traducirlos exige o bien keys en `errors.json` (fuera de mi frontera) o cambiar firmas que consumen ficheros de otras unidades.
- **`lib/sidebar-nav.ts`** — vetado por contrato; sus labels son tokens.

## CONFLICTO ESPERADO CON PR #22

`app/(app)/layout.tsx` pertenece a **W14 (PR #22, `feat/i18n-w14-alumno-social`)**, que ya lo migró entero pero aún no está en este base. Lo he tocado con el cambio mínimo para cerrar el **MUST-FIX 15** y lo he aislado en su **propio commit** (`33d36f82`) para que la resolución sea mecánica.

**Hunk exacto (mi lado):**

```diff
-  const sectionLabel = resolveSectionLabel(mergedGroups, pathname ?? '');
+  // Los `label` del sidebar son TOKENS canónicos en español (ver SidebarContent):
+  // sin resolverlos, con la UI en inglés el `<title>` del navegador mezclaría
+  // idiomas. `labelOr` degrada al token crudo si no hay traducción.
+  const tNav = useTranslations('nav');
+  const rawSectionLabel = resolveSectionLabel(mergedGroups, pathname ?? '');
+  const sectionLabel = rawSectionLabel
+    ? labelOr(tNav, `items.${rawSectionLabel}`, rawSectionLabel)
+    : null;
```

Más dos imports: `useTranslations` de `next-intl` (**línea idéntica a la que añade W14**, debería auto-mergear) y `labelOr` de `@/lib/i18n/labels` (solo mío).

**Receta de resolución — quedarse con la versión de W14 y añadir encima mi `labelOr`:**

```ts
const tNav = useTranslations('nav');
const rawSectionLabel = resolveSectionLabel(mergedGroups, pathname ?? '', sectionExtras); // ← firma de W14
const sectionLabel = rawSectionLabel
  ? labelOr(tNav, `items.${rawSectionLabel}`, rawSectionLabel)
  : null;
```

Es decir: **la llamada es la de W14** (3 argumentos, con su `sectionExtras`), **el wrapper es el mío**. Hay que conservar el import de `labelOr`.

**Por qué es seguro envolver también los extras de W14:** sus 3 extras (`shell.seccionMiPerfil`, `shell.seccionGrupos`, `shell.seccionRutas`) llegan **ya traducidos**, y ninguno de sus valores —ni en ES (`Mi perfil`, `Grupos`, `Rutas de aprendizaje`) ni en EN— existe como key en `nav.items` (verificado). `labelOr` no los encuentra y los deja pasar tal cual. Solo los tokens del sidebar se traducen.

## HALLAZGOS

Cosas que vi y **no** arreglé, por estar fuera de mi frontera o de mis reglas.

**1. Mensajes de error en español en `lib/module-loader.ts` y `lib/module-runtime.ts` (sin migrar).**
Aunque ambos ficheros estaban en mi asignación, no son componentes y no pueden usar hooks. Afectados:
- `module-loader.ts:128,134,161,171,180` — `El módulo "X" no tiene UI para surface "Y"`, `Error cargando UI del módulo: …`, `Error ejecutando bundle del módulo: …`, `El bundle del módulo no exportó correctamente …`, `El bundle del módulo no tiene export default válido`. Se pintan en el recuadro monoespaciado de `components/module-renderer.tsx` (**no es mío**), así que son semi-diagnósticos.
- `module-runtime.ts:246` — `new ApiHttpError({ message: 'Sesión expirada', status: 401 })`, que sí puede llegar a pantalla vía `apiErrorMessage`.

Traducirlos exige una de dos, ambas fuera de mi frontera: añadir keys a `errors.json` (prohibido) y un `code` al `ApiHttpError`, o pasar un `t` por parámetro cambiando firmas que consumen `module-renderer.tsx` y `admin/integraciones/migrator-learndash/page.tsx`. **Sugerencia para integración:** darle a `module-runtime.ts:246` un `code: 'sessionExpired'` y meter esa key en `errors.json`; es aditivo y no rompe nada.

**2. Copy español que entra en mis componentes desde fuera de mi frontera.**
- `components/notifications-toaster.tsx` pinta `link.actionLabel`, que viene de **`lib/notification-link.ts`** (no es mío) con textos en español (p. ej. "Responder"). Con la UI en inglés el toast sale mezclado. Le toca al dueño de `lib/notification-link.ts`.
- `components/module-renderer.tsx` (no es mío) tiene copy sin migrar: "UI no disponible", "Error cargando módulo", "Reintentar", "Recargar página" y dos frases largas de descripción.

**3. Cambio de comportamiento en EN, deliberado: plural del contador de notificaciones.**
`shell.notifications.unreadAria` en **ES se deja byte-exacto** (`"{count} notificaciones sin leer"`, gramaticalmente mal en n=1, tal y como estaba). En **EN sí lleva plural ICU** (`{count, plural, one {# unread notification} other {# unread notifications}}`). Cada locale lleva su propio mensaje, que es lo correcto en ICU. **No he "arreglado" el español** por la regla de byte-exactitud; si se quiere pluralizar ES, es un cambio de una línea en el catálogo y no toca código.

**4. `ui/dialog.tsx` — el `aria-label` por defecto del diálogo legacy dice `'Dialog'` (en inglés) también en español.**
Lo he preservado byte-exacto: `shell.dialog.fallbackLabel` vale `"Dialog"` en **ambos** catálogos. Lo natural sería `"Diálogo"` en ES, pero eso alteraría el copy actual. Un carácter en el catálogo cuando se decida.

**5. Ratchet i18n de `eslint.config.mjs`: no hay nada que sacar por mi parte.**
Ninguno de mis ficheros aparece en la lista de `ignores`, y ninguno usa `toLocale*String` ni `Intl.*` (verificado por grep). Mi unidad no necesita formateo locale-aware, así que no hay entradas que retirar.

**6. Sin fugas whitelabel en mi área.**
Barrido de «n8n», Telegram, Hetzner, dominios e IPs de cliente en los ficheros de mi frontera: **cero coincidencias**. Nada que preservar ni que reportar aquí.

**7. `components/tenant-title.test.ts` sigue verde sin tocarlo** — la lógica de marca no cambió.

## Verificación

Todo en verde, sin E2E (los corre el coordinador tras integrar):

- `pnpm install --frozen-lockfile`
- `prisma generate`
- build de los 5 packages (`database`, `core-kernel`, `core-registry`, `license-sdk`, `module-package-spec`) — OK
- `dev-check.sh --format-fix` + `dev-check.sh --quick` → typecheck **apps/api** OK, typecheck **apps/web** OK, **eslint** OK, **prettier --check** OK
- vitest `apps/web` → **312/312 tests, 36/36 ficheros**
- `ee-fence.ts` → **1377 ficheros, 0 violaciones**
