### PR TITLE
fix(i18n): los 5 arreglos de código de la Fase 2 de integración (Bundle B)

### DIFF
--- a/apps/e2e/tests/espacios.spec.ts
+++ b/apps/e2e/tests/espacios.spec.ts
@@ -75,9 +75,10 @@ test.describe('Sidebar — sección ESPACIOS', () => {
   test('la sección ESPACIOS es visible en el sidebar', async ({ page }) => {
     await withAdminSession(page, '/comunidad');
     const sidebar = page.locator('aside').first();
-    // El label del grupo es "Espacios" en el DOM (CSS text-transform:uppercase es solo visual).
-    // exact:true evita que coincida con otros elementos que contienen "Espacios" como substring.
-    await expect(sidebar.getByText('Espacios', { exact: true })).toBeVisible();
+    // El label del grupo es "Foros" en el DOM desde el bloque 9 de simplificación
+    // de navegación (`app/(app)/layout.tsx`); el CSS text-transform:uppercase es
+    // solo visual. exact:true evita coincidir con substrings de otros elementos.
+    await expect(sidebar.getByText('Foros', { exact: true })).toBeVisible();
   });
 
   test('el sidebar carga espacios reales de la BD (al menos 1 item en ESPACIOS)', async ({
@@ -97,13 +98,13 @@ test.describe('Sidebar — sección ESPACIOS', () => {
   test('como alumno (rol) NO hay botón "+" junto a ESPACIOS', async ({ page }) => {
     await withAdminSession(page, '/comunidad', ['alumno']);
     const sidebar = page.locator('aside').first();
-    await expect(sidebar.getByRole('button', { name: /Añadir a Espacios/i })).not.toBeVisible();
+    await expect(sidebar.getByRole('button', { name: /Añadir a Foros/i })).not.toBeVisible();
   });
 
   test('como admin SÍ hay botón "+" junto a ESPACIOS', async ({ page }) => {
     await withAdminSession(page, '/comunidad');
     const sidebar = page.locator('aside').first();
-    await expect(sidebar.getByRole('button', { name: /Añadir a Espacios/i })).toBeVisible();
+    await expect(sidebar.getByRole('button', { name: /Añadir a Foros/i })).toBeVisible();
   });
 
   test('los items de ESPACIOS no muestran texto crudo de IconName (bug regresión)', async ({
@@ -134,7 +135,7 @@ test.describe('Sidebar — sección ESPACIOS', () => {
 test.describe('CreateSpaceModal — modal de creación de espacio', () => {
   test.beforeEach(async ({ page }) => {
     await withAdminSession(page, '/comunidad');
-    await page.getByRole('button', { name: /Añadir a Espacios/i }).click();
+    await page.getByRole('button', { name: /Añadir a Foros/i }).click();
     await expect(page.getByRole('dialog', { name: 'Nuevo espacio' })).toBeVisible();
   });
 
@@ -357,10 +358,8 @@ test.describe('Consistencia visual y rutas', () => {
 
   test('la sección ESPACIOS en el sidebar tiene el label en mayúsculas (CSS)', async ({ page }) => {
     await withAdminSession(page, '/comunidad');
-    // El DOM tiene "Espacios"; la clase CSS "uppercase" lo hace aparecer en mayúsculas visualmente.
-    await expect(
-      page.locator('aside').first().getByText('Espacios', { exact: true }),
-    ).toBeVisible();
+    // El DOM tiene "Foros"; la clase CSS "uppercase" lo hace aparecer en mayúsculas visualmente.
+    await expect(page.locator('aside').first().getByText('Foros', { exact: true })).toBeVisible();
   });
 
   test('/comunidad no da error 500', async ({ page }) => {

--- a/apps/web/src/app/(app)/mensajes/page.tsx
+++ b/apps/web/src/app/(app)/mensajes/page.tsx
@@ -290,6 +290,9 @@ function NewDmDialog({
   onOpened: (conversationId: string, member: MessagingPublicUser) => void | Promise<void>;
 }) {
   const t = useTranslations('alumnoSocial');
+  // `humanizeError` resuelve su copy contra el namespace del módulo, no contra
+  // el de esta página: por eso hacen falta dos traductores.
+  const tMsg = useTranslations('modMessaging');
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<MessagingPublicUser[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -310,10 +313,10 @@ function NewDmDialog({
           setResults(r.members);
           setError(null);
         })
-        .catch((e) => setError(humanizeError(e)));
+        .catch((e) => setError(humanizeError(e, tMsg)));
     }, 250);
     return () => clearTimeout(handle);
-  }, [open, query]);
+  }, [open, query, tMsg]);
 
   async function pick(member: MessagingPublicUser) {
     setOpeningId(member.id);
@@ -322,7 +325,7 @@ function NewDmDialog({
       const { conversationId } = await messagingApi.openDm(member.id);
       await onOpened(conversationId, member);
     } catch (e) {
-      setError(humanizeError(e));
+      setError(humanizeError(e, tMsg));
       setOpeningId(null);
     }
   }

--- a/apps/web/src/app/(app)/notificaciones/page.tsx
+++ b/apps/web/src/app/(app)/notificaciones/page.tsx
@@ -81,6 +81,8 @@ function formatRelative(iso: string, t: TranslatorLike): string {
 export default function NotificacionesPage() {
   const t = useTranslations('alumnoSocial');
   const tErrors = useTranslations('errors');
+  // `notificationLink` resuelve «Responder»/«Ver» contra su propio namespace.
+  const tLib = useTranslations('libShared');
   const [notifications, setNotifications] = useState<Notification[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -193,7 +195,7 @@ export default function NotificacionesPage() {
                 tone: 'info' as const,
               };
               const style = TONE_STYLES[spec.tone];
-              const link = notificationLink(n.templateKey, n.metadata);
+              const link = notificationLink(n.templateKey, n.metadata, tLib);
               const details = (
                 <>
                   <div className="flex flex-wrap items-baseline gap-2">

--- a/apps/web/src/app/(public)/verificar/[id]/page.tsx
+++ b/apps/web/src/app/(public)/verificar/[id]/page.tsx
@@ -7,7 +7,7 @@
 
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Icon } from '@/components/icon';
@@ -24,6 +24,7 @@ type State = 'loading' | 'ok' | 'notfound' | 'error';
  */
 export default function VerifyCertificatePage() {
   const t = useTranslations('publicSite');
+  const locale = useLocale();
   const params = useParams<{ id: string }>();
   // La API pública no devuelve el emisor: usamos el nombre del tenant resuelto
   // por host (misma resolución que el resto de pantallas sin sesión).
@@ -116,7 +117,7 @@ export default function VerifyCertificatePage() {
               <dl className="mx-auto grid max-w-xs grid-cols-2 gap-x-4 gap-y-2 border-t border-border pt-4 text-left text-sm">
                 <dt className="text-text-subtle">{t('verificar.issuedAt')}</dt>
                 <dd className="text-right font-medium text-text tabular-nums">
-                  {issuedDateLabel(cert.issuedAt)}
+                  {issuedDateLabel(cert.issuedAt, locale)}
                 </dd>
                 <dt className="text-text-subtle">{t('verificar.certNumber')}</dt>
                 <dd className="text-right font-mono text-text">{cert.number}</dd>
@@ -132,8 +133,14 @@ export default function VerifyCertificatePage() {
   );
 }
 
-function issuedDateLabel(iso: string): string {
+/**
+ * El `locale` va EXPLÍCITO: esta es un área pública que sí se pinta en SSR, y
+ * ahí el singleton de `user-prefs` está vacío a propósito. Sin él el servidor
+ * pintaría la fecha con el locale por defecto y el cliente la repintaría con el
+ * activo → mismatch de hidratación visible.
+ */
+function issuedDateLabel(iso: string, locale: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '—';
-  return formatDate(d, { day: '2-digit', month: 'long', year: 'numeric' });
+  return formatDate(d, { locale, day: '2-digit', month: 'long', year: 'numeric' });
 }

--- a/apps/web/src/app/(venta)/catalogo/[slug]/ficha-venta-view.tsx
+++ b/apps/web/src/app/(venta)/catalogo/[slug]/ficha-venta-view.tsx
@@ -18,7 +18,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/icon';
 import { authStorage } from '@/lib/auth-storage';
@@ -35,6 +35,10 @@ import {
 export function FichaVentaView() {
   const t = useTranslations('publicSite');
   const tCommon = useTranslations('common');
+  // Área pública: se pinta en SSR, donde el singleton de `user-prefs` está
+  // vacío. Sin `locale` explícito el importe del servidor y el del cliente no
+  // coinciden → mismatch de hidratación.
+  const locale = useLocale();
   const params = useParams<{ slug: string }>();
   const { tenant } = useTenantContext();
 
@@ -210,11 +214,11 @@ export function FichaVentaView() {
                         <span className="flex items-baseline gap-1.5">
                           {option.compareAtAmount ? (
                             <span className="text-xs text-text-subtle line-through">
-                              {formatCents(option.compareAtAmount, option.currency)}
+                              {formatCents(option.compareAtAmount, option.currency, { locale })}
                             </span>
                           ) : null}
                           <span className="font-bold text-text">
-                            {formatCents(option.unitAmount, option.currency)}
+                            {formatCents(option.unitAmount, option.currency, { locale })}
                           </span>
                         </span>
                       </div>
@@ -238,11 +242,11 @@ export function FichaVentaView() {
             ) : selected ? (
               <div className="flex items-baseline justify-center gap-2">
                 <span className="text-3xl font-bold text-text" data-testid="precio-curso">
-                  {formatCents(selected.unitAmount, selected.currency)}
+                  {formatCents(selected.unitAmount, selected.currency, { locale })}
                 </span>
                 {selected.compareAtAmount ? (
                   <span className="text-text-subtle line-through">
-                    {formatCents(selected.compareAtAmount, selected.currency)}
+                    {formatCents(selected.compareAtAmount, selected.currency, { locale })}
                   </span>
                 ) : null}
                 {selected.discountPercent ? (

--- a/apps/web/src/app/(venta)/catalogo/catalogo-view.tsx
+++ b/apps/web/src/app/(venta)/catalogo/catalogo-view.tsx
@@ -17,7 +17,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Icon } from '@/components/icon';
 import { formatDuration } from '@/lib/i18n/format';
 import { useTenantContext } from '@/lib/tenant-context';
@@ -27,6 +27,10 @@ import { featuredOption, getPublicCatalog, type CatalogCourse } from '@/lib/cata
 export function CatalogoView() {
   const t = useTranslations('publicSite');
   const tCommon = useTranslations('common');
+  // Área pública: se pinta en SSR, donde el singleton de `user-prefs` está
+  // vacío. Sin `locale` explícito el importe del servidor y el del cliente no
+  // coinciden → mismatch de hidratación.
+  const locale = useLocale();
   const { tenant } = useTenantContext();
   const [courses, setCourses] = useState<CatalogCourse[] | null>(null);
   const [loadError, setLoadError] = useState(false);
@@ -174,11 +178,11 @@ export function CatalogoView() {
                       {option ? (
                         <div className="flex items-baseline gap-2">
                           <span className="text-lg font-bold text-text">
-                            {formatCents(option.unitAmount, option.currency)}
+                            {formatCents(option.unitAmount, option.currency, { locale })}
                           </span>
                           {option.compareAtAmount ? (
                             <span className="text-sm text-text-subtle line-through">
-                              {formatCents(option.compareAtAmount, option.currency)}
+                              {formatCents(option.compareAtAmount, option.currency, { locale })}
                             </span>
                           ) : null}
                           {option.discountPercent ? (

--- a/apps/web/src/app/(venta)/unete/unete-view.tsx
+++ b/apps/web/src/app/(venta)/unete/unete-view.tsx
@@ -21,7 +21,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/icon';
 import { ApiHttpError } from '@/lib/api-client';
@@ -72,6 +72,11 @@ function intervalDescriptionLabel(t: TranslatorLike, intervalMonths: number): st
 export function UneteView() {
   const t = useTranslations('publicSite');
   const tCommon = useTranslations('common');
+  // `/unete` sí se pinta en SSR y ahí el singleton de `user-prefs` está vacío a
+  // propósito: sin `locale` explícito el servidor pintaría la fecha del primer
+  // cargo con el locale por defecto y el cliente la repintaría → mismatch de
+  // hidratación visible.
+  const locale = useLocale();
   const params = useSearchParams();
   const status = params.get('status');
   const { tenant } = useTenantContext();
@@ -364,6 +369,7 @@ export function UneteView() {
                         days: trialDays,
                         amount: formatCents(selected.amountCents, selected.currency),
                         date: formatDate(firstChargeDate, {
+                          locale,
                           day: 'numeric',
                           month: 'long',
                           year: 'numeric',

--- a/apps/web/src/app/(venta)/unete/unete-view.tsx
+++ b/apps/web/src/app/(venta)/unete/unete-view.tsx
@@ -314,11 +314,11 @@ export function UneteView() {
                         <span className="flex flex-wrap items-baseline gap-2">
                           {plan.compareAtCents && plan.compareAtCents > plan.amountCents ? (
                             <span className="text-sm text-text-subtle line-through">
-                              {formatCents(plan.compareAtCents, plan.currency)}
+                              {formatCents(plan.compareAtCents, plan.currency, { locale })}
                             </span>
                           ) : null}
                           <span className="text-xl font-bold">
-                            {formatCents(plan.amountCents, plan.currency)}
+                            {formatCents(plan.amountCents, plan.currency, { locale })}
                           </span>
                           <span className="text-sm text-text-muted">
                             {intervalSuffixLabel(t, plan.intervalMonths)}
@@ -349,8 +349,8 @@ export function UneteView() {
                   <span className="font-semibold">{t('unete.totalToday')}</span>
                   <span className="text-[22px] font-extrabold">
                     {trialDays > 0
-                      ? formatCents(0, selected.currency)
-                      : formatCents(selected.amountCents, selected.currency)}
+                      ? formatCents(0, selected.currency, { locale })
+                      : formatCents(selected.amountCents, selected.currency, { locale })}
                   </span>
                 </div>
                 {savings ? (
@@ -358,7 +358,7 @@ export function UneteView() {
                     <span className="text-text-muted">{t('unete.savingsLabel')}</span>
                     <span className="font-bold text-success-700">
                       {t('unete.savingsAmount', {
-                        amount: formatCents(savings, selected.currency),
+                        amount: formatCents(savings, selected.currency, { locale }),
                       })}
                     </span>
                   </div>
@@ -367,7 +367,7 @@ export function UneteView() {
                   {trialDays > 0
                     ? t('unete.trialFirstCharge', {
                         days: trialDays,
-                        amount: formatCents(selected.amountCents, selected.currency),
+                        amount: formatCents(selected.amountCents, selected.currency, { locale }),
                         date: formatDate(firstChargeDate, {
                           locale,
                           day: 'numeric',
@@ -516,21 +516,21 @@ export function UneteView() {
             <div>
               <div className="text-[13px] text-text-muted">{t('unete.boughtSeparately')}</div>
               <div className="text-[22px] font-bold text-text-subtle line-through">
-                {formatCents(page.standaloneTotalCents, selected.currency)}
+                {formatCents(page.standaloneTotalCents, selected.currency, { locale })}
               </div>
             </div>
             <Icon name="arrow-right" className="h-6 w-6 text-success-600" />
             <div>
               <div className="text-[13px] text-text-muted">{t('unete.withMembership')}</div>
               <div className="text-[22px] font-bold">
-                {formatCents(selected.amountCents, selected.currency)}
+                {formatCents(selected.amountCents, selected.currency, { locale })}
                 {intervalSuffixLabel(t, selected.intervalMonths)}
               </div>
             </div>
             {catalogSavings ? (
               <span className="ml-auto rounded-full bg-success-100 px-4 py-2.5 text-sm font-bold text-success-700">
                 {t('unete.youSave', {
-                  amount: formatCents(catalogSavings, selected.currency),
+                  amount: formatCents(catalogSavings, selected.currency, { locale }),
                 })}
               </span>
             ) : null}
@@ -617,6 +617,7 @@ function CourseCardWithDetail({
 }) {
   const t = useTranslations('publicSite');
   const tCommon = useTranslations('common');
+  const locale = useLocale();
   const meta = [
     course.estimatedMinutes ? formatDuration(course.estimatedMinutes, tCommon) : null,
     course.moduleCount > 0 ? t('unete.modulesCount', { count: course.moduleCount }) : null,
@@ -655,7 +656,7 @@ function CourseCardWithDetail({
           )}
           {course.amountCents !== null ? (
             <span className="absolute right-2.5 top-2.5 rounded-lg bg-black/75 px-2.5 py-1 text-xs font-bold text-white">
-              {formatCents(course.amountCents, currency)}
+              {formatCents(course.amountCents, currency, { locale })}
             </span>
           ) : null}
         </div>
@@ -740,7 +741,7 @@ function CourseCardWithDetail({
               {course.amountCents !== null ? (
                 <span className="text-[13px] text-text-subtle line-through">
                   {t('unete.standalonePrice', {
-                    amount: formatCents(course.amountCents, currency),
+                    amount: formatCents(course.amountCents, currency, { locale }),
                   })}
                 </span>
               ) : null}

--- a/apps/web/src/components/notifications-toaster.tsx
+++ b/apps/web/src/components/notifications-toaster.tsx
@@ -47,6 +47,9 @@ export function NotificationsToaster() {
 
 function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: string) => void }) {
   const t = useTranslations('shell');
+  // `notificationLink` resuelve «Responder»/«Ver» contra `libShared`, que es su
+  // propio namespace: no se puede pedir con el traductor de `shell`.
+  const tLib = useTranslations('libShared');
   const { id } = toast;
 
   useEffect(() => {
@@ -54,7 +57,7 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: str
     return () => clearTimeout(handle);
   }, [id, onDismiss]);
 
-  const link = notificationLink(toast.templateKey, toast.metadata);
+  const link = notificationLink(toast.templateKey, toast.metadata, tLib);
   const title = toast.subject ?? t('notifications.toastDefaultTitle');
 
   return (

--- a/apps/web/src/i18n/messages/en/errors.json
+++ b/apps/web/src/i18n/messages/en/errors.json
@@ -1,5 +1,6 @@
 {
   "unknown": "Something went wrong. Please try again.",
+  "sessionExpired": "Session expired",
   "mfa_required": "Two-step verification is required to continue.",
   "AMBIGUOUS_TENANT": "Your account exists in several academies. Sign in from your academy's domain."
 }

--- a/apps/web/src/i18n/messages/es/errors.json
+++ b/apps/web/src/i18n/messages/es/errors.json
@@ -1,5 +1,6 @@
 {
   "unknown": "Algo salió mal. Inténtalo de nuevo.",
+  "sessionExpired": "Sesión expirada",
   "mfa_required": "Se requiere verificación en dos pasos para continuar.",
   "AMBIGUOUS_TENANT": "Tu cuenta existe en varias academias. Accede desde el dominio de tu academia."
 }

--- a/apps/web/src/lib/membership.ts
+++ b/apps/web/src/lib/membership.ts
@@ -12,7 +12,7 @@
  */
 
 import { apiFetch } from './api-client';
-import { formatCents as formatCentsI18n } from './i18n/format';
+import { formatCents as formatCentsI18n, type FmtOverrides } from './i18n/format';
 
 const PUBLIC_BASE = '/api/v1/membership';
 const ADMIN_BASE = '/api/v1/membership/admin';
@@ -176,9 +176,18 @@ export const membershipAdminApi = {
  * conversión canónica de `@/lib/i18n/format`: la regla de decimales («sin
  * decimales si la cantidad es redonda») vive allí y solo allí, y coincide con
  * la que este wrapper aplicaba a mano — el español sale byte a byte igual.
+ *
+ * `opts` es OPCIONAL y solo reenvía overrides a la canónica. Lo necesitan las
+ * pantallas de `(public)`/`(venta)`, que sí se pintan en SSR: allí el singleton
+ * de `user-prefs` está vacío a propósito y hay que pasar `{ locale }` explícito
+ * para que servidor y cliente pinten el mismo importe.
  */
-export function formatCents(cents: number, currency = 'eur'): string {
-  return formatCentsI18n(cents, currency.toUpperCase());
+export function formatCents(
+  cents: number,
+  currency = 'eur',
+  opts?: Intl.NumberFormatOptions & FmtOverrides,
+): string {
+  return formatCentsI18n(cents, currency.toUpperCase(), opts);
 }
 
 /** Etiqueta de periodicidad: "/mes", "/trimestre", …, "/N meses". */

--- a/apps/web/src/lib/notification-link.test.ts
+++ b/apps/web/src/lib/notification-link.test.ts
@@ -10,50 +10,51 @@ const tEn = createTranslator({ locale: 'en-US', messages: en, namespace: 'libSha
 describe('notificationLink', () => {
   it('comentario en post → hilo enfocado en el comentario con acción Responder', () => {
     expect(
-      notificationLink('community.comment.on_post', { postId: 'p1', commentId: 'c1' }),
+      notificationLink('community.comment.on_post', { postId: 'p1', commentId: 'c1' }, tEs),
     ).toEqual({ href: '/comunidad/p1?comment=c1', actionLabel: 'Responder' });
   });
 
   it('respuesta → enfoca el comentario padre (para seguir la conversación)', () => {
     expect(
-      notificationLink('community.reply.to_comment', {
-        postId: 'p1',
-        commentId: 'c2',
-        parentCommentId: 'c1',
-      }),
+      notificationLink(
+        'community.reply.to_comment',
+        { postId: 'p1', commentId: 'c2', parentCommentId: 'c1' },
+        tEs,
+      ),
     ).toEqual({ href: '/comunidad/p1?comment=c1', actionLabel: 'Responder' });
   });
 
   it('respuesta sin parentCommentId cae al nuevo comentario', () => {
     expect(
-      notificationLink('community.reply.to_comment', { postId: 'p1', commentId: 'c2' }),
+      notificationLink('community.reply.to_comment', { postId: 'p1', commentId: 'c2' }, tEs),
     ).toEqual({ href: '/comunidad/p1?comment=c2', actionLabel: 'Responder' });
   });
 
   it('mención → acción Ver', () => {
-    expect(notificationLink('community.mention', { postId: 'p1', commentId: 'c1' })).toEqual({
+    expect(notificationLink('community.mention', { postId: 'p1', commentId: 'c1' }, tEs)).toEqual({
       href: '/comunidad/p1?comment=c1',
       actionLabel: 'Ver',
     });
   });
 
   it('comentario sin postId → sin enlace (null)', () => {
-    expect(notificationLink('community.comment.on_post', {})).toBeNull();
+    expect(notificationLink('community.comment.on_post', {}, tEs)).toBeNull();
   });
 
   it('templateKey no navegable → null', () => {
-    expect(notificationLink('enrollment.created', { course: 'x' })).toBeNull();
+    expect(notificationLink('enrollment.created', { course: 'x' }, tEs)).toBeNull();
   });
 
   it('metadata ausente → null sin lanzar', () => {
-    expect(notificationLink('community.comment.on_post', undefined)).toBeNull();
-    expect(notificationLink('community.comment.on_post', null)).toBeNull();
+    expect(notificationLink('community.comment.on_post', undefined, tEs)).toBeNull();
+    expect(notificationLink('community.comment.on_post', null, tEs)).toBeNull();
   });
 
-  it('con traductor, la acción sale del catálogo (MUST-FIX 25)', () => {
+  it('la acción sale del catálogo en los dos idiomas (MUST-FIX 25)', () => {
     const meta = { postId: 'p1', commentId: 'c1' };
     expect(notificationLink('community.comment.on_post', meta, tEs)?.actionLabel).toBe('Responder');
     expect(notificationLink('community.comment.on_post', meta, tEn)?.actionLabel).toBe('Reply');
+    expect(notificationLink('community.mention', meta, tEs)?.actionLabel).toBe('Ver');
     expect(notificationLink('community.mention', meta, tEn)?.actionLabel).toBe('View');
   });
 });

--- a/apps/web/src/lib/notification-link.ts
+++ b/apps/web/src/lib/notification-link.ts
@@ -24,22 +24,20 @@ function str(value: unknown): string | null {
 }
 
 /**
- * `t` = `useTranslations('libShared')` del componente que la llama.
- *
- * Va OPCIONAL solo por compatibilidad: `/notificaciones` y el toaster
- * pertenecen a otras unidades de la migración y todavía la llaman sin
- * traductor. Sin `t` devuelve el español cableado de siempre (nunca una key en
- * pantalla). Cuando esos dos pasen el suyo, `t` pasa a obligatorio.
+ * `t` = `useTranslations('libShared')` del componente que la llama, y es
+ * OBLIGATORIO: los dos únicos llamantes (`/notificaciones` y el toaster) le
+ * pasan el suyo. No hay rama degradada a español — un `t` opcional aquí
+ * significaba español en la UI inglesa sin que fallara ningún test.
  */
 export function notificationLink(
   templateKey: string,
   metadata: Record<string, unknown> | null | undefined,
-  t?: TranslatorLike,
+  t: TranslatorLike,
 ): NotificationLink | null {
   const meta = metadata ?? {};
   const postId = str(meta.postId);
-  const reply = t ? t('notificationAction.reply') : 'Responder';
-  const view = t ? t('notificationAction.view') : 'Ver';
+  const reply = t('notificationAction.reply');
+  const view = t('notificationAction.view');
 
   switch (templateKey) {
     case 'community.comment.on_post': {

--- a/apps/web/src/modules/ai-tutor/client.ts
+++ b/apps/web/src/modules/ai-tutor/client.ts
@@ -61,7 +61,8 @@ export interface UpsertProviderInput {
 
 function bearer(): string {
   const token = authStorage.getAccessToken();
-  if (!token) throw new ApiHttpError({ message: 'Sesión expirada', status: 401 });
+  if (!token)
+    throw new ApiHttpError({ message: 'Sesión expirada', status: 401, code: 'sessionExpired' });
   return token;
 }
 

--- a/apps/web/src/modules/gamification/client.ts
+++ b/apps/web/src/modules/gamification/client.ts
@@ -137,7 +137,8 @@ export interface BackfillSummary {
 
 function withAuth(): string {
   const token = authStorage.getAccessToken();
-  if (!token) throw new ApiHttpError({ message: 'Sesión expirada', status: 401 });
+  if (!token)
+    throw new ApiHttpError({ message: 'Sesión expirada', status: 401, code: 'sessionExpired' });
   return token;
 }
 

--- a/apps/web/src/modules/messaging/shared.ts
+++ b/apps/web/src/modules/messaging/shared.ts
@@ -56,34 +56,27 @@ export function relTime(iso: string, t: TranslatorLike): string {
 }
 
 /**
- * `t` = `useTranslations('modMessaging')`.
- *
- * Va OPCIONAL solo por compatibilidad: la página `/mensajes` pertenece a otra
- * unidad de la migración y todavía la llama sin traductor. Sin `t` devuelve el
- * español cableado de siempre (nunca una key en pantalla). Cuando esa página
- * pase el suyo, `t` pasa a obligatorio y esta rama desaparece.
+ * `t` = `useTranslations('modMessaging')`, y es OBLIGATORIO: los 6 call-sites
+ * (los 4 de `use-conversation-thread` y los 2 de `/mensajes`) le pasan el suyo.
+ * No hay rama degradada a español — un `t` opcional aquí significaba español en
+ * la UI inglesa sin que fallara ningún test.
  */
-export function humanizeError(e: unknown, t?: TranslatorLike): string {
-  if (!(e instanceof ApiHttpError))
-    return t ? t('errorLoad') : 'No pudimos cargar los mensajes. Recarga para reintentar.';
+export function humanizeError(e: unknown, t: TranslatorLike): string {
+  if (!(e instanceof ApiHttpError)) return t('errorLoad');
   switch (e.code) {
     case 'MESSAGING_NOT_PARTICIPANT':
-      return t ? t('errorNotParticipant') : 'No participas en esta conversación.';
+      return t('errorNotParticipant');
     case 'MESSAGING_CONVERSATION_NOT_FOUND':
-      return t ? t('errorConversationNotFound') : 'La conversación ya no está disponible.';
+      return t('errorConversationNotFound');
     case 'MESSAGING_BODY_INVALID':
-      return t ? t('errorBodyInvalid') : 'El mensaje debe tener entre 1 y 4000 caracteres.';
+      return t('errorBodyInvalid');
     case 'MESSAGING_SELF_DM':
-      return t ? t('errorSelfDm') : 'No puedes abrir un directo contigo mismo.';
+      return t('errorSelfDm');
     case 'MESSAGING_RATE_LIMITED':
-      return t
-        ? t('errorRateLimited')
-        : 'Vas demasiado rápido. Espera unos segundos y vuelve a intentarlo.';
+      return t('errorRateLimited');
     default:
       if (e.status !== 403) return e.message;
-      return t
-        ? t('errorModuleInactive')
-        : 'El módulo de mensajería no está activo en esta comunidad.';
+      return t('errorModuleInactive');
   }
 }
 

--- a/apps/web/src/modules/resources/client.ts
+++ b/apps/web/src/modules/resources/client.ts
@@ -45,7 +45,8 @@ export interface CreateResourceInput {
 
 function withAuth(): string {
   const token = authStorage.getAccessToken();
-  if (!token) throw new ApiHttpError({ message: 'Sesión expirada', status: 401 });
+  if (!token)
+    throw new ApiHttpError({ message: 'Sesión expirada', status: 401, code: 'sessionExpired' });
   return token;
 }
 

--- a/apps/web/src/modules/zoom-live/client.ts
+++ b/apps/web/src/modules/zoom-live/client.ts
@@ -98,7 +98,8 @@ export interface PaginatedWebhookEvents {
 
 function withAuth(): string {
   const token = authStorage.getAccessToken();
-  if (!token) throw new ApiHttpError({ message: 'Sesión expirada', status: 401 });
+  if (!token)
+    throw new ApiHttpError({ message: 'Sesión expirada', status: 401, code: 'sessionExpired' });
   return token;
 }
 

--- a/modules/community/src/community.service.ts
+++ b/modules/community/src/community.service.ts
@@ -366,7 +366,7 @@ export class CommunityService {
           tenantId: args.tenantId,
           channel,
           templateKey,
-          locale: 'es-ES',
+          // Sin `locale`: el hub resuelve el idioma de cada destinatario.
           to: recipient,
           category: 'COMMUNITY',
           variables,
@@ -949,7 +949,7 @@ export class CommunityService {
           tenantId,
           channel: 'in-app',
           templateKey: 'community.mention',
-          locale: 'es-ES',
+          // Sin `locale`: el hub resuelve el idioma de cada destinatario.
           to: m.mentionedUserId,
           variables: {
             authorId,


### PR DESCRIPTION
Bundle B (código) de la Fase 2 de integración i18n. Base: `deba3784`.

Los 5 arreglos del encargo **más el 4-bis** (los importes de `(venta)`, añadido por decisión del coordinador tras el hallazgo). Cada uno verificado contra el código antes de editar. Ninguno toca la frontera del Bundle A (`admin/membresia/page.tsx`, `new-course-form.tsx`, `community-upload.ts`, ni los namespaces `formadorCursos`, `formadorAula`, `modResources`, `playersContenido`, `alumnoAprendizaje`, `comunidadComponentes`, **`shell`**).

---

## 1 · `'Sesión expirada'` sin `code` en los 4 clientes de W19 (must-fix 24 + 31)

`modules/{ai-tutor,zoom-live,resources,gamification}/client.ts` lanzaban `ApiHttpError` sin `code`, así que `apiErrorMessage` no podía resolverlo y la UI inglesa mostraba español. Es el mismo helper `bearer()`/`withAuth()` copiado 4 veces.

- **Verificado antes de editar:** la key `sessionExpired` NO existía en `errors.json` (0 ocurrencias en es y en). Creada en los dos catálogos.
- El español **no cambia**: `es.errors.sessionExpired` vale exactamente `"Sesión expirada"`, byte a byte igual que el `message` del throw. `en` = `"Session expired"`.
- **Verificación por grep:** `code: 'sessionExpired'` pasa de 26 a **30** ocurrencias en `apps/web/src` (26 de W20 + 4 míos). Los 26 de W20 no se han reescrito: quedan traducidos por el solo hecho de existir la key (`apiErrorMessage` hace `t.has(code)`).
- El único `message: 'Sesión expirada'` que queda suelto es `lib/module-runtime.ts:247`, que **ya lleva** su `code` (throw multilínea).

## 2 · Los 3 call-sites de `t` que faltaban (must-fix 32 + 25) — **`t` queda OBLIGATORIO**

| fichero:línea (sobre `deba3784`) | qué |
|---|---|
| `app/(app)/mensajes/page.tsx:313` y `:325` | `humanizeError(e)` sin `t` — es todo el copy de error de `NewDmDialog` (búsqueda de miembros + apertura del directo) |
| `app/(app)/notificaciones/page.tsx:196` | `notificationLink(...)` sin `t` |
| `components/notifications-toaster.tsx:57` | `notificationLink(...)` sin `t` — el sufijo «· Ver curso» de cada toast |

Con los **7 call-sites** cubiertos (4 de `use-conversation-thread` + 2 de `/mensajes` para `humanizeError`; 2 para `notificationLink`), **`t` pasa a OBLIGATORIO en los dos helpers y se borran sus ramas de fallback en español**. No hay camino degradado, así que las tres condiciones alternativas (constante nombrada / lista de call-sites sin `t` / test del camino degradado) no aplican.

- `modules/messaging/shared.ts:humanizeError` — 7 ramas `t ? t(...) : '…'` eliminadas.
- `lib/notification-link.ts:notificationLink` — `'Responder'` / `'Ver'` cableados eliminados.
- `lib/notification-link.test.ts` adaptado a la firma nueva; el caso de catálogo ahora comprueba las **dos** acciones en los **dos** idiomas (`Responder`/`Reply`, `Ver`/`View`).

**Sobre la trampa de `shell.json`:** `notifications-toaster.tsx` es mío pero usa `useTranslations('shell')`, que es del Bundle A. **No he añadido ninguna key a `shell.json`**: el toaster estrena un segundo traductor `useTranslations('libShared')` (namespace mío, donde ya viven `notificationAction.reply`/`.view`). Mismo patrón en `/notificaciones` y en `/mensajes` (`modMessaging`).

## 3 · Los 2 `locale: 'es-ES'` que quedaban en `modules/`

`modules/community/src/community.service.ts:369` y `:952`. Eran las 2 líneas idénticas a las 18 que W21 ya borró en `apps/api/`; quedaron fuera solo por vivir en `modules/`. Verificado que `locale` es opcional en la interfaz del kernel (`packages/core-kernel/src/module/module.ts:167`) y que el hub resuelve `user.locale` del destinatario.

**Verificación por grep:** tras el cambio no queda **ningún** `locale: 'es-ES'` en código de producción del monorepo — los 37 hits restantes son todos fixtures de test (`apps/api/tests/**`, `apps/web/src/**/*.test.ts`).

## 4 · Flip de hidratación en las fechas de `(public)` y `(venta)`

Grep de `formatDate`/`formatDateTime`/`formatTime` + `toLocale*`/`Intl.DateTimeFormat` bajo las dos áreas → exactamente **2** sitios, los dos client components:

- `app/(public)/verificar/[id]/page.tsx:138` (`issuedDateLabel`, la fecha de emisión del certificado) — la función es de módulo, así que recibe `locale` como parámetro.
- `app/(venta)/unete/unete-view.tsx:366` (la fecha del primer cargo del trial).

Los dos pasan ahora `{ locale }` de `useLocale()` de next-intl. **`(app)` no se ha tocado**: su layout devuelve `null` en SSR hasta tener sesión.

## 4-bis · El mismo flip, en los importes de `(venta)` (cerrado a petición del coordinador)

Las fechas dejaban el arreglo a medias: `formatCents` resuelve el locale por el **mismo** singleton vacío en SSR, así que el servidor pintaba `19 €` y el cliente inglés repintaba `€19`.

**Recuento real, verificado por grep (no era 11):** **17 call-sites** en **3** client components de `(venta)`, no en uno.

| fichero | call-sites |
|---|---|
| `app/(venta)/unete/unete-view.tsx` | 11 (uno de ellos en el subcomponente `CourseCardWithDetail`, que estrena su propio `useLocale()`) |
| `app/(venta)/catalogo/[slug]/ficha-venta-view.tsx` | 4 |
| `app/(venta)/catalogo/catalogo-view.tsx` | 2 |

En `(public)` **no hay ninguno** (`formatCents`/`formatNumber`/`formatCurrency`/`Intl.NumberFormat`: 0 hits). `formatDuration` no está afectado: formatea vía ICU del provider de next-intl, que sí es correcto en servidor y cliente.

**Un fichero fuera del alcance literal, y por qué.** `lib/membership.formatCents(cents, currency)` no aceptaba overrides, así que no había forma de pasarle el locale. Le he añadido un **tercer parámetro opcional** que solo reenvía a la conversión canónica. Es estrictamente aditivo: su otro llamante — `app/(app)/admin/membresia/page.tsx`, **de la frontera del Bundle A** — sigue llamándolo con 2 argumentos y no se entera. La alternativa (duplicar el wrapper en cada una de las 3 vistas) chocaba con la doctrina del propio fichero: «la regla de decimales vive allí y solo allí».

**Comprobación de la DECISIÓN 16 — el importe NO cambia de forma.** Solo se pasa `locale`; no se tocan `minimumFractionDigits`/`maximumFractionDigits`, así que la regla «sin decimales si es redondo» queda intacta. Además el tag que devuelve `useLocale()` es exactamente el que `LocaleSync` mete en el singleton (`SUPPORTED_LOCALES = ['es-ES','es-AR','en-US']`), así que en cliente el resultado es el de hoy. Verificado con `Intl`:

| céntimos | hoy (es-ES) | con locale explícito (es-ES) | en-US |
|---|---|---|---|
| 1900 | `19 €` | `19 €` | `€19` |
| 1999 | `19,99 €` | `19,99 €` | `€19.99` |
| 0 | `0 €` | `0 €` | `€0` |
| 12000 | `120 €` | `120 €` | `€120` |
| 4950 | `49,50 €` | `49,50 €` | `€49.50` |

El español sale byte a byte igual: **no hay cambio visible de copy**, así que no hace falta decisión de Valen. Lo que se arregla es `en-US` y `es-AR`, que hoy sufren el mismatch.

## 5 · `apps/e2e/tests/espacios.spec.ts` — se arregla el spec, no el copy

Verificado que el label real del grupo es `'Foros'` (`app/(app)/layout.tsx:257`, bloque 9 de simplificación de navegación) y que está traducido en el namespace `nav` (`es: "Foros"`, `en: "Forums"`). Los tokens de `lib/sidebar-nav.ts` que dicen `'Espacios'` son otra cosa: el item admin `/admin/comunidad/espacios`, que no es el grupo que el spec busca.

**Eran 5 localizadores rotos, no 2.** Además de los 2 `getByText('Espacios', { exact: true })` (líneas ~80 y ~362), había **3 más con la misma causa raíz**: `getByRole('button', { name: /Añadir a Espacios/i })` en las líneas 100, 106 y 137 — el aria-label del botón «+» se compone con `nav.addToGroup` (`"Añadir a {group}"`) sobre el label del grupo, o sea `Añadir a Foros`. Los 5 corregidos.

Comprobado que el resto de literales del spec siguen vivos: `'Nuevo espacio'` (`comunidadComponentes.newSpaceTitle`) y `'Otros espacios'` (`alumnoSocial.otrosEspacios`). Grep en los 86 specs: no queda ningún otro `Añadir a Espacios` ni `getByText('Espacios'` en `apps/e2e`.

**Playwright NO ejecutado** (es trabajo de la Sesión H): el spec se arregla por inspección.

---

## Verificación

| comando | resultado |
|---|---|
| `pnpm install --frozen-lockfile` | OK |
| `prisma generate` | OK |
| `tsc` de los 5 `packages/*` | OK · 0 errores |
| `tsc` de los **24** `modules/*` | OK · 24/24 (necesario para el collect de la API) |
| `scripts/dev-check.sh --format-fix` | OK · prettier --write |
| `scripts/dev-check.sh --quick` | OK · typecheck api + typecheck web + eslint + prettier --check |
| `vitest run` en `apps/web` | **36 ficheros · 314/314 verdes** |
| `vitest run` en `apps/api` | **160 ficheros · 2106/2106 verdes** |
| `scripts/ee-fence.ts` | 1377 ficheros, **0 violaciones** |
| Playwright | SKIP (Sesión H) |

La verificación se repitió entera tras el arreglo 4-bis: `--quick` verde, **314/314** en web, ee-fence **0**. (`vitest` de `apps/api` no se repite: el arreglo 4-bis no toca `modules/`.)

`git status` tras cada `--format-fix` mostró exactamente los ficheros de mi frontera —16 en la primera tanda, 4 en la segunda—: cero fugas a la del Bundle A.

---

## Hallazgos que he visto y NO he tocado

1. **must-fix 37 (fuera de alcance por instrucción)** — focos de español que viajan al hub como variables ya renderizadas. No tocado.
2. **must-fix 38 (fuera de alcance por instrucción)** — las 11 plantillas transaccionales espejo del copy de los composers, con test de coherencia. No tocado.
3. **`apps/e2e/tests/espacios.spec.ts:302`** — `getByRole('heading', { name: /espacios/i })` sobre `/admin/comunidad/espacios`. Pasa hoy porque los E2E corren en español, pero es un localizador acoplado al idioma: en inglés ese heading no dirá «Espacios». Mismo patrón en varias aserciones de copy del resto del fichero. No lo he tocado porque no está roto y arreglar el acoplamiento idioma↔spec es una decisión de la Sesión H (¿fijar cookie de locale en el harness, o localizar por `data-testid`?).
4. **`eslint.config.mjs`** — el ratchet de `no-restricted-syntax` sigue con su `ignores` (limpieza del plan, explícitamente fuera de alcance).
