### PR TITLE
fix(api): los mensajes de marketplace dejan de filtrar detalle interno

### DIFF
--- a/apps/api/src/marketplace/module-assets.controller.ts
+++ b/apps/api/src/marketplace/module-assets.controller.ts
@@ -7,6 +7,7 @@ import {
   Controller,
   Get,
   Header,
+  Logger,
   NotFoundException,
   Param,
   Res,
@@ -28,6 +29,22 @@ const bundleCache = new Map<string, { data: Buffer; version: string }>();
 /// lleva la versión del módulo para invalidación automática.
 const CACHE_MAX_AGE = 3600;
 
+/// Respuesta ÚNICA del endpoint público cuando no puede servir un bundle,
+/// sea cual sea el motivo real (módulo no instalado, instalado pero en un
+/// status no servible, fallo del storage, ZIP corrupto o paquete sin ese
+/// bundle). Es deliberadamente vaga.
+///
+/// SEGURIDAD (MUST-FIX 26): este endpoint NO pide autenticación. Antes
+/// devolvía un `code` + `message` distinto por causa, e incluso el status
+/// interno de instalación y el `err.message` crudo del storage (que en
+/// disco local lleva la ruta absoluta del fichero y en S3 el bucket).
+/// Cualquiera podía enumerar qué módulos hay instalados en la instancia y
+/// en qué estado. Ahora las cinco causas son indistinguibles desde fuera:
+/// mismo 404, mismo `code`, mismo `message`. El motivo real va al log del
+/// servidor vía `denyAsset`.
+const ASSET_NOT_FOUND_CODE = 'MARKETPLACE_ASSET_NOT_FOUND';
+const ASSET_NOT_FOUND_MESSAGE = 'El recurso solicitado no está disponible.';
+
 /**
  * Endpoints públicos para servir assets de módulos instalados.
  *
@@ -44,6 +61,8 @@ const CACHE_MAX_AGE = 3600;
 // reales — devolviendo "No hay módulo registrado". Ver bug alpha.60.
 @Controller('modules')
 export class ModuleAssetsController {
+  private readonly logger = new Logger(ModuleAssetsController.name);
+
   constructor(
     private readonly installed: InstalledModuleService,
     private readonly contextFactory: ModuleContextFactory,
@@ -80,18 +99,23 @@ export class ModuleAssetsController {
       return new StreamableFile(cached.data);
     }
 
+    // A partir de aquí toda salida de error usa `denyAsset`: el cliente
+    // anónimo recibe siempre el mismo 404 y el motivo real solo va al log.
+    const bundlePath = `dist/ui/${surface}.js`;
+
     // Buscar módulo instalado
     const module = await this.installed.findByName(moduleName);
     if (!module) {
-      throw new NotFoundException({
-        message: `Módulo "${moduleName}" no está instalado.`,
-        code: 'MARKETPLACE_MODULE_NOT_INSTALLED',
+      throw this.denyAsset('el módulo no está instalado en esta instancia', {
+        module: moduleName,
+        surface,
       });
     }
     if (module.status !== 'INSTALLED') {
-      throw new NotFoundException({
-        message: `Módulo "${moduleName}" no está disponible (status: ${module.status}).`,
-        code: 'MARKETPLACE_MODULE_NOT_AVAILABLE',
+      throw this.denyAsset(`el módulo está en status ${module.status}, no en INSTALLED`, {
+        module: moduleName,
+        surface,
+        version: module.version,
       });
     }
 
@@ -101,24 +125,46 @@ export class ModuleAssetsController {
     try {
       packageBuffer = await storage.download(module.packageStorageKey);
     } catch (err) {
-      throw new NotFoundException({
-        message: `Error descargando paquete del módulo: ${err instanceof Error ? err.message : String(err)}`,
-        code: 'MARKETPLACE_PACKAGE_DOWNLOAD_FAILED',
-      });
+      throw this.denyAsset(
+        'falló la descarga del paquete desde el storage',
+        { module: moduleName, surface, storageKey: module.packageStorageKey },
+        err,
+      );
     }
 
-    // Extraer el bundle UI
-    const zip = new AdmZip(packageBuffer);
-    const bundlePath = `dist/ui/${surface}.js`;
-    const entry = zip.getEntry(bundlePath);
+    // Extraer el bundle UI. `adm-zip` parsea el directorio central de forma
+    // perezosa, así que un paquete corrupto revienta aquí y no en el
+    // constructor — por eso ambos van dentro del mismo try. Sin este try el
+    // fallo escapaba como 500 y volvía a ser un oráculo: solo se llega a
+    // este punto si el módulo existe, está INSTALLED y su blob se descargó.
+    let entry: ReturnType<AdmZip['getEntry']> = null;
+    try {
+      entry = new AdmZip(packageBuffer).getEntry(bundlePath);
+    } catch (err) {
+      throw this.denyAsset(
+        'el paquete descargado no se pudo leer como ZIP',
+        { module: moduleName, surface, storageKey: module.packageStorageKey },
+        err,
+      );
+    }
     if (!entry) {
-      throw new NotFoundException({
-        message: `El módulo "${moduleName}" no tiene UI para surface "${surface}".`,
-        code: 'MARKETPLACE_SURFACE_UI_MISSING',
+      throw this.denyAsset(`el paquete no incluye "${bundlePath}"`, {
+        module: moduleName,
+        surface,
+        version: module.version,
       });
     }
 
-    const bundleData = entry.getData();
+    let bundleData: Buffer;
+    try {
+      bundleData = entry.getData();
+    } catch (err) {
+      throw this.denyAsset(
+        `no se pudo extraer "${bundlePath}" del paquete`,
+        { module: moduleName, surface, storageKey: module.packageStorageKey },
+        err,
+      );
+    }
 
     // Cachear para próximos requests
     bundleCache.set(cacheKey, { data: bundleData, version: module.version });
@@ -129,6 +175,42 @@ export class ModuleAssetsController {
     res.header('X-Module-Version', module.version);
 
     return new StreamableFile(bundleData);
+  }
+
+  /// Única fábrica del 404 del endpoint público (MUST-FIX 26).
+  ///
+  /// Registra en el log del servidor el motivo REAL con contexto suficiente
+  /// para depurar (módulo, surface, versión, storage key y, si lo hay, el
+  /// error original con su stack) y devuelve al cliente un cuerpo idéntico
+  /// para todas las causas. Que exista un solo constructor del error es lo
+  /// que garantiza que las respuestas no puedan divergir en un refactor
+  /// futuro y volver a convertirse en un oráculo de enumeración.
+  ///
+  /// `warn` cuando la causa es esperable (módulo ausente, sin bundle para
+  /// esa surface); `error` cuando hay un fallo real de infraestructura
+  /// (storage caído, paquete corrupto) que el operador debe atender.
+  private denyAsset(
+    reason: string,
+    context: Record<string, string | undefined>,
+    cause?: unknown,
+  ): NotFoundException {
+    const detail = Object.entries(context)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(' ');
+    const line = `Assets · no se sirve el bundle: ${reason} — ${detail}`;
+    if (cause === undefined) {
+      this.logger.warn(line);
+    } else {
+      this.logger.error(
+        line,
+        cause instanceof Error ? (cause.stack ?? cause.message) : String(cause),
+      );
+    }
+    return new NotFoundException({
+      message: ASSET_NOT_FOUND_MESSAGE,
+      code: ASSET_NOT_FOUND_CODE,
+    });
   }
 
   /**

--- a/apps/api/src/marketplace/modules-dispatcher.controller.ts
+++ b/apps/api/src/marketplace/modules-dispatcher.controller.ts
@@ -219,11 +219,25 @@ export class ModulesDispatcherController {
         : matched.handler(ctx));
       result = ret ?? { status: 204, body: null };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`[mod:${matched.moduleName}] handler lanzó: ${msg}`);
+      // SEGURIDAD (MUST-FIX 26): el mensaje del error lo escribe código
+      // third-party del marketplace y puede llevar cualquier cosa —
+      // fragmentos de SQL, rutas de fichero, respuestas de una API externa,
+      // incluso un secreto interpolado por descuido del módulo. Este
+      // dispatcher sirve rutas que pueden ser anónimas, así que el detalle
+      // NO viaja al cliente: se queda en el log del servidor y el cliente
+      // recibe un mensaje genérico y estable con su `code`.
+      //
+      // Un módulo que quiera comunicar algo al usuario final no debe lanzar:
+      // devuelve `{ status, body }` desde el handler, que sí se envía tal cual.
+      this.logger.error(
+        `Dispatcher · el handler del módulo lanzó una excepción — ` +
+          `module=${matched.moduleName} tenant=${user?.tenantId ?? 'anónimo'} ` +
+          `operation=${method} ${stripped}`,
+        err instanceof Error ? (err.stack ?? err.message) : String(err),
+      );
       throw new HttpException(
         {
-          message: `Error en módulo "${matched.moduleName}": ${msg}`,
+          message: 'El módulo no pudo completar la operación.',
           code: 'MARKETPLACE_MODULE_HANDLER_ERROR',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/apps/api/tests/marketplace/module-assets.controller.test.ts
+++ b/apps/api/tests/marketplace/module-assets.controller.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Tests del endpoint público de assets de módulos (MUST-FIX 26).
+ *
+ * `GET /api/v1/modules/:slug/ui/:surface.js` NO pide autenticación. Antes de
+ * este fix cada motivo de fallo devolvía un `code` y un `message` distintos:
+ *
+ *   - `MARKETPLACE_MODULE_NOT_INSTALLED`  → "no está instalado"
+ *   - `MARKETPLACE_MODULE_NOT_AVAILABLE`  → "(status: FAILED)"   ← estado interno
+ *   - `MARKETPLACE_PACKAGE_DOWNLOAD_FAILED` → `err.message` crudo ← ruta/bucket
+ *   - `MARKETPLACE_SURFACE_UI_MISSING`    → "no tiene UI para surface"
+ *
+ * Un anónimo podía por tanto enumerar qué módulos hay instalados en la
+ * instancia y en qué estado, y sacarle al storage la ruta absoluta del blob
+ * (disco local) o el nombre del bucket (S3).
+ *
+ * Estos tests fijan las dos mitades del contrato nuevo:
+ *   (a) el cliente NO ve ningún detalle interno y las cinco causas son
+ *       indistinguibles entre sí — mismo status, mismo `code`, mismo `message`;
+ *   (b) el detalle real SÍ queda en el log del servidor con contexto para
+ *       depurar (módulo, surface, versión, storage key y el error original).
+ */
+
+import { Logger, NotFoundException } from '@nestjs/common';
+import AdmZip from 'adm-zip';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FastifyReply } from 'fastify';
+import { ModuleAssetsController } from '../../src/marketplace/module-assets.controller';
+import type { InstalledModuleService } from '../../src/marketplace/installed-module.service';
+import type { ModuleContextFactory } from '../../src/modules/module-context.factory';
+
+/// Cuerpo exacto que el endpoint debe devolver ante CUALQUIER motivo por el
+/// que no puede servir el bundle. Si un refactor futuro diferencia una causa,
+/// estos tests caen.
+const GENERIC_BODY = {
+  message: 'El recurso solicitado no está disponible.',
+  code: 'MARKETPLACE_ASSET_NOT_FOUND',
+};
+
+/// Fragmentos que NUNCA pueden aparecer en lo que ve el cliente. Cubren las
+/// dos familias de storage soportadas: disco local (ruta absoluta en el
+/// ENOENT de `readFile`) y S3/MinIO (bucket + endpoint en el error del SDK).
+const LOCAL_DISK_ERROR =
+  "ENOENT: no such file or directory, open '/var/lib/didacta/storage/modules/mod.example-1.0.0.zip'";
+const S3_ERROR = 'NoSuchKey: The specified key does not exist. Bucket: didacta-prod-modules';
+
+function makeRes(): FastifyReply {
+  return { header: vi.fn() } as unknown as FastifyReply;
+}
+
+function makeInstalled(row: unknown): InstalledModuleService {
+  return { findByName: vi.fn(async () => row) } as unknown as InstalledModuleService;
+}
+
+function makeContextFactory(download: () => Promise<Buffer>): ModuleContextFactory {
+  return { getStorage: () => ({ download }) } as unknown as ModuleContextFactory;
+}
+
+/// Row mínimo de `installed_module` con los campos que el controller lee.
+function moduleRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'mod.example',
+    version: '1.0.0',
+    status: 'INSTALLED',
+    packageStorageKey: 'modules/mod.example-1.0.0.zip',
+    ...overrides,
+  };
+}
+
+/// ZIP válido que NO contiene `dist/ui/<surface>.js`.
+function zipWithoutBundle(): Buffer {
+  const zip = new AdmZip();
+  zip.addFile('module.json', Buffer.from('{"name":"mod.example"}', 'utf8'));
+  return zip.toBuffer();
+}
+
+/// ZIP válido que SÍ contiene el bundle de la surface `admin`.
+function zipWithBundle(code: string): Buffer {
+  const zip = new AdmZip();
+  zip.addFile('dist/ui/admin.js', Buffer.from(code, 'utf8'));
+  return zip.toBuffer();
+}
+
+let warn: ReturnType<typeof vi.spyOn>;
+let error: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warn = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  error = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // El cache de bundles es estático a nivel de módulo: sin esto un test que
+  // sirve un bundle contamina a los siguientes con el mismo slug+surface.
+  ModuleAssetsController.invalidateCache('mod.example');
+});
+
+/// Ejecuta el endpoint y devuelve el cuerpo que vería el cliente.
+async function callAndCaptureBody(ctrl: ModuleAssetsController): Promise<unknown> {
+  try {
+    await ctrl.getUIBundle('example', 'admin', makeRes());
+  } catch (err) {
+    expect(err).toBeInstanceOf(NotFoundException);
+    return (err as NotFoundException).getResponse();
+  }
+  throw new Error('Se esperaba un NotFoundException y no se lanzó ninguno.');
+}
+
+/// Aplana todo lo que se pasó al logger (mensaje + trace) en un solo string.
+function loggedText(): string {
+  return [...warn.mock.calls, ...error.mock.calls].flat().map(String).join('\n');
+}
+
+describe('ModuleAssetsController · endpoint público sin auth', () => {
+  it('status distinto de INSTALLED: el cliente no ve el estado interno, el log sí', async () => {
+    const ctrl = new ModuleAssetsController(
+      makeInstalled(moduleRow({ status: 'FAILED' })),
+      makeContextFactory(async () => zipWithBundle('ok')),
+    );
+
+    const body = await callAndCaptureBody(ctrl);
+
+    // (a) el cliente no ve el status interno de instalación
+    expect(body).toEqual(GENERIC_BODY);
+    expect(JSON.stringify(body)).not.toContain('FAILED');
+    expect(JSON.stringify(body)).not.toContain('status');
+
+    // (b) el operador sí lo ve, con módulo y surface para depurar
+    const log = loggedText();
+    expect(log).toContain('FAILED');
+    expect(log).toContain('module=mod.example');
+    expect(log).toContain('surface=admin');
+  });
+
+  it('fallo del storage: el cliente no ve el error crudo (ruta local), el log sí', async () => {
+    const ctrl = new ModuleAssetsController(
+      makeInstalled(moduleRow()),
+      makeContextFactory(async () => {
+        throw new Error(LOCAL_DISK_ERROR);
+      }),
+    );
+
+    const body = await callAndCaptureBody(ctrl);
+
+    // (a) ni el mensaje del storage ni la ruta absoluta llegan al cliente
+    expect(body).toEqual(GENERIC_BODY);
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('ENOENT');
+    expect(serialized).not.toContain('/var/lib/didacta');
+    expect(serialized).not.toContain('modules/mod.example-1.0.0.zip');
+
+    // (b) el log lleva el error original + la storage key que falló
+    const log = loggedText();
+    expect(log).toContain('ENOENT');
+    expect(log).toContain('/var/lib/didacta/storage/modules/mod.example-1.0.0.zip');
+    expect(log).toContain('storageKey=modules/mod.example-1.0.0.zip');
+    expect(error).toHaveBeenCalled();
+  });
+
+  it('fallo del storage S3: el nombre del bucket no llega al cliente', async () => {
+    const ctrl = new ModuleAssetsController(
+      makeInstalled(moduleRow()),
+      makeContextFactory(async () => {
+        throw new Error(S3_ERROR);
+      }),
+    );
+
+    const body = await callAndCaptureBody(ctrl);
+
+    expect(body).toEqual(GENERIC_BODY);
+    expect(JSON.stringify(body)).not.toContain('didacta-prod-modules');
+    expect(loggedText()).toContain('didacta-prod-modules');
+  });
+
+  it('paquete sin bundle para la surface: no confirma que el módulo esté instalado', async () => {
+    const ctrl = new ModuleAssetsController(
+      makeInstalled(moduleRow()),
+      makeContextFactory(async () => zipWithoutBundle()),
+    );
+
+    const body = await callAndCaptureBody(ctrl);
+
+    // (a) el cliente no puede deducir que el módulo existe ni su versión
+    expect(body).toEqual(GENERIC_BODY);
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('mod.example');
+    expect(serialized).not.toContain('1.0.0');
+    expect(serialized).not.toContain('dist/ui');
+
+    // (b) el log dice exactamente qué entrada faltaba en el ZIP
+    const log = loggedText();
+    expect(log).toContain('dist/ui/admin.js');
+    expect(log).toContain('version=1.0.0');
+  });
+
+  it('paquete corrupto: no escapa como 500 ni filtra el error de adm-zip', async () => {
+    const ctrl = new ModuleAssetsController(
+      makeInstalled(moduleRow()),
+      // Bytes que no son un ZIP: adm-zip revienta al parsear el directorio.
+      makeContextFactory(async () => Buffer.from('esto no es un zip', 'utf8')),
+    );
+
+    const body = await callAndCaptureBody(ctrl);
+
+    expect(body).toEqual(GENERIC_BODY);
+    expect(error).toHaveBeenCalled();
+    expect(loggedText()).toContain('module=mod.example');
+  });
+
+  it('las cinco causas de fallo son indistinguibles desde fuera', async () => {
+    const scenarios: Array<() => ModuleAssetsController> = [
+      // no instalado
+      () =>
+        new ModuleAssetsController(
+          makeInstalled(null),
+          makeContextFactory(async () => zipWithBundle('ok')),
+        ),
+      // instalado pero en otro status
+      () =>
+        new ModuleAssetsController(
+          makeInstalled(moduleRow({ status: 'INSTALLING' })),
+          makeContextFactory(async () => zipWithBundle('ok')),
+        ),
+      // storage caído
+      () =>
+        new ModuleAssetsController(
+          makeInstalled(moduleRow()),
+          makeContextFactory(async () => {
+            throw new Error(S3_ERROR);
+          }),
+        ),
+      // ZIP corrupto
+      () =>
+        new ModuleAssetsController(
+          makeInstalled(moduleRow()),
+          makeContextFactory(async () => Buffer.from('no soy un zip', 'utf8')),
+        ),
+      // ZIP válido sin el bundle de esa surface
+      () =>
+        new ModuleAssetsController(
+          makeInstalled(moduleRow()),
+          makeContextFactory(async () => zipWithoutBundle()),
+        ),
+    ];
+
+    const bodies: unknown[] = [];
+    const statuses: number[] = [];
+    for (const build of scenarios) {
+      try {
+        await build().getUIBundle('example', 'admin', makeRes());
+        throw new Error('Se esperaba un NotFoundException y no se lanzó ninguno.');
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotFoundException);
+        bodies.push((err as NotFoundException).getResponse());
+        statuses.push((err as NotFoundException).getStatus());
+      }
+    }
+
+    // Un solo status y un solo cuerpo para las cinco: sin oráculo de
+    // enumeración. Esta es la aserción que impide que el fix se revierta.
+    expect(new Set(statuses)).toEqual(new Set([404]));
+    for (const body of bodies) expect(body).toEqual(GENERIC_BODY);
+  });
+
+  it('el camino feliz sigue sirviendo el bundle con sus headers de cache', async () => {
+    const res = makeRes();
+    const ctrl = new ModuleAssetsController(
+      makeInstalled(moduleRow()),
+      makeContextFactory(async () => zipWithBundle('console.log(1)')),
+    );
+
+    const file = await ctrl.getUIBundle('example', 'admin', res);
+
+    expect(file.getStream()).toBeDefined();
+    expect(res.header).toHaveBeenCalledWith('ETag', '"1.0.0"');
+    expect(res.header).toHaveBeenCalledWith('X-Module-Version', '1.0.0');
+  });
+
+  it('surface inválida mantiene su code: no depende de qué haya instalado', async () => {
+    const installed = makeInstalled(moduleRow());
+    const ctrl = new ModuleAssetsController(
+      installed,
+      makeContextFactory(async () => zipWithBundle('ok')),
+    );
+
+    await expect(ctrl.getUIBundle('example', 'inventada', makeRes())).rejects.toMatchObject({
+      response: { code: 'MARKETPLACE_ASSET_SURFACE_INVALID' },
+    });
+    // Se rechaza antes de tocar la BD, así que no revela nada de la instancia.
+    expect(installed.findByName).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/tests/marketplace/modules-dispatcher.controller.test.ts
+++ b/apps/api/tests/marketplace/modules-dispatcher.controller.test.ts
@@ -1,4 +1,4 @@
-import { HttpException, NotFoundException } from '@nestjs/common';
+import { HttpException, Logger, NotFoundException } from '@nestjs/common';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ModuleRouterService } from '../../src/marketplace/module-router.service';
 import { ModulesDispatcherController } from '../../src/marketplace/modules-dispatcher.controller';
@@ -721,5 +721,99 @@ describe('ModulesDispatcherController.dispatch', () => {
       externalSource: 'learndash',
       permissions: ['users.upsertByExternalRef'],
     });
+  });
+});
+
+/// MUST-FIX 26 — el dispatcher deja de reenviar al cliente el `err.message`
+/// crudo del handler de un módulo third-party.
+///
+/// El mensaje lo escribe código que NO es nuestro y que se instala desde el
+/// marketplace: puede llevar SQL, rutas de fichero, la respuesta de una API
+/// externa o un secreto interpolado por descuido del módulo. Como muchas
+/// rutas del dispatcher son anónimas (ver la decodificación opcional del
+/// Bearer arriba), ese detalle no puede viajar en la respuesta.
+///
+/// Un módulo que quiera comunicar algo al usuario final no debe lanzar:
+/// devuelve `{ status, body }` desde el handler, que sí se envía tal cual
+/// (cubierto por los tests de despacho de arriba).
+describe('ModulesDispatcherController · saneado del error del handler', () => {
+  /// Mensaje de un módulo que filtra a la vez red interna, SQL y un secreto.
+  const LEAKY = 'connect ECONNREFUSED 10.0.0.7:5432 — SELECT * FROM wp_users; secret=sk_live_abc';
+
+  function makeDispatcher(handler: () => Promise<never>): ModulesDispatcherController {
+    const router = new ModuleRouterService();
+    router.registerModule('mod.example', '/modules/example', [
+      { method: 'GET', path: '/probe', handler },
+    ]);
+    return new ModulesDispatcherController(
+      router,
+      makeTokens({ [VALID_TOKEN]: claims() }),
+      httpSvc,
+      rateLimiter,
+      dbSvc,
+      didactaFactory,
+      jobsFactory,
+      secretsFactory,
+      moduleRegistry,
+      contextFactory,
+      tenantContext,
+      tenantResolver,
+    );
+  }
+
+  it('el cliente recibe un mensaje genérico con su code y el detalle va al log', async () => {
+    const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    const ctrl = makeDispatcher(async () => {
+      throw new Error(LEAKY);
+    });
+    const req = makeReq({
+      url: '/api/v1/modules/example/probe',
+      headers: { authorization: `Bearer ${VALID_TOKEN}` },
+    });
+    const { reply } = makeReply();
+
+    const thrown: unknown = await ctrl.dispatch(req, reply, undefined).catch((e: unknown) => e);
+
+    // (a) el cliente no ve nada del error original
+    expect(thrown).toBeInstanceOf(HttpException);
+    const body = (thrown as HttpException).getResponse();
+    expect((thrown as HttpException).getStatus()).toBe(500);
+    expect(body).toEqual({
+      message: 'El módulo no pudo completar la operación.',
+      code: 'MARKETPLACE_MODULE_HANDLER_ERROR',
+    });
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('ECONNREFUSED');
+    expect(serialized).not.toContain('10.0.0.7');
+    expect(serialized).not.toContain('wp_users');
+    expect(serialized).not.toContain('sk_live_abc');
+
+    // (b) el detalle sí queda en el log, con módulo, tenant y operación
+    const logged = errorSpy.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain(LEAKY);
+    expect(logged).toContain('module=mod.example');
+    expect(logged).toContain('tenant=t-1');
+    expect(logged).toContain('operation=GET /modules/example/probe');
+
+    errorSpy.mockRestore();
+  });
+
+  it('un throw que no es Error tampoco filtra su contenido', async () => {
+    const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    const ctrl = makeDispatcher(async () => {
+      throw 'DB_PASSWORD=hunter2' as never;
+    });
+    const req = makeReq({ url: '/api/v1/modules/example/probe' });
+    const { reply } = makeReply();
+
+    const thrown: unknown = await ctrl.dispatch(req, reply, undefined).catch((e: unknown) => e);
+
+    expect(JSON.stringify((thrown as HttpException).getResponse())).not.toContain('hunter2');
+    const logged = errorSpy.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain('hunter2');
+    // Ruta anónima: el log lo deja explícito en lugar de un tenant vacío.
+    expect(logged).toContain('tenant=anónimo');
+
+    errorSpy.mockRestore();
   });
 });

--- a/apps/web/src/i18n/messages/en/errorsApiResto.json
+++ b/apps/web/src/i18n/messages/en/errorsApiResto.json
@@ -5,6 +5,7 @@
   "MANIFEST_CONSISTENCY_INVALID": "The module manifest is inconsistent with the package contents.",
   "MANIFEST_INVALID_JSON": "The module manifest is not valid JSON.",
   "MANIFEST_SCHEMA_INVALID": "The module manifest does not match the expected schema.",
+  "MARKETPLACE_ASSET_NOT_FOUND": "The requested asset is not available.",
   "MARKETPLACE_ASSET_SURFACE_INVALID": "That surface is not valid.",
   "MARKETPLACE_DISPATCHER_METHOD_NOT_ALLOWED": "Method not supported by the dispatcher",
   "MARKETPLACE_DISPATCHER_ROUTE_NOT_FOUND": "No module is registered for that route.",

--- a/apps/web/src/i18n/messages/es/errorsApiResto.json
+++ b/apps/web/src/i18n/messages/es/errorsApiResto.json
@@ -1,5 +1,6 @@
 {
   "ALREADY_INITIALIZED": "La plataforma ya fue inicializada. Inicia sesión con tu cuenta admin.",
+  "MARKETPLACE_ASSET_NOT_FOUND": "El recurso solicitado no está disponible.",
   "MARKETPLACE_DISPATCHER_METHOD_NOT_ALLOWED": "Método no soportado por el dispatcher",
   "MARKETPLACE_SUPER_ADMIN_REQUIRED": "Esta acción requiere rol super_admin.",
   "MODERATION_ADMIN_REQUIRED": "Esta acción requiere rol de administrador.",


### PR DESCRIPTION
Cierra el **MUST-FIX 26**. Es un hallazgo de seguridad **preexistente y ajeno a la migración i18n** — lo destapó otro worker al catalogar códigos de error, pero el código es de antes. No toca ningún fichero de la migración.

## El problema

`GET /api/v1/modules/:slug/ui/:surface.js` (`ModuleAssetsController`) **no pide autenticación** — es correcto, sirve bundles JS que el navegador carga directamente. Lo que no era correcto es que devolviera un `code` + `message` **distinto por cada causa de fallo**. Eso lo convertía en un **oráculo de enumeración**: cualquiera, sin credenciales, podía barrer slugs y deducir qué módulos hay instalados en la instancia, en qué estado y con qué versión. Y en dos de los casos le sacaba al servidor detalle de infraestructura.

En español el impacto era directo: `apiErrorMessage` (`apps/web/src/lib/i18n/api-error.ts`) **cae al `message` del backend** cuando el `code` no está en el catálogo, así que el texto crudo se pintaba tal cual en pantalla.

## Mensajes saneados

### 1. `apps/api/src/marketplace/module-assets.controller.ts:93` (antes) — estado interno de instalación

- **Antes**: `404 MARKETPLACE_MODULE_NOT_AVAILABLE` — `Módulo "mod.x" no está disponible (status: FAILED).`
- **Ahora**: `404 MARKETPLACE_ASSET_NOT_FOUND` — `El recurso solicitado no está disponible.`
- **Al log**: `Assets · no se sirve el bundle: el módulo está en status FAILED, no en INSTALLED — module=mod.x surface=admin version=1.0.0` (`warn`)
- **Test**: `module-assets.controller.test.ts` › «status distinto de INSTALLED: el cliente no ve el estado interno, el log sí»

### 2. `apps/api/src/marketplace/module-assets.controller.ts:105` (antes) — `err.message` crudo del storage

- **Antes**: `404 MARKETPLACE_PACKAGE_DOWNLOAD_FAILED` — `Error descargando paquete del módulo: ${err.message}`. Con `LocalDiskStorage` eso es el ENOENT de `readFile`, es decir **la ruta absoluta del blob en el disco del servidor**; con `S3StorageService`, el error del SDK con **nombre del bucket**.
- **Ahora**: el 404 genérico idéntico al resto.
- **Al log**: `… falló la descarga del paquete desde el storage — module=mod.x surface=admin storageKey=modules/mod.x-1.0.0.zip` + el error original con su stack (`error`).
- **Tests**: «fallo del storage: el cliente no ve el error crudo (ruta local), el log sí» y «fallo del storage S3: el nombre del bucket no llega al cliente».

### 3. `apps/api/src/marketplace/modules-dispatcher.controller.ts:226` (antes) — `err.message` crudo de un módulo third-party

- **Antes**: `500 MARKETPLACE_MODULE_HANDLER_ERROR` — `Error en módulo "mod.x": ${err.message}`. Ese texto lo escribe **código que no es nuestro**, instalado desde el marketplace: puede llevar SQL, rutas, la respuesta de una API externa o un secreto interpolado por descuido del módulo. Y el dispatcher sirve rutas que **pueden ser anónimas** (decodificación opcional del Bearer).
- **Ahora**: `500 MARKETPLACE_MODULE_HANDLER_ERROR` (**mismo code**) — `El módulo no pudo completar la operación.`
- **Al log**: `Dispatcher · el handler del módulo lanzó una excepción — module=mod.x tenant=t-1 operation=GET /modules/x/probe` + stack (`error`). Antes solo se logueaba `err.message`, sin tenant, sin operación y sin stack.
- **Tests**: `modules-dispatcher.controller.test.ts` › «el cliente recibe un mensaje genérico con su code y el detalle va al log» y «un throw que no es Error tampoco filtra su contenido».
- Nota de contrato para autores de módulos, escrita en el propio comentario: **un módulo que quiera comunicar algo al usuario final no debe lanzar** — devuelve `{ status, body }` desde el handler, que sí se envía tal cual (comportamiento ya cubierto por los tests de despacho existentes).

### 4. El cuarto: `apps/api/src/marketplace/module-assets.controller.ts:116` (antes) — sí existe

Lo confirmo con evidencia, no lo estiro:

- **Antes**: `404 MARKETPLACE_SURFACE_UI_MISSING` — `El módulo "mod.x" no tiene UI para surface "admin".`
- Ese mensaje **solo es alcanzable si el módulo existe, está en status `INSTALLED` y su paquete se descargó del storage**. Es decir: es una confirmación positiva, a un anónimo, de instalación y estado — exactamente la misma clase de fuga que el nº 1, en el mismo endpoint sin auth.
- **Ahora**: el 404 genérico idéntico al resto.
- **Al log**: `… el paquete no incluye "dist/ui/admin.js" — module=mod.x surface=admin version=1.0.0` (`warn`)
- **Test**: «paquete sin bundle para la surface: no confirma que el módulo esté instalado».

### Extra encontrado por el camino: oráculo por status code

`new AdmZip(packageBuffer)` / `getEntry` / `getData` no estaban dentro de ningún `try`. Con un paquete corrupto el fallo escapaba como **500** en vez de 404 — y ese 500 solo es alcanzable si el módulo existe, está `INSTALLED` y su blob se descargó: otro oráculo, esta vez por código de estado en lugar de por mensaje. Ahora cae en el mismo 404 genérico y el error se registra. **Test**: «paquete corrupto: no escapa como 500 ni filtra el error de adm-zip».

## Cómo está resuelto

Una **única fábrica** del error, `ModuleAssetsController.denyAsset(reason, context, cause?)`:

- construye **siempre** el mismo `NotFoundException` — que exista un solo constructor es lo que impide que un refactor futuro vuelva a diferenciar las causas;
- escribe el motivo real en el log con contexto para depurar (módulo, surface, versión, storage key, error original + stack);
- `warn` para causas esperables (módulo ausente, sin bundle para esa surface), `error` para fallos reales de infraestructura (storage caído, ZIP corrupto) que el operador debe atender.

El test **«las cinco causas de fallo son indistinguibles desde fuera»** recorre los cinco escenarios y afirma que el conjunto de status es `{404}` y que los cinco cuerpos son `toEqual` entre sí. Esa es la aserción que impide que la fuga vuelva.

## Contrato: qué cambia y qué no

- **Ningún `code` existente se renombra.** `MARKETPLACE_MODULE_HANDLER_ERROR`, `MARKETPLACE_ASSET_SURFACE_INVALID`, `MARKETPLACE_DISPATCHER_ROUTE_NOT_FOUND`, `MARKETPLACE_DISPATCHER_METHOD_NOT_ALLOWED` y `MARKETPLACE_SUPER_ADMIN_REQUIRED` siguen igual.
- **Un `code` nuevo**: `MARKETPLACE_ASSET_NOT_FOUND`, añadido a `apps/web/src/i18n/messages/es/errorsApiResto.json` y `en/errorsApiResto.json` — el mismo namespace donde ya viven sus hermanos `MARKETPLACE_*`, con el mismo estilo.
- Los cuatro codes que el endpoint ya no emite (`MODULE_NOT_INSTALLED`, `MODULE_NOT_AVAILABLE`, `PACKAGE_DOWNLOAD_FAILED`, `SURFACE_UI_MISSING`) **se dejan en el catálogo EN**: no se renombran ni se borran, simplemente dejan de emitirse. Grep: no los referencia ningún código, solo el catálogo.

### Consumidores: comprobado antes de unificar

El único consumidor legítimo del endpoint es **`apps/web/src/lib/module-loader.ts`**, y discrimina por **`response.status === 404`** (línea 124) — **nunca parsea el body ni lee el `code`**. Grep en `apps/web/src` y `modules/`: ningún otro consumidor. La ruta de fallo de storage ya devolvía 404 antes, así que para el loader el comportamiento observable es **idéntico**.

`MARKETPLACE_ASSET_SURFACE_INVALID` **se mantiene diferenciado a propósito**: valida el parámetro contra la constante estática `MODULE_SURFACES` y se rechaza **antes de tocar la BD** (el test lo afirma con `expect(installed.findByName).not.toHaveBeenCalled()`), así que no revela nada de la instancia y sigue siendo útil para quien desarrolla un módulo.

### Fuera de alcance, dicho explícitamente

Los mensajes de `MarketplacePackageError` que salen por `MarketplaceErrorFilter` (`STORAGE_FAILED`, `MODULE_BOOT_FAILED`…) **sí llevan detalle interno, y se quedan como están**: solo se alcanzan desde `AdminMarketplaceController`, que exige Bearer válido **y rol `super_admin`**, y son precisamente lo que el operador necesita para saber por qué le falló una instalación. Destinatario distinto, decisión distinta.

Queda un canal lateral **por tiempo** (el caso «no instalado» responde sin bajar a storage), no abordado aquí: cerrarlo exigiría respuestas de tiempo constante en un endpoint de assets estáticos, y el coste no compensa frente a lo que cierra este PR.

## Verificación

- `apps/api` vitest: **2116/2116** verde (base 2106 + los 10 nuevos).
- `apps/web` vitest: **314/314** verde, sin cambios.
- `dev-check --format-fix` + `dev-check --quick`: typecheck api, typecheck web, eslint y prettier en verde.
- `ee-fence`: **0 violaciones** sobre 1378 ficheros (base 1377 + el test nuevo).
- E2E: los corre la otra vía de la sesión; este PR no los toca.
