### PR TITLE
feat(e2e): script de captura de las 40 pantallas de la documentación (ES + EN)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ apps/api/data/
 # Test artifacts
 apps/e2e/test-results/
 apps/e2e/branding-shots/
+# Capturas de la documentación: se generan con apps/e2e/shots/ y su sitio es el
+# repo didacta-docs, no este. Aquí solo vive el script que las produce.
+apps/e2e/shots-output/
 test-results/
 playwright-report/
 

--- a/apps/e2e/playwright.shots.config.ts
+++ b/apps/e2e/playwright.shots.config.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Config de Playwright para el generador de capturas de la documentación
+ * (`shots/`). Es un proyecto aparte del `playwright.config.ts` de los specs
+ * E2E porque:
+ *
+ *  - el viewport tiene que ser FIJO (1440x900, dsf 1) para que la tanda
+ *    española y la inglesa sean comparables píxel a píxel;
+ *  - los "tests" no aseveran nada de negocio: recorren la app y escriben PNGs,
+ *    así que no deben mezclarse con el reporte de la suite;
+ *  - el orden entre ficheros es significativo (el recorrido de ventas continúa
+ *    donde acaba el de primeros pasos) → `workers: 1` y `fullyParallel: false`.
+ *
+ * Ver `shots/README.md` para qué hay que tener levantado y cómo se lanza.
+ */
+
+import { defineConfig } from '@playwright/test';
+
+const BASE_URL = process.env.SHOTS_BASE_URL ?? process.env.E2E_BASE_URL ?? 'http://localhost:3010';
+
+export default defineConfig({
+  testDir: './shots',
+  // Los ficheros se descubren y ejecutan en orden alfabético; el prefijo
+  // numérico de cada spec (`01-…`, `02-…`) fija la secuencia del recorrido.
+  testMatch: /\d\d-.*\.spec\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  // Cada spec es UN recorrido completo (20 pantallas encadenadas), no un test
+  // suelto: el presupuesto es el del recorrido entero.
+  timeout: 20 * 60 * 1000,
+  reporter: [['list']],
+  use: {
+    baseURL: BASE_URL,
+    // Mismo tamaño que las 40 capturas originales de la documentación.
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+    colorScheme: 'light',
+    // Determinista: las fechas relativas ("hace unos segundos") y los formatos
+    // de fecha del servidor se calculan siempre en la misma zona.
+    timezoneId: 'Europe/Madrid',
+    trace: 'off',
+    video: 'off',
+    screenshot: 'off',
+  },
+  projects: [{ name: 'shots' }],
+});

--- a/apps/e2e/shots/01-recorrido-visual.spec.ts
+++ b/apps/e2e/shots/01-recorrido-visual.spec.ts
@@ -1,0 +1,414 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Recorrido visual 1 — «del asistente de configuración al primer certificado».
+ * Genera las 22 capturas de `didacta-docs/docs/assets/recorrido-visual/`.
+ *
+ * Precondición: instancia VIRGEN (cero tenants) y token de setup a mano.
+ * Lánzalo siempre después de `shots/reset-instance.sh`; ver `shots/README.md`.
+ *
+ * Es un único `test` a propósito: las 22 capturas son un mismo recorrido con
+ * estado acumulado (el curso de la 11 es el que se publicó en la 10, el código
+ * de la 17 es el que se generó en la 12). Partirlo en 22 tests daría 22
+ * contextos de navegador sin nada que compartir.
+ */
+
+import path from 'node:path';
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { encodePng } from '../helpers/png';
+import { newShotContext, newShotPage, readAccessToken } from './lib/browser';
+import {
+  api,
+  deleteTenantSmtp,
+  extractResetToken,
+  injectSession,
+  mailpitClear,
+  mailpitWaitFor,
+  putTenantSmtp,
+  seedSystemSpaces,
+  setProfileLocale,
+  signin,
+} from './lib/api';
+import { annotationLabel, DEMO, LOCALE, SETUP_TOKEN } from './lib/config';
+import { t } from './lib/i18n';
+import { assertLocale, setRange, shot } from './lib/shot';
+
+const WALKTHROUGH = 'recorrido-visual';
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+/**
+ * Imágenes generadas en memoria (degradado suave) para la foto de perfil y el
+ * logo del tenant. Así no hay binarios en el repo y las capturas no dependen
+ * de la marca de nadie — un degradado es un marcador de posición neutro.
+ */
+function gradientPng(width: number, height: number): Buffer {
+  const raw = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      raw[i] = 46 + Math.round((x * 80) / width);
+      raw[i + 1] = 125 + Math.round((y * 60) / height);
+      raw[i + 2] = 206;
+      raw[i + 3] = 255;
+    }
+  }
+  return encodePng(raw, width, height);
+}
+
+const AVATAR_PNG = gradientPng(512, 512);
+const LOGO_PNG = gradientPng(320, 96);
+
+/**
+ * Sube un fichero por el diálogo del navegador, que es como lo hace una
+ * persona. Más fiable que `setInputFiles` sobre el `<input type="file">`
+ * oculto: en varias de estas pantallas el input vive dentro de un componente
+ * que se monta al vuelo.
+ */
+async function uploadThrough(
+  page: Page,
+  trigger: Locator,
+  file: { name: string; buffer: Buffer },
+): Promise<void> {
+  const [chooser] = await Promise.all([page.waitForEvent('filechooser'), trigger.click()]);
+  await chooser.setFiles({ name: file.name, mimeType: 'image/png', buffer: file.buffer });
+}
+
+test('recorrido visual · 22 capturas', async ({ browser }) => {
+  test.skip(!SETUP_TOKEN, 'Falta SHOTS_SETUP_TOKEN — corre antes shots/reset-instance.sh');
+
+  const adminCtx = await newShotContext(browser);
+  const admin = await newShotPage(adminCtx);
+
+  // ───────────────────────────────────────────────────────────── 1 · setup ──
+  await admin.goto(`/setup?token=${encodeURIComponent(SETUP_TOKEN)}`);
+  await expect(admin.getByRole('heading', { name: t('auth', 'setup.welcomeTitle') })).toBeVisible({
+    timeout: 30_000,
+  });
+  await assertLocale(admin, LOCALE);
+
+  const welcomeCta = admin.getByRole('button', { name: t('auth', 'setup.welcomeCta') });
+  await shot(admin, WALKTHROUGH, '01-setup-intro', {
+    annotations: [{ target: welcomeCta, label: t('auth', 'setup.welcomeCta') }],
+  });
+
+  await welcomeCta.click();
+  await admin.locator('#orgName').fill(DEMO.org.name);
+  // `window.location.host` trae el puerto y `HOSTNAME_RE` del backend no acepta
+  // ":". Hay que sobreescribirlo: vaciarlo no vale, un effect lo repuebla.
+  await admin.locator('#hostname').fill(DEMO.org.hostname);
+  const continueCta = admin.getByRole('button', { name: t('auth', 'setup.continue') });
+  await shot(admin, WALKTHROUGH, '02-setup-organizacion', {
+    annotations: [{ target: continueCta, label: t('auth', 'setup.continue') }],
+  });
+
+  await continueCta.click();
+  await expect(admin.getByRole('heading', { name: t('auth', 'setup.modulesTitle') })).toBeVisible();
+  await admin.getByRole('button', { name: t('auth', 'setup.continue') }).click();
+
+  await expect(admin.getByRole('heading', { name: t('auth', 'setup.adminTitle') })).toBeVisible();
+  await admin.locator('#adminName').fill(DEMO.admin.name);
+  await admin.locator('#adminEmail').fill(DEMO.admin.email);
+  await admin.locator('#adminPassword').fill(DEMO.admin.password);
+  await admin.locator('#adminPasswordConfirm').fill(DEMO.admin.password);
+  const createCta = admin.getByRole('button', { name: t('auth', 'setup.submit') });
+  await shot(admin, WALKTHROUGH, '03-setup-admin', {
+    annotations: [{ target: createCta, label: t('auth', 'setup.submit') }],
+  });
+
+  await createCta.click();
+  await expect(admin.getByRole('heading', { name: t('auth', 'setup.tourTitle') })).toBeVisible({
+    timeout: 30_000,
+  });
+  await shot(admin, WALKTHROUGH, '04-setup-listo');
+
+  // El tenant ya existe: ahora sí se pueden sembrar los espacios de sistema,
+  // igual que hace `infra/docker/entrypoint.sh` en cada arranque de la imagen.
+  seedSystemSpaces(REPO_ROOT);
+
+  // ⚠️ Idioma del PERFIL antes de entrar a ninguna ruta autenticada. `LocaleSync`
+  // compara `/me/profile` con la cookie y, si el perfil no dice nada, devuelve
+  // la UI a español. Sin esta línea la tanda inglesa sale en español entera.
+  const adminToken = await readAccessToken(admin);
+  await setProfileLocale(adminToken);
+
+  // ──────────────────────────────────────────────────────── 2 · onboarding ──
+  await admin.getByRole('button', { name: t('auth', 'setup.tourCta') }).click();
+  await admin.waitForURL(/\/onboarding/, { timeout: 30_000 });
+  await expect(
+    admin.getByRole('heading', { name: t('auth', 'onboarding.photoTitle') }),
+  ).toBeVisible({ timeout: 30_000 });
+  await assertLocale(admin, LOCALE);
+
+  await uploadThrough(
+    admin,
+    admin.getByRole('button', { name: t('cuentaComponentes', 'avatar.upload') }),
+    { name: 'foto-de-perfil.png', buffer: AVATAR_PNG },
+  );
+  // El botón pasa de "Subir foto" a "Cambiar foto" cuando la subida termina.
+  await expect(
+    admin.getByRole('button', { name: t('cuentaComponentes', 'avatar.change') }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await shot(admin, WALKTHROUGH, '05-onboarding-foto');
+
+  // Terminamos el onboarding (no se retrata): sin él, el gate de
+  // `(app)/layout.tsx` desvía cualquier ruta autenticada de vuelta al wizard.
+  for (let i = 0; i < 3; i++) {
+    await admin.getByRole('button', { name: t('auth', 'onboarding.continue') }).click();
+  }
+  await admin.getByRole('button', { name: t('auth', 'onboarding.submit') }).click();
+  await admin.waitForURL((url) => !url.pathname.startsWith('/onboarding'), { timeout: 30_000 });
+
+  // ───────────────────────────────────────────────────────────── 3 · login ──
+  // Pantalla pública: contexto sin sesión, manda la cookie de idioma.
+  const publicCtx = await newShotContext(browser);
+  const publicPage = await newShotPage(publicCtx);
+  await publicPage.goto('/signin');
+  await expect(publicPage.locator('#email')).toBeVisible({ timeout: 30_000 });
+  await assertLocale(publicPage, LOCALE);
+  await publicPage.locator('#email').fill(DEMO.admin.email);
+  await publicPage.locator('#password').fill(DEMO.admin.password);
+  const signinCta = publicPage.locator('form button[type="submit"]').first();
+  await shot(publicPage, WALKTHROUGH, '06-signin', {
+    annotations: [{ target: signinCta, label: await signinCta.innerText() }],
+  });
+
+  // ──────────────────────────────────────────────────────────── 4 · marca ──
+  await admin.goto('/admin/branding');
+  await expect(admin.locator('#brandHue')).toBeVisible({ timeout: 30_000 });
+  await assertLocale(admin, LOCALE);
+  // Aquí el disparador NO es un botón sino un `<label>` con el input dentro en
+  // `sr-only`, así que no hay diálogo de fichero que interceptar: se le pasan
+  // los ficheros al input directamente, acotado por el texto del label para no
+  // pillar el uploader de otra tarjeta de la misma página.
+  await admin
+    .locator('label', { hasText: t('adminMarca', 'branding.uploadCta') })
+    .locator('input[type="file"]')
+    .setInputFiles({ name: 'logo.png', mimeType: 'image/png', buffer: LOGO_PNG });
+  await expect(admin.getByAltText(t('adminMarca', 'branding.uploadedAlt'))).toBeVisible({
+    timeout: 30_000,
+  });
+  await setRange(admin, '#brandHue', 212);
+  const brandingSave = admin.getByRole('button', {
+    name: t('adminMarca', 'branding.saveButton'),
+  });
+  await shot(admin, WALKTHROUGH, '07-branding', {
+    scrollTo: brandingSave,
+    annotations: [{ target: brandingSave, label: t('adminMarca', 'branding.saveButton') }],
+  });
+  await brandingSave.click();
+
+  // ───────────────────────────────────────────────────────────── 5 · curso ──
+  await admin.goto('/formador/cursos/nuevo');
+  await expect(admin.locator('#title')).toBeVisible({ timeout: 30_000 });
+  await admin.locator('#title').fill(DEMO.course.title);
+  await admin.locator('#category').fill(DEMO.course.category);
+  const description = admin.getByLabel(t('playersContenido', 'newCourse.descriptionAriaLabel'));
+  await description.click();
+  await description.fill(DEMO.course.description);
+  await shot(admin, WALKTHROUGH, '08-curso-nuevo');
+
+  await admin.getByRole('button', { name: t('playersContenido', 'newCourse.submit') }).click();
+  await admin.waitForURL(/\/formador\/cursos\/[0-9a-f-]{10,}/, { timeout: 30_000 });
+  const courseId = admin.url().split('/').pop()!;
+
+  // Sección + lección por la interfaz: la 09 retrata justo el alta de la lección.
+  await admin.getByRole('button', { name: t('formadorCursos', 'addModule') }).click();
+  await admin.locator('input[name="title"]').fill(DEMO.course.section);
+  await admin.getByRole('button', { name: t('formadorCursos', 'createModule') }).click();
+  await expect(admin.getByText(DEMO.course.section)).toBeVisible({ timeout: 15_000 });
+
+  await admin.getByRole('button', { name: t('formadorCursos', 'addLesson') }).click();
+  await admin
+    .getByPlaceholder(t('formadorCursos', 'lessonTitlePlaceholder'))
+    .fill(DEMO.course.lesson);
+  // `exact` obligatorio: "Crear" es subcadena de "Crear sección" y "Crear curso".
+  const createLesson = admin.getByRole('button', {
+    name: t('formadorCursos', 'create'),
+    exact: true,
+  });
+  await shot(admin, WALKTHROUGH, '09-curso-leccion-alta', {
+    annotations: [{ target: createLesson, label: t('formadorCursos', 'create') }],
+  });
+  await createLesson.click();
+  await expect(admin.getByText(DEMO.course.lesson)).toBeVisible({ timeout: 15_000 });
+
+  // Contenido real de la lección — se ve en las capturas 19 y 20.
+  const detail = await api<{
+    modules: Array<{ id: string; lessons: Array<{ id: string; title: string }> }>;
+  }>(`/api/v1/modules/courses/${courseId}`, { bearer: adminToken });
+  const lessonId = detail.modules[0]?.lessons[0]?.id;
+  if (!lessonId) throw new Error('[shots] La lección no se creó');
+  await api(`/api/v1/modules/courses/lessons/${lessonId}`, {
+    method: 'PUT',
+    body: { content: { text: DEMO.course.lessonText }, durationSec: 300 },
+    bearer: adminToken,
+  });
+
+  await admin.reload();
+  const publishCta = admin.getByRole('button', { name: t('formadorCursos', 'publish') });
+  await expect(publishCta).toBeVisible({ timeout: 30_000 });
+  await shot(admin, WALKTHROUGH, '10-curso-listo-publicar', {
+    annotations: [{ target: publishCta, label: t('formadorCursos', 'publish') }],
+  });
+
+  await publishCta.click();
+  await expect(admin.getByRole('button', { name: t('formadorCursos', 'archive') })).toBeVisible({
+    timeout: 30_000,
+  });
+  await admin.mouse.wheel(0, -2000);
+  await shot(admin, WALKTHROUGH, '11-curso-publicado');
+
+  // ─────────────────────────────────────────────────────── 6 · invitación ──
+  const generate = admin.getByRole('button', { name: t('formadorCursos', 'generate') });
+  await generate.scrollIntoViewIfNeeded();
+  await generate.click();
+  await expect(admin.getByText(t('formadorCursos', 'codeGenerated'))).toBeVisible({
+    timeout: 15_000,
+  });
+  const codeNode = admin.getByText(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/).first();
+  const invitationCode = (await codeNode.innerText()).trim();
+  await shot(admin, WALKTHROUGH, '12-curso-invitacion-generada', {
+    annotations: [{ target: codeNode, label: annotationLabel('invitationCode') }],
+  });
+
+  // Catálogo público de venta: el curso no tiene precio, así que está vacío.
+  await publicPage.goto('/catalogo');
+  await assertLocale(publicPage, LOCALE);
+  await shot(publicPage, WALKTHROUGH, '13-catalogo-publico');
+
+  // ─────────────────────────────────────────────── 7 · alta de la alumna ──
+  // El enlace de "define tu contraseña" viaja por email: hace falta SMTP. Se
+  // pone por API (no por UI) y se quita al terminar, para que el recorrido de
+  // ventas arranque con la pestaña Notificaciones realmente vacía.
+  await putTenantSmtp(adminToken, {
+    host: DEMO.smtp.host,
+    port: Number(DEMO.smtp.port),
+    secure: false,
+    username: DEMO.smtp.username,
+    password: DEMO.smtp.password,
+    fromEmail: DEMO.smtp.fromEmail,
+    fromName: DEMO.smtp.fromName,
+  });
+  await mailpitClear();
+
+  await admin.goto('/admin/usuarios/invitar');
+  await expect(admin.locator('#email')).toBeVisible({ timeout: 30_000 });
+  await admin.locator('#email').fill(DEMO.alumna.email);
+  await admin.locator('#name').fill(DEMO.alumna.name);
+  const inviteCta = admin.getByRole('button', { name: t('adminUsuarios', 'invite.submit') });
+  await shot(admin, WALKTHROUGH, '14-admin-invitar-alumna', {
+    annotations: [{ target: inviteCta, label: t('adminUsuarios', 'invite.submit') }],
+  });
+  await inviteCta.click();
+  await admin.waitForURL(/\/admin\/usuarios/, { timeout: 30_000 });
+
+  const inviteMail = await mailpitWaitFor(DEMO.alumna.email);
+  const resetToken = extractResetToken(inviteMail);
+
+  const alumnaCtx = await newShotContext(browser);
+  const alumna = await newShotPage(alumnaCtx);
+  await alumna.goto(`/reset-password?token=${encodeURIComponent(resetToken)}`);
+  await expect(alumna.locator('#newPassword')).toBeVisible({ timeout: 30_000 });
+  await assertLocale(alumna, LOCALE);
+  await alumna.locator('#newPassword').fill(DEMO.alumna.password);
+  await alumna.locator('#confirm').fill(DEMO.alumna.password);
+  await shot(alumna, WALKTHROUGH, '15-alumna-definir-password');
+  await alumna.locator('form button[type="submit"]').first().click();
+  await expect(alumna.getByText(t('auth', 'reset.doneTitle'))).toBeVisible({ timeout: 30_000 });
+
+  // SMTP fuera: la pestaña Notificaciones vuelve a estar sin configurar.
+  await deleteTenantSmtp(adminToken);
+
+  // ──────────────────────────────────────────── 7bis · la alumna entra ──
+  const alumnaSession = await signin({
+    tenantSlug: DEMO.org.slug,
+    email: DEMO.alumna.email,
+    password: DEMO.alumna.password,
+  });
+  await setProfileLocale(alumnaSession.tokens.accessToken);
+  await alumna.goto('/signin');
+  await injectSession(alumna, {
+    accessToken: alumnaSession.tokens.accessToken,
+    refreshToken: alumnaSession.tokens.refreshToken,
+    user: { ...alumnaSession.user, onboardingCompletedAt: new Date().toISOString() },
+  });
+  // El onboarding de la alumna se completa por API: no se retrata y el gate
+  // solo mira el flag.
+  await api('/api/v1/me/onboarding/complete', {
+    method: 'POST',
+    body: {},
+    bearer: alumnaSession.tokens.accessToken,
+  }).catch(() => undefined);
+
+  await alumna.goto('/cursos');
+  await expect(alumna.getByText(DEMO.course.title)).toBeVisible({ timeout: 30_000 });
+  await assertLocale(alumna, LOCALE);
+  await shot(alumna, WALKTHROUGH, '16-alumna-catalogo');
+
+  await alumna.goto(`/cursos/${DEMO.course.slug}`);
+  const codeInput = alumna.locator('#code');
+  await expect(codeInput).toBeVisible({ timeout: 30_000 });
+  await codeInput.fill(invitationCode);
+  const redeemCta = alumna.getByRole('button', {
+    name: t('alumnoAprendizaje', 'redeemCode'),
+  });
+  await shot(alumna, WALKTHROUGH, '17-alumna-canjear-codigo', {
+    annotations: [{ target: redeemCta, label: t('alumnoAprendizaje', 'redeemCode') }],
+  });
+
+  await redeemCta.click();
+  await expect(alumna.getByText(t('alumnoAprendizaje', 'yourProgress'))).toBeVisible({
+    timeout: 30_000,
+  });
+  // Arriba del todo: el panel de progreso que describe la documentación.
+  await alumna.mouse.wheel(0, -2000);
+  await shot(alumna, WALKTHROUGH, '18-alumna-matriculada');
+
+  // ─────────────────────────────────────── 8 · lección y certificado ──
+  // La primera lección queda seleccionada sola al entrar; basta con traer el
+  // reproductor a la vista.
+  const lessonBody = alumna.getByText(DEMO.course.lessonText.slice(0, 40));
+  await expect(lessonBody).toBeVisible({ timeout: 30_000 });
+  const markCompleted = alumna.getByRole('button', {
+    name: t('playersContenido', 'lesson.markCompleted'),
+  });
+  // El curso de ejemplo cabe entero en el viewport, así que la 18 y la 19
+  // encuadran lo mismo: lo que las distingue es qué señala cada una — la 18, el
+  // panel de progreso; la 19, el botón de completar del reproductor, que es de
+  // lo que habla la documentación.
+  await shot(alumna, WALKTHROUGH, '19-alumna-leccion', {
+    scrollTo: lessonBody,
+    annotations: [{ target: markCompleted, label: t('playersContenido', 'lesson.markCompleted') }],
+  });
+
+  await markCompleted.click();
+  const downloadCert = alumna.getByRole('button', {
+    name: t('alumnoAprendizaje', 'downloadCertificate'),
+  });
+  await expect(downloadCert).toBeVisible({ timeout: 60_000 });
+  await alumna.mouse.wheel(0, -2000);
+  await shot(alumna, WALKTHROUGH, '20-alumna-curso-completado', {
+    annotations: [{ target: downloadCert, label: t('alumnoAprendizaje', 'downloadCertificate') }],
+  });
+
+  await alumna.goto('/mis-certificados');
+  const certNumber = alumna.getByText(/^[A-Z]{2}-\d{4}-\d{6}$/).first();
+  await expect(certNumber).toBeVisible({ timeout: 30_000 });
+  await shot(alumna, WALKTHROUGH, '21-alumna-mis-certificados', {
+    annotations: [{ target: certNumber, label: annotationLabel('certificateNumber') }],
+  });
+
+  // ──────────────────────────────────────────────────────── 9 · licencia ──
+  await admin.goto('/admin/licencia');
+  await expect(admin.getByTestId('license-status-banner')).toBeVisible({ timeout: 30_000 });
+  await assertLocale(admin, LOCALE);
+  await shot(admin, WALKTHROUGH, '22-admin-licencia');
+
+  await adminCtx.close();
+  await publicCtx.close();
+  await alumnaCtx.close();
+});

--- a/apps/e2e/shots/02-notificaciones-y-pagos.spec.ts
+++ b/apps/e2e/shots/02-notificaciones-y-pagos.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Recorrido visual 2 — «notificaciones y ventas». Genera las 18 capturas de
+ * `didacta-docs/docs/assets/notificaciones-y-pagos/`.
+ *
+ * Continúa donde termina `01-recorrido-visual.spec.ts`: da por hecho el tenant
+ * `academia-demo`, su administrador y el curso publicado. Por eso el fichero
+ * lleva el prefijo `02-` (Playwright ejecuta los ficheros en orden alfabético
+ * con `workers: 1`).
+ *
+ * El correo de prueba sale de verdad: la instancia apunta al Mailpit del stack
+ * y la captura de la bandeja es su interfaz web, no una simulación. Las claves
+ * de Stripe son inventadas a propósito — una de las capturas documenta
+ * justamente el error con el que Stripe rechaza una clave inválida.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+import { newShotContext, newShotPage } from './lib/browser';
+import { injectSession, mailpitClear, setProfileLocale, signin } from './lib/api';
+import { annotationLabel, DEMO, LOCALE, MAILPIT_URL } from './lib/config';
+import { t } from './lib/i18n';
+import { assertLocale, setSwitch, shot } from './lib/shot';
+
+const WALKTHROUGH = 'notificaciones-y-pagos';
+
+/** Abre `/admin/configuracion` en la pestaña pedida. No hay parámetro de URL. */
+async function openConfigTab(page: Page, tabKey: 'notifications' | 'pagos'): Promise<void> {
+  if (!page.url().includes('/admin/configuracion')) {
+    await page.goto('/admin/configuracion');
+  }
+  await expect(page.getByRole('heading', { name: t('adminMarca', 'config.title') })).toBeVisible({
+    timeout: 30_000,
+  });
+  await page.getByRole('tab', { name: t('adminMarca', `configTabs.${tabKey}`) }).click();
+}
+
+test('notificaciones y pagos · 18 capturas', async ({ browser }) => {
+  const adminCtx = await newShotContext(browser);
+  const admin = await newShotPage(adminCtx);
+
+  const session = await signin({
+    tenantSlug: DEMO.org.slug,
+    email: DEMO.admin.email,
+    password: DEMO.admin.password,
+  });
+  const bearer = session.tokens.accessToken;
+  await setProfileLocale(bearer);
+
+  await admin.goto('/signin');
+  await injectSession(admin, {
+    accessToken: bearer,
+    refreshToken: session.tokens.refreshToken,
+    user: { ...session.user, onboardingCompletedAt: new Date().toISOString() },
+  });
+
+  // ─────────────────────────────────────────────────────── 1 · SMTP ──
+  await openConfigTab(admin, 'notifications');
+  await expect(admin.getByTestId('smtp-banner-none')).toBeVisible({ timeout: 30_000 });
+  await assertLocale(admin, LOCALE);
+  await shot(admin, WALKTHROUGH, '01-smtp-vacio');
+
+  await admin.locator('#smtp-host').fill(DEMO.smtp.host);
+  await admin.locator('#smtp-port').fill(DEMO.smtp.port);
+  // Mailpit escucha sin cifrar: con TLS encendido (el valor por defecto) la
+  // conexión falla en el handshake. Es el detalle que la documentación subraya.
+  await setSwitch(admin.locator('#smtp-secure'), false);
+  await admin.locator('#smtp-username').fill(DEMO.smtp.username);
+  await admin.locator('#smtp-password').fill(DEMO.smtp.password);
+  await admin.locator('#smtp-from-email').fill(DEMO.smtp.fromEmail);
+  await admin.locator('#smtp-from-name').fill(DEMO.smtp.fromName);
+  await shot(admin, WALKTHROUGH, '02-smtp-form');
+
+  await admin.getByRole('button', { name: t('adminSso', 'smtp.saveButton') }).click();
+  await expect(admin.getByTestId('smtp-banner-unverified')).toBeVisible({ timeout: 30_000 });
+  await shot(admin, WALKTHROUGH, '03-smtp-guardado');
+
+  await mailpitClear();
+  await admin.getByRole('button', { name: t('adminSso', 'smtp.testButton') }).click();
+  await expect(admin.locator('#smtp-test-email')).toBeVisible({ timeout: 15_000 });
+  await shot(admin, WALKTHROUGH, '04-smtp-modal-prueba');
+
+  await admin.getByRole('button', { name: t('adminSso', 'smtp.sendButton'), exact: true }).click();
+  await expect(admin.getByTestId('smtp-banner-verified')).toBeVisible({ timeout: 60_000 });
+  await shot(admin, WALKTHROUGH, '05-smtp-verificado');
+
+  // Bandeja real de Mailpit. Su interfaz es solo inglesa (no la traduce
+  // Didacta); lo que sí cambia de idioma es el CONTENIDO del correo, que lo
+  // genera la plataforma en el idioma del destinatario.
+  const mail = await newShotPage(adminCtx);
+  await mail.goto(MAILPIT_URL);
+  await mail.getByText(DEMO.admin.email).first().click();
+  // Mailpit renderiza la vista HTML dentro de un iframe; esperar a él es la
+  // señal de que el mensaje ya está abierto y pintado.
+  await expect(mail.locator('iframe').first()).toBeVisible({ timeout: 30_000 });
+  await shot(mail, WALKTHROUGH, '06-mailpit-bandeja');
+  await mail.close();
+
+  // ─────────────────────────────────────────────────────── 2 · Pagos ──
+  await openConfigTab(admin, 'pagos');
+  await expect(admin.getByTestId('stripe-banner-none')).toBeVisible({ timeout: 30_000 });
+  await shot(admin, WALKTHROUGH, '07-pagos-vacio');
+
+  await admin.goto('/admin/membresia');
+  const stripeWarning = admin.getByText(
+    t('adminMonetizacion', 'membership.stripeWarning')
+      .replace(/<\/?link>/g, '')
+      .slice(0, 60),
+  );
+  await expect(stripeWarning).toBeVisible({ timeout: 30_000 });
+  await shot(admin, WALKTHROUGH, '08-membresia-aviso-stripe');
+
+  await admin.goto('/admin/billing/products');
+  await expect(admin.locator('#courseId')).toBeVisible({ timeout: 30_000 });
+  await admin.locator('#courseId').selectOption({ index: 1 });
+  await admin.locator('#stripePriceId').fill('price_0000000000000000000000');
+  await admin.getByRole('button', { name: t('adminPagos', 'billing.linkCta') }).click();
+  await expect(
+    admin.getByRole('link', { name: t('adminPagos', 'billing.stripeMissingCta') }),
+  ).toBeVisible({
+    timeout: 30_000,
+  });
+  await shot(admin, WALKTHROUGH, '09-billing-cta-sin-stripe');
+
+  await openConfigTab(admin, 'pagos');
+  await expect(admin.locator('#stripe-secret-key')).toBeVisible({ timeout: 30_000 });
+  await admin.locator('#stripe-secret-key').fill(DEMO.stripe.secretKey);
+  await admin.locator('#stripe-webhook-secret').fill(DEMO.stripe.webhookSecret);
+  await shot(admin, WALKTHROUGH, '10-pagos-form-relleno');
+
+  await admin.getByRole('button', { name: t('adminPagos', 'stripe.saveCta') }).click();
+  await expect(admin.getByTestId('stripe-banner-unverified')).toBeVisible({ timeout: 30_000 });
+  await shot(admin, WALKTHROUGH, '11-pagos-guardado-sin-verificar');
+
+  // Llamada REAL a la API de Stripe (`balance.retrieve`, solo lectura). Con una
+  // clave inventada responde con su propio mensaje de error: la señal de que la
+  // validación no es cosmética.
+  await admin.getByRole('button', { name: t('adminPagos', 'stripe.testCta') }).click();
+  const stripeToast = admin.getByTestId('stripe-toast');
+  await expect(stripeToast).toBeVisible({ timeout: 60_000 });
+  await expect(stripeToast).toContainText(/stripe|api key|invalid/i, { timeout: 60_000 });
+  await shot(admin, WALKTHROUGH, '12-pagos-probar-conexion-error', {
+    annotations: [{ target: stripeToast, label: annotationLabel('stripeError') }],
+  });
+
+  // ────────────────────────────────────────────────── 3 · Membresía ──
+  await admin.goto('/admin/grupos-acceso');
+  await expect(admin.locator('#ag-name')).toBeVisible({ timeout: 30_000 });
+  await admin.locator('#ag-name').fill(DEMO.accessGroup.name);
+  await admin.locator('#ag-kind').selectOption('ALL_COURSES');
+  const createGroup = admin.getByRole('button', { name: t('adminUsuarios', 'groups.create') });
+  await shot(admin, WALKTHROUGH, '13-grupo-acceso', {
+    annotations: [{ target: createGroup, label: t('adminUsuarios', 'groups.create') }],
+  });
+  await createGroup.click();
+  await expect(admin.getByText(DEMO.accessGroup.name).first()).toBeVisible({ timeout: 30_000 });
+
+  await admin.goto('/admin/membresia');
+  await expect(admin.locator('#plan-name')).toBeVisible({ timeout: 30_000 });
+  await admin.locator('#plan-name').fill(DEMO.plan.name);
+  await admin.locator('#plan-amount').fill(DEMO.plan.price);
+  await admin.locator('#plan-compare').fill(DEMO.plan.compareAtPrice);
+  await admin.locator('#plan-trial').fill(DEMO.plan.trialDays);
+  await setSwitch(admin.locator('#plan-featured'), true);
+  const createPlan = admin.getByRole('button', {
+    name: t('adminMonetizacion', 'membership.createPlan'),
+  });
+  await shot(admin, WALKTHROUGH, '14-membresia-plan-form', {
+    scrollTo: admin.locator('#plan-name'),
+    annotations: [{ target: createPlan, label: t('adminMonetizacion', 'membership.createPlan') }],
+  });
+
+  await createPlan.click();
+  await expect(admin.getByText(DEMO.plan.name).first()).toBeVisible({ timeout: 30_000 });
+  await shot(admin, WALKTHROUGH, '15-membresia-plan-creado', {
+    scrollTo: admin.getByText(DEMO.plan.name).first(),
+  });
+
+  // ───────────────────────────────────────── 4 · página pública /unete ──
+  // Recarga obligatoria: al crear el plan, la página vuelve a pedir la config
+  // y `applyConfig()` reescribe el estado del formulario. Si se teclea encima
+  // sin esperar, la respuesta llega a mitad y borra lo escrito — que es
+  // exactamente el fallo que dejaba la captura 16 con los campos vacíos.
+  await admin.reload();
+  const pageActive = admin.locator('#page-active');
+  await expect(pageActive).toBeVisible({ timeout: 30_000 });
+  await pageActive.scrollIntoViewIfNeeded();
+  await setSwitch(pageActive, true);
+  await admin.locator('#cfg-headline').fill(DEMO.unete.title);
+  await admin.locator('#cfg-sub').fill(DEMO.unete.subtitle);
+  await admin.locator('#cfg-group').selectOption({ label: DEMO.accessGroup.name });
+  await setSwitch(admin.locator('#cfg-courses'), true);
+  const saveConfig = admin.getByRole('button', {
+    name: t('adminMonetizacion', 'membership.saveConfig'),
+  });
+  await shot(admin, WALKTHROUGH, '16-unete-config', {
+    scrollTo: admin.locator('#cfg-headline'),
+    annotations: [{ target: saveConfig, label: t('adminMonetizacion', 'membership.saveConfig') }],
+  });
+
+  await saveConfig.click();
+  await expect(admin.getByText(t('adminMonetizacion', 'membership.badgeActive'))).toBeVisible({
+    timeout: 30_000,
+  });
+  await shot(admin, WALKTHROUGH, '17-unete-config-guardada', {
+    scrollTo: admin.locator('#cfg-headline'),
+  });
+
+  const publicCtx = await newShotContext(browser);
+  const publicPage = await newShotPage(publicCtx);
+  await publicPage.goto('/unete');
+  await expect(publicPage.getByText(DEMO.unete.title)).toBeVisible({ timeout: 30_000 });
+  await assertLocale(publicPage, LOCALE);
+  await shot(publicPage, WALKTHROUGH, '18-unete-publico');
+
+  await publicCtx.close();
+  await adminCtx.close();
+});

--- a/apps/e2e/shots/README.md
+++ b/apps/e2e/shots/README.md
@@ -1,0 +1,142 @@
+<!--
+Copyright (c) VA360 LABS S.L.
+SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+-->
+
+# Generador de capturas de la documentación
+
+Las 40 capturas de los dos recorridos visuales de [`didacta-docs`](https://github.com/va360labs/didacta-docs)
+se hacían **a mano**. Esto las genera solas, en español y en inglés, contra una
+instalación real. Si mañana cambia la interfaz, se vuelve a lanzar.
+
+| Recorrido                           | Capturas | Destino en `didacta-docs`                                   |
+| ----------------------------------- | -------- | ----------------------------------------------------------- |
+| `01-recorrido-visual.spec.ts`       | 22       | `docs/assets/recorrido-visual/` (es) · `.../en/` (en)       |
+| `02-notificaciones-y-pagos.spec.ts` | 18       | `docs/assets/notificaciones-y-pagos/` (es) · `.../en/` (en) |
+
+Los PNG **no se versionan en este repo**: caen en `apps/e2e/shots-output/`
+(ignorado) y de ahí se copian al repo de documentación.
+
+---
+
+## Qué tiene que estar levantado
+
+1. **Postgres** del stack (por defecto el contenedor `didacta-e2e-postgres` en
+   `127.0.0.1:5442`, imagen `pgvector/pgvector:pg16`).
+2. **API** compilada (`apps/api/dist/main.js`) — la arranca `reset-instance.sh`.
+3. **Web** compilada y sirviendo en `:3010`:
+
+   ```bash
+   (cd apps/web && unset PORT && node ../../node_modules/next/dist/bin/next start -p 3010)
+   ```
+
+   ⚠️ `API_INTERNAL_URL` se hornea en el `next build`: si mueves la API de
+   puerto hay que **reconstruir** la web, no basta con reexportar la variable.
+
+4. **Mailpit** — lo crea `reset-instance.sh` (`didacta-shots-mailpit`,
+   SMTP `:1027`, web `:8027`). La captura de la bandeja de entrada es su
+   interfaz real: el correo de prueba se envía de verdad.
+5. **Salida a internet**: una de las capturas llama a la API real de Stripe
+   para retratar el error con el que rechaza una clave inválida.
+
+## Cómo se lanza
+
+```bash
+source apps/e2e/shots/env.example.sh     # o tu propio env
+
+# 1. Instancia virgen (cero tenants) + API reiniciada + Mailpit vacío.
+#    Imprime el token de un solo uso del asistente de configuración.
+bash apps/e2e/shots/reset-instance.sh
+export SHOTS_SETUP_TOKEN='…'             # el que acaba de imprimir
+
+# 2. Tanda española (40 capturas)
+cd apps/e2e
+SHOTS_LOCALE=es-ES node ../../node_modules/@playwright/test/cli.js \
+  test --config playwright.shots.config.ts
+```
+
+Para la tanda inglesa hay que **volver a resetear**: el asistente de
+configuración solo se completa una vez por instancia.
+
+```bash
+cd ../..
+bash apps/e2e/shots/reset-instance.sh
+export SHOTS_SETUP_TOKEN='…'
+cd apps/e2e
+SHOTS_LOCALE=en-US node ../../node_modules/@playwright/test/cli.js \
+  test --config playwright.shots.config.ts
+```
+
+Cada tanda tarda **~35 s**. Al terminar:
+
+```
+apps/e2e/shots-output/
+├── recorrido-visual/            22 PNG en español
+│   └── en/                      22 PNG en inglés
+└── notificaciones-y-pagos/      18 PNG en español
+    └── en/                      18 PNG en inglés
+```
+
+Copiar a `didacta-docs/docs/assets/` respetando la misma estructura.
+
+## Variables
+
+Todas tienen default razonable; ver `env.example.sh`.
+
+| Variable                                          | Para qué                                                      |
+| ------------------------------------------------- | ------------------------------------------------------------- |
+| `SHOTS_LOCALE`                                    | `es-ES` (default) o `en-US`                                   |
+| `SHOTS_OUT_DIR`                                   | Dónde caen los PNG (default `apps/e2e/shots-output/`)         |
+| `SHOTS_BASE_URL`                                  | Web (default `http://localhost:3010`)                         |
+| `SHOTS_API_URL`                                   | API; por defecto a través del rewrite de Next                 |
+| `SHOTS_SETUP_TOKEN`                               | Token de un solo uso de `POST /setup/init`                    |
+| `SHOTS_MAILPIT_URL` / `_SMTP_HOST` / `_SMTP_PORT` | Mailpit                                                       |
+| `SHOTS_PG_CONTAINER` / `_PG_USER` / `_PG_DB`      | Para aplicar `seed.sql` tras crear el tenant                  |
+| `WEB_PUBLIC_URL`                                  | **De la API.** El enlace del email de invitación sale de aquí |
+
+## Decisiones que conviene conocer antes de tocar esto
+
+**Viewport fijo 1440×900, `deviceScaleFactor: 1`.** Es el tamaño de las 40
+capturas originales y lo que hace que la española y la inglesa se puedan
+comparar píxel a píxel. `browser.newContext()` **no** hereda el bloque `use`
+de la config: el viewport se pasa a mano en `lib/browser.ts`.
+
+**El idioma se resuelve por el PERFIL, no solo por la cookie.** `LocaleSync`
+(`apps/web/src/components/locale-sync.tsx`) lee `GET /me/profile` y, si el
+locale del perfil no coincide con la cookie `didacta_locale`, **reescribe la
+cookie con el del perfil**. Poner solo la cookie a `en-US` hace que la página
+parpadee y vuelva a español. Por eso cada recorrido llama a
+`setProfileLocale()` nada más existir la sesión, y `assertLocale()` revienta si
+`<html lang>` no es el esperado — así una tanda inglesa nunca sale en español
+sin que nadie se entere.
+
+**Selectores por catálogo, no por texto literal.** `lib/i18n.ts` lee los mismos
+JSON que consume la web (`apps/web/src/i18n/messages/<es|en>/*.json`), así que
+el mismo recorrido funciona en los dos idiomas y una clave que falte en `en`
+falla con un error explícito en vez de con un timeout.
+
+**Nada de `networkidle`.** Con sesión iniciada la app abre dos canales SSE
+(`/messaging/stream` y `/me/notifications/stream`) y la red no queda ociosa
+nunca: cada captura se comía 30 s de timeout. `settle()` espera por el DOM
+(sin esqueletos, imágenes decodificadas, sin mutaciones durante 400 ms).
+
+**Datos neutros, regla whitelabel.** `lib/config.ts` es la única fuente de la
+organización, las cuentas y el contenido que aparecen en pantalla:
+`Academia Demo`, `Admin Demo`, `alumna@example.com`. Las páginas de la
+documentación citan esos mismos nombres — si cambias uno, cambia también el
+texto que lo menciona.
+
+**Mismos datos en los dos idiomas.** Lo que se traduce es la interfaz, no el
+contenido que teclea el operador. El curso se llama igual en la captura
+española y en la inglesa: así la comparación entre ambas aísla el idioma de la
+UI, y las páginas `.en.md` —que nombran `Academia Demo` / `Admin Demo` /
+`Alumna Demo` en inglés— siguen describiendo lo que se ve.
+
+**El SMTP se pone y se quita.** El enlace de «define tu contraseña» viaja por
+email, así que el primer recorrido configura el SMTP por API antes de invitar a
+la alumna y lo **borra** justo después: el segundo recorrido tiene que empezar
+con la pestaña Notificaciones realmente vacía.
+
+**Las claves de Stripe son inventadas.** No hace falta cuenta: la captura 12
+del segundo recorrido documenta precisamente el error con el que Stripe rechaza
+una clave inválida, y para eso la llamada tiene que ser real.

--- a/apps/e2e/shots/env.example.sh
+++ b/apps/e2e/shots/env.example.sh
@@ -1,0 +1,49 @@
+# Copyright (c) VA360 LABS S.L.
+# SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+#
+# Entorno de ejemplo para el generador de capturas. Sourcéalo (o copia y ajusta)
+# antes de `reset-instance.sh` y antes de lanzar Playwright.
+#
+#   source apps/e2e/shots/env.example.sh
+#
+# Es el mismo stack del job `e2e` de .github/workflows/e2e.yml, con la API en
+# :4000 y la web en :3010. Ver shots/README.md.
+
+# ── API ──────────────────────────────────────────────────────────────────────
+export DATABASE_URL="postgresql://didacta:didacta@localhost:5442/didacta?schema=public"
+# Secretos SINTÉTICOS, nunca credenciales. Se componen a partir de una raíz con
+# la marca "de-prueba" que exige la convención del repo (ver .gitleaks.toml):
+# así ninguna línea de este fichero contiene un literal con pinta de secreto.
+DUMMY_SUFFIX='must-be-at-least-32-chars-de-prueba'
+export JWT_SECRET="jwt-$DUMMY_SUFFIX"
+export JWT_REFRESH_SECRET="refresh-$DUMMY_SUFFIX"
+export AUTH_SECRET="auth-$DUMMY_SUFFIX"
+export AUTH_URL="http://localhost:4000"
+export TENANT_SETTINGS_ENC_KEY="0000000000000000000000000000000000000000000000000000000000000000"
+export NODE_ENV="production"
+export AUTH_SIGNUP_ENABLED="true"
+export PORT="4000"
+export API_PORT="4000"
+export API_INTERNAL_URL="http://localhost:4000"
+# El enlace de "define tu contraseña" que sale por email tiene que apuntar a la
+# web: de ahí sale la captura 15-alumna-definir-password. Sin esta variable,
+# `resolveWebBaseUrl` cae al dominio primario del tenant (`localhost`, SIN
+# puerto) y el enlace del email no abre nada.
+export WEB_PUBLIC_URL="http://localhost:3010"
+# Sin REDIS_URL a propósito: enciende el rate-limit distribuido (30 req/min) y
+# estrangula el recorrido completo.
+
+# ── Generador de capturas ────────────────────────────────────────────────────
+export SHOTS_BASE_URL="http://localhost:3010"
+export SHOTS_API_URL="http://localhost:3010"
+export SHOTS_PG_CONTAINER="didacta-e2e-postgres"
+export SHOTS_PG_USER="didacta"
+export SHOTS_PG_DB="didacta"
+export SHOTS_MAILPIT_URL="http://localhost:8027"
+export SHOTS_MAILPIT_SMTP_HOST="localhost"
+export SHOTS_MAILPIT_SMTP_PORT="1027"
+export SHOTS_MAILPIT_HTTP_PORT="8027"
+# Idioma de la tanda: es-ES | en-US. Se sobreescribe por línea de comandos.
+export SHOTS_LOCALE="es-ES"
+# Dónde caen los PNG. Por defecto apps/e2e/shots-output/ (fuera de git).
+# export SHOTS_OUT_DIR="/c/Users/…/didacta-docs/docs/assets"

--- a/apps/e2e/shots/lib/api.ts
+++ b/apps/e2e/shots/lib/api.ts
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Lo que no se ve en la captura, se hace por API.
+ *
+ * Cada pantallazo retrata UN estado; llegar hasta él pinchando por la interfaz
+ * multiplicaría los puntos de fallo sin aportar nada a la imagen. Aquí viven
+ * las llamadas de preparación (activar módulos, cambiar el idioma del perfil,
+ * dejar el SMTP puesto o quitado) y la lectura del buzón de Mailpit.
+ */
+
+import { execFileSync } from 'node:child_process';
+import type { BrowserContext, Page } from '@playwright/test';
+import { API_URL, LOCALE, MAILPIT_URL, PG_CONTAINER, PG_DB, PG_USER } from './config';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string | null;
+  tenantId: string;
+  tenantSlug: string;
+  roles: string[];
+  mfaEnabled: boolean;
+}
+
+export interface AuthResponse {
+  tokens: { accessToken: string; refreshToken: string; expiresIn: number };
+  mfaRequired: boolean;
+  user: AuthUser;
+}
+
+export async function api<T>(
+  path: string,
+  init: { method?: string; body?: unknown; bearer?: string } = {},
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (init.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (init.bearer) headers['Authorization'] = `Bearer ${init.bearer}`;
+
+  const res = await fetch(`${API_URL}${path}`, {
+    method: init.method ?? 'GET',
+    headers,
+    body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+  const text = await res.text();
+  const body = text ? (JSON.parse(text) as unknown) : null;
+  if (!res.ok) {
+    const message =
+      body && typeof body === 'object' && 'message' in body
+        ? String((body as { message: unknown }).message)
+        : res.statusText;
+    throw new Error(`[shots] API ${init.method ?? 'GET'} ${path} → ${res.status}: ${message}`);
+  }
+  return body as T;
+}
+
+export async function signin(args: {
+  tenantSlug: string;
+  email: string;
+  password: string;
+}): Promise<AuthResponse> {
+  return api<AuthResponse>('/api/v1/auth/signin', { method: 'POST', body: args });
+}
+
+/**
+ * Fija el idioma del PERFIL, no solo la cookie.
+ *
+ * `LocaleSync` compara `GET /me/profile` con la cookie `didacta_locale` y, si
+ * difieren, reescribe la cookie con lo que dice el perfil. Poner solo la
+ * cookie a `en-US` hace que la página parpadee y vuelva a español; hay que
+ * cambiar `user.locale`. Es el paso que se lleva por delante una tanda entera
+ * de capturas si se olvida.
+ */
+export async function setProfileLocale(bearer: string, locale = LOCALE): Promise<void> {
+  await api('/api/v1/me/profile', { method: 'PATCH', body: { locale }, bearer });
+}
+
+/** Cookie de idioma para que el PRIMER render del servidor ya salga bien. */
+export async function setLocaleCookie(context: BrowserContext, url: string): Promise<void> {
+  await context.addCookies([{ name: 'didacta_locale', value: LOCALE, url }]);
+}
+
+/**
+ * Mete tokens y sesión en el web storage del origen ya cargado, igual que
+ * `helpers/auth.ts` de los specs. `onboardingCompletedAt` evita que el gate de
+ * `(app)/layout.tsx` desvíe cualquier ruta autenticada al wizard.
+ */
+export async function injectSession(
+  page: Page,
+  args: {
+    accessToken: string;
+    refreshToken?: string;
+    user: AuthUser & { onboardingCompletedAt?: string | null };
+  },
+): Promise<void> {
+  await page.evaluate((data) => {
+    sessionStorage.setItem('didacta.access_token', data.accessToken);
+    if (data.refreshToken) localStorage.setItem('didacta.refresh_token', data.refreshToken);
+    sessionStorage.setItem(
+      'didacta.session',
+      JSON.stringify({ user: data.user, mfaRequired: false }),
+    );
+  }, args);
+}
+
+/** Activa un módulo para el tenant (`POST /admin/modules/:name/enable`). */
+export async function enableModule(bearer: string, name: string): Promise<void> {
+  await api(`/api/v1/admin/modules/${encodeURIComponent(name)}/enable`, {
+    method: 'POST',
+    body: {},
+    bearer,
+  }).catch((err: unknown) => {
+    // Ya activo → el backend responde 409/400. Para el generador es un no-op.
+    const message = err instanceof Error ? err.message : String(err);
+    if (/40[09]/.test(message)) return;
+    throw err;
+  });
+}
+
+export interface SmtpPayload {
+  host: string;
+  port: number;
+  secure: boolean;
+  username: string;
+  password: string;
+  fromEmail: string;
+  fromName?: string;
+}
+
+/** Deja el SMTP del tenant puesto sin pasar por el formulario. */
+export async function putTenantSmtp(bearer: string, payload: SmtpPayload): Promise<void> {
+  await api('/api/v1/admin/tenant-settings/smtp', { method: 'PUT', body: payload, bearer });
+}
+
+/**
+ * Borra la config SMTP del tenant (las dos rows: `smtp` y `smtp_meta`), para
+ * que el recorrido de ventas arranque con la pestaña Notificaciones realmente
+ * vacía.
+ */
+export async function deleteTenantSmtp(bearer: string): Promise<void> {
+  for (const key of ['smtp', 'smtp_meta']) {
+    await api(`/api/v1/tenant-settings/notifications/${key}`, { method: 'DELETE', bearer }).catch(
+      () => undefined,
+    );
+  }
+}
+
+interface MailpitSummary {
+  messages: Array<{ ID: string; Subject: string; To: Array<{ Address: string }> }>;
+}
+
+/** Vacía el buzón de Mailpit para que la captura de la bandeja tenga un solo correo. */
+export async function mailpitClear(): Promise<void> {
+  await fetch(`${MAILPIT_URL}/api/v1/messages`, { method: 'DELETE' });
+}
+
+/** Devuelve los mensajes del buzón, del más reciente al más antiguo. */
+export async function mailpitList(): Promise<MailpitSummary['messages']> {
+  const res = await fetch(`${MAILPIT_URL}/api/v1/messages?limit=50`);
+  if (!res.ok) throw new Error(`[shots] Mailpit no responde (${res.status}) en ${MAILPIT_URL}`);
+  const body = (await res.json()) as MailpitSummary;
+  return body.messages ?? [];
+}
+
+/**
+ * Espera a que llegue un correo para `to` y devuelve su cuerpo de texto.
+ * Sondea el buzón porque el envío es asíncrono respecto de la petición HTTP
+ * que lo dispara — no hay ningún estado en la UI al que engancharse.
+ */
+export async function mailpitWaitFor(to: string, timeoutMs = 30_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const messages = await mailpitList().catch(() => []);
+    const found = messages.find((m) => m.To?.some((addr) => addr.Address === to));
+    if (found) {
+      const res = await fetch(`${MAILPIT_URL}/api/v1/message/${found.ID}`);
+      const body = (await res.json()) as { Text?: string; HTML?: string };
+      return `${body.Text ?? ''}\n${body.HTML ?? ''}`;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`[shots] No llegó ningún correo para ${to} en ${timeoutMs} ms`);
+}
+
+/** Saca el `?token=` de un enlace `/reset-password` dentro del cuerpo del email. */
+export function extractResetToken(mailBody: string): string {
+  const match = mailBody.match(/reset-password\?token=([A-Za-z0-9_%-]+)/);
+  if (!match?.[1]) {
+    throw new Error('[shots] El email no contiene ningún enlace /reset-password?token=');
+  }
+  return decodeURIComponent(match[1]);
+}
+
+/**
+ * Aplica `packages/database/prisma/seed.sql` — los cuatro espacios de sistema
+ * de mod.community para cada tenant existente. Es literalmente lo que hace
+ * `infra/docker/entrypoint.sh` en cada arranque de la imagen, y hay que
+ * repetirlo DESPUÉS de que el asistente cree el tenant (antes no hay a quién
+ * asignárselos). Si `SHOTS_PG_CONTAINER` no está seteado, se salta.
+ */
+export function seedSystemSpaces(repoRoot: string): void {
+  if (!PG_CONTAINER) return;
+  const sql = require('node:fs').readFileSync(
+    require('node:path').join(repoRoot, 'packages', 'database', 'prisma', 'seed.sql'),
+    'utf8',
+  ) as string;
+  execFileSync(
+    'docker',
+    ['exec', '-i', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DB, '-v', 'ON_ERROR_STOP=1'],
+    { input: sql, stdio: ['pipe', 'ignore', 'inherit'] },
+  );
+}

--- a/apps/e2e/shots/lib/browser.ts
+++ b/apps/e2e/shots/lib/browser.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Contextos de navegador para las capturas.
+ *
+ * `browser.newContext()` NO hereda el bloque `use` de la config, así que el
+ * viewport se pasa aquí explícitamente: si se olvida, la tanda inglesa sale a
+ * 1280x720 y deja de ser comparable con la española.
+ */
+
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+import { BASE_URL, LOCALE } from './config';
+import { freeze } from './shot';
+
+export const VIEWPORT = { width: 1440, height: 900 } as const;
+
+/**
+ * Contexto nuevo con el viewport fijo y la cookie de idioma ya puesta, para que
+ * el PRIMER render del servidor salga en el idioma bueno y no haya un flash de
+ * español en la captura.
+ */
+export async function newShotContext(browser: Browser): Promise<BrowserContext> {
+  const context = await browser.newContext({
+    viewport: { ...VIEWPORT },
+    deviceScaleFactor: 1,
+    colorScheme: 'light',
+    locale: LOCALE,
+    timezoneId: 'Europe/Madrid',
+  });
+  await context.addCookies([{ name: 'didacta_locale', value: LOCALE, url: BASE_URL }]);
+  // Techo por acción: sin esto un selector que no resuelve se come el timeout
+  // del recorrido entero y el error final no dice dónde se atascó.
+  context.setDefaultTimeout(30_000);
+  return context;
+}
+
+/** Página del contexto con las animaciones ya congeladas en cada navegación. */
+export async function newShotPage(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  page.on('load', () => {
+    void freeze(page);
+  });
+  return page;
+}
+
+/**
+ * Lee el access token que la app guardó al iniciar sesión. `authStorage` elige
+ * `localStorage` o `sessionStorage` según el "mantener la sesión abierta", así
+ * que hay que mirar en los dos.
+ */
+export async function readAccessToken(page: Page): Promise<string> {
+  const token = await page.evaluate(
+    () =>
+      localStorage.getItem('didacta.access_token') ??
+      sessionStorage.getItem('didacta.access_token'),
+  );
+  if (!token) throw new Error('[shots] La página no tiene sesión iniciada (sin access token)');
+  return token;
+}

--- a/apps/e2e/shots/lib/config.ts
+++ b/apps/e2e/shots/lib/config.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Configuración y datos de la instancia de demostración que se retrata en la
+ * documentación.
+ *
+ * REGLA WHITELABEL (CLAUDE.md §1): aquí no puede entrar ni un dato de un
+ * cliente real. Dominios reservados (`example.com`), nombres genéricos
+ * (`Academia Demo`, `Admin Demo`, `Alumna Demo`) y credenciales de juguete.
+ * Los textos de `didacta-docs` citan estos mismos nombres — si cambias uno,
+ * cambia también la página que lo menciona.
+ *
+ * Los datos son IDÉNTICOS en las dos tandas de idioma a propósito: lo que se
+ * traduce es la interfaz, no el contenido que teclea el operador. Así la
+ * captura española y la inglesa se diferencian solo en el chrome de la app y
+ * se pueden comparar píxel a píxel; y las páginas `.en.md` de la doc, que
+ * nombran `Academia Demo` / `Admin Demo` / `Alumna Demo` en inglés, siguen
+ * describiendo lo que se ve.
+ */
+
+import path from 'node:path';
+
+export type ShotLocale = 'es-ES' | 'en-US';
+
+function resolveLocale(): ShotLocale {
+  const raw = (process.env.SHOTS_LOCALE ?? 'es-ES').toLowerCase();
+  if (raw.startsWith('en')) return 'en-US';
+  return 'es-ES';
+}
+
+export const LOCALE: ShotLocale = resolveLocale();
+
+/** `es` | `en` — el catálogo de mensajes que corresponde al locale activo. */
+export const CATALOG: 'es' | 'en' = LOCALE.startsWith('en') ? 'en' : 'es';
+
+/** Web (Next). Todas las capturas salen de aquí. */
+export const BASE_URL =
+  process.env.SHOTS_BASE_URL ?? process.env.E2E_BASE_URL ?? 'http://localhost:3010';
+
+/**
+ * API. Por defecto se habla con ella a través del rewrite de Next (mismo
+ * origen que el navegador), igual que hace el propio frontend.
+ */
+export const API_URL = process.env.SHOTS_API_URL ?? BASE_URL;
+
+/** UI web de Mailpit — de ahí sale la captura real de la bandeja de entrada. */
+export const MAILPIT_URL = process.env.SHOTS_MAILPIT_URL ?? 'http://localhost:8027';
+
+/** Host y puerto SMTP de ese mismo Mailpit, vistos desde la API. */
+export const MAILPIT_SMTP_HOST = process.env.SHOTS_MAILPIT_SMTP_HOST ?? 'localhost';
+export const MAILPIT_SMTP_PORT = process.env.SHOTS_MAILPIT_SMTP_PORT ?? '1027';
+
+/**
+ * Contenedor de Postgres del stack. Solo se usa para aplicar `seed.sql` (los
+ * cuatro espacios de sistema de mod.community) sobre el tenant que acaba de
+ * crear el asistente, que es exactamente lo que hace `infra/docker/entrypoint.sh`
+ * en cada arranque de la imagen. Si no está seteado, ese paso se salta.
+ */
+export const PG_CONTAINER = process.env.SHOTS_PG_CONTAINER ?? '';
+export const PG_USER = process.env.SHOTS_PG_USER ?? 'didacta';
+export const PG_DB = process.env.SHOTS_PG_DB ?? 'didacta';
+
+/**
+ * Token de un solo uso de `POST /setup/init`. Lo imprime la API en el log al
+ * arrancar contra una instancia sin tenants (`SetupTokenService`); el script
+ * `reset-instance.sh` lo extrae y lo exporta.
+ */
+export const SETUP_TOKEN = process.env.SHOTS_SETUP_TOKEN ?? '';
+
+/** Raíz de salida. Un subdirectorio por recorrido; el idioma lo mete `shot()`. */
+export const OUT_DIR =
+  process.env.SHOTS_OUT_DIR ?? path.resolve(__dirname, '..', '..', 'shots-output');
+
+/** Organización, cuentas y contenido que se ve en las capturas. */
+export const DEMO = {
+  org: {
+    name: 'Academia Demo',
+    slug: 'academia-demo',
+    /** Sin puerto: `HOSTNAME_RE` del backend no acepta `:`. */
+    hostname: 'localhost',
+  },
+  admin: {
+    name: 'Admin Demo',
+    email: 'admin@example.com',
+    password: 'DidactaDemo2026!',
+  },
+  alumna: {
+    name: 'Alumna Demo',
+    email: 'alumna@example.com',
+    password: 'AlumnaDemo2026!',
+  },
+  course: {
+    title: 'Introducción a la fotografía digital',
+    slug: 'introduccion-a-la-fotografia-digital',
+    category: 'Fotografía',
+    description:
+      'Aprende los fundamentos de la fotografía digital: composición, luz natural y edición básica para empezar a tomar mejores fotos con lo que ya tienes.',
+    section: 'Primeros pasos',
+    lesson: 'Bienvenida al curso',
+    lessonText:
+      'Bienvenida o bienvenido. En este curso vas a aprender los fundamentos de la fotografía digital paso a paso: composición, luz y un flujo de edición sencillo. No necesitas equipo profesional para empezar, solo ganas de practicar.',
+  },
+  smtp: {
+    host: MAILPIT_SMTP_HOST,
+    port: MAILPIT_SMTP_PORT,
+    username: 'notificaciones',
+    password: 'mailpit-no-pide-password',
+    fromEmail: 'notificaciones@example.com',
+    fromName: 'Academia Demo',
+  },
+  /**
+   * Credenciales de Stripe INVENTADAS. Una de las capturas documenta
+   * precisamente el error con el que Stripe rechaza una clave inválida, así
+   * que el valor tiene que tener forma de clave pero no ser una.
+   */
+  stripe: {
+    secretKey: 'sk_test_00000000000000000000000000000000000000000000000000',
+    webhookSecret: 'whsec_0000000000000000000000000000000000000000000000000000',
+  },
+  accessGroup: {
+    name: 'Acceso completo',
+  },
+  plan: {
+    name: 'Suscripción mensual',
+    price: '19',
+    compareAtPrice: '29',
+    trialDays: '7',
+  },
+  unete: {
+    title: 'Fotografía digital, sin límites',
+    subtitle: 'Todos los cursos, actualizaciones y comunidad por una cuota mensual.',
+  },
+} as const;
+
+/**
+ * Etiquetas de las anotaciones rojas que NO son copy de la aplicación.
+ *
+ * Casi todas las anotaciones reutilizan el texto del propio botón (y por tanto
+ * se traducen solas leyendo el catálogo de la app). Estas señalan un dato en
+ * pantalla, no un control, así que el texto se escribe aquí.
+ */
+const ANNOTATIONS = {
+  es: {
+    invitationCode: 'Código de invitación',
+    certificateNumber: 'Número de certificado',
+    stripeError: 'Stripe rechaza la clave',
+  },
+  en: {
+    invitationCode: 'Invitation code',
+    certificateNumber: 'Certificate number',
+    stripeError: 'Stripe rejects the key',
+  },
+} as const;
+
+export function annotationLabel(key: keyof (typeof ANNOTATIONS)['es']): string {
+  return ANNOTATIONS[CATALOG][key];
+}

--- a/apps/e2e/shots/lib/i18n.ts
+++ b/apps/e2e/shots/lib/i18n.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Resolución de copy por idioma para los selectores de las capturas.
+ *
+ * Un selector `getByRole('button', { name: 'Publicar' })` solo funciona en
+ * español. En vez de duplicar los recorridos, se leen los MISMOS catálogos que
+ * consume la app (`apps/web/src/i18n/messages/<es|en>/<namespace>.json`) y se
+ * pide la clave: la tanda inglesa busca por el texto inglés de verdad, sin
+ * listas paralelas que se desincronicen.
+ *
+ * Efecto secundario útil: si una clave existe en `es` y falta en `en`, esto
+ * revienta con un error explícito — que es justo lo que quieres saber antes de
+ * publicar una captura inglesa a medio traducir.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { CATALOG } from './config';
+
+const MESSAGES_DIR = path.resolve(__dirname, '..', '..', '..', 'web', 'src', 'i18n', 'messages');
+
+const cache = new Map<string, Record<string, unknown>>();
+
+function loadNamespace(namespace: string): Record<string, unknown> {
+  const cacheKey = `${CATALOG}/${namespace}`;
+  const hit = cache.get(cacheKey);
+  if (hit) return hit;
+
+  const file = path.join(MESSAGES_DIR, CATALOG, `${namespace}.json`);
+  if (!fs.existsSync(file)) {
+    throw new Error(`[shots] No existe el catálogo ${CATALOG}/${namespace}.json (${file})`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>;
+  cache.set(cacheKey, parsed);
+  return parsed;
+}
+
+/**
+ * Devuelve el texto de `namespace` + `key` (con puntos) en el idioma activo.
+ *
+ * ```ts
+ * t('auth', 'setup.welcomeCta') // es → "Empezar configuración" · en → "Start setup"
+ * ```
+ */
+export function t(namespace: string, key: string, values?: Record<string, string>): string {
+  let node: unknown = loadNamespace(namespace);
+  for (const segment of key.split('.')) {
+    if (node === null || typeof node !== 'object') {
+      throw new Error(`[shots] Clave i18n inexistente: ${namespace}.${key} (${CATALOG})`);
+    }
+    node = (node as Record<string, unknown>)[segment];
+  }
+  if (typeof node !== 'string') {
+    throw new Error(
+      `[shots] Clave i18n inexistente o no textual: ${namespace}.${key} (${CATALOG})`,
+    );
+  }
+  if (!values) return node;
+  // Interpolación mínima estilo ICU simple: `{nombre}`.
+  return node.replace(/\{(\w+)\}/g, (match, name: string) => values[name] ?? match);
+}
+
+/**
+ * Igual que `t()` pero escapando el resultado para usarlo dentro de un regex
+ * (`getByLabel(new RegExp(...))`), que es lo que hace falta cuando el label
+ * lleva un asterisco de obligatorio o paréntesis.
+ */
+export function tRe(namespace: string, key: string): RegExp {
+  const literal = t(namespace, key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(literal, 'i');
+}

--- a/apps/e2e/shots/lib/shot.ts
+++ b/apps/e2e/shots/lib/shot.ts
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Toma de la captura: anotación, estabilización y escritura del PNG.
+ *
+ * Determinismo: nada de `waitForTimeout`. Antes de disparar se espera a que no
+ * queden esqueletos de carga, a que las imágenes hayan decodificado y a que el
+ * DOM deje de mutar. Lo único que se congela por tiempo son las animaciones
+ * CSS, y se hace desactivándolas, no esperándolas.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Locator, Page } from '@playwright/test';
+import { CATALOG, OUT_DIR } from './config';
+
+/** `recorrido-visual` | `notificaciones-y-pagos`. */
+export type Walkthrough = 'recorrido-visual' | 'notificaciones-y-pagos';
+
+/**
+ * Directorio de salida del recorrido en el idioma activo.
+ *
+ * El español conserva la ruta histórica (`<out>/recorrido-visual/`) porque sus
+ * PNGs sustituyen a los actuales de `didacta-docs` uno a uno; el inglés cuelga
+ * de un subdirectorio `en/`, que es la convención que se usa en la doc.
+ */
+export function outputDir(walkthrough: Walkthrough): string {
+  return CATALOG === 'en' ? path.join(OUT_DIR, walkthrough, 'en') : path.join(OUT_DIR, walkthrough);
+}
+
+const CSS_FREEZE = `
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+  /* El cursor de texto parpadeante hace que dos capturas del mismo estado
+     salgan distintas. */
+`;
+
+/** Inyecta el congelador de animaciones. Idempotente por página. */
+export async function freeze(page: Page): Promise<void> {
+  await page.addStyleTag({ content: CSS_FREEZE }).catch(() => {
+    /* la página puede estar navegando; el siguiente intento lo pilla */
+  });
+}
+
+/**
+ * Espera a que la pantalla esté quieta.
+ *
+ * ⚠️ Nada de `waitForLoadState('networkidle')`: la app abre DOS canales SSE
+ * (`/messaging/stream` y `/me/notifications/stream`) en cuanto hay sesión, así
+ * que la red NUNCA queda ociosa y cada captura se comía los 30 s de timeout.
+ * El criterio bueno es el DOM: sin esqueletos de carga, con las imágenes ya
+ * decodificadas y sin mutaciones durante un rato.
+ */
+export async function settle(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await page
+    .waitForFunction(
+      () => {
+        const skeletons = document.querySelectorAll('[data-loading="true"], .animate-pulse');
+        if (skeletons.length > 0) return false;
+        return Array.from(document.images).every((img) => img.complete);
+      },
+      undefined,
+      { timeout: 10_000 },
+    )
+    .catch(() => {
+      /* si algo sigue cargando, mejor una captura honesta que un fallo del
+         generador: la revisión humana lo detecta */
+    });
+  await page
+    .evaluate(
+      ({ quietMs, capMs }) =>
+        new Promise<void>((resolve) => {
+          let timer: ReturnType<typeof setTimeout>;
+          const observer = new MutationObserver(() => {
+            clearTimeout(timer);
+            timer = setTimeout(done, quietMs);
+          });
+          const done = () => {
+            observer.disconnect();
+            clearTimeout(cap);
+            resolve();
+          };
+          const cap = setTimeout(done, capMs);
+          timer = setTimeout(done, quietMs);
+          observer.observe(document.body, { subtree: true, childList: true, characterData: true });
+        }),
+      { quietMs: 400, capMs: 8_000 },
+    )
+    .catch(() => undefined);
+  await freeze(page);
+  await page.evaluate(() => document.fonts.ready).catch(() => undefined);
+}
+
+export interface AnnotationSpec {
+  /** Elemento a resaltar. */
+  target: Locator;
+  /** Texto de la etiqueta roja. Ya viene en el idioma activo. */
+  label: string;
+}
+
+/**
+ * Dibuja el marco rojo con etiqueta sobre uno o varios elementos, replicando la
+ * anotación a mano de las capturas originales. Se pinta como overlay dentro de
+ * la propia página, así que el PNG sale ya anotado y no hace falta post-proceso.
+ */
+export async function annotate(page: Page, specs: AnnotationSpec[]): Promise<void> {
+  const boxes: Array<{ x: number; y: number; width: number; height: number; label: string }> = [];
+  for (const spec of specs) {
+    const box = await spec.target.first().boundingBox();
+    if (!box) {
+      throw new Error(`[shots] No se pudo medir el elemento a anotar ("${spec.label}")`);
+    }
+    boxes.push({ ...box, label: spec.label });
+  }
+
+  await page.evaluate((items) => {
+    const previous = document.getElementById('didacta-shots-annotations');
+    if (previous) previous.remove();
+
+    const layer = document.createElement('div');
+    layer.id = 'didacta-shots-annotations';
+    layer.style.cssText =
+      'position:fixed;inset:0;pointer-events:none;z-index:2147483647;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;';
+
+    for (const item of items) {
+      const frame = document.createElement('div');
+      frame.style.cssText = [
+        'position:absolute',
+        `left:${item.x - 5}px`,
+        `top:${item.y - 5}px`,
+        `width:${item.width + 10}px`,
+        `height:${item.height + 10}px`,
+        'border:3px solid #F5325B',
+        'border-radius:12px',
+        'box-shadow:0 0 0 3px #fff, 0 0 14px 5px rgba(245,50,91,.35)',
+        'box-sizing:border-box',
+      ].join(';');
+      layer.appendChild(frame);
+
+      const tag = document.createElement('span');
+      tag.textContent = item.label;
+      tag.style.cssText = [
+        'position:absolute',
+        `left:${item.x - 5}px`,
+        `top:${item.y - 24}px`,
+        'background:#F5325B',
+        'color:#fff',
+        'font-size:10px',
+        'font-weight:700',
+        'line-height:1',
+        'padding:4px 7px',
+        'border-radius:5px 5px 5px 0',
+        'white-space:nowrap',
+      ].join(';');
+      layer.appendChild(tag);
+    }
+
+    document.body.appendChild(layer);
+  }, boxes);
+}
+
+/**
+ * Escribe un `<input type="range">` como lo haría un humano moviendo el
+ * control. `locator.fill()` no vale con los range, y React ignora un
+ * `element.value = …` a pelo: hay que llamar al setter nativo y disparar el
+ * evento `input` para que el estado del componente se entere.
+ */
+export async function setRange(page: Page, selector: string, value: number): Promise<void> {
+  await page.evaluate(
+    ({ selector: sel, value: v }) => {
+      const element = document.querySelector<HTMLInputElement>(sel);
+      if (!element) throw new Error(`No existe ${sel}`);
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(element, String(v));
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+    },
+    { selector, value },
+  );
+}
+
+/**
+ * Deja un `<Switch>` en el estado pedido, sea cual sea el de partida.
+ *
+ * El componente es un `<button role="switch" aria-checked>` propio (no Radix),
+ * así que el estado se lee de `aria-checked`. Clicar a ciegas es un error
+ * clásico: varios de estos toggles vienen encendidos de fábrica y el click los
+ * apaga — y luego la captura contradice al texto de la documentación.
+ */
+export async function setSwitch(target: Locator, checked: boolean): Promise<void> {
+  await target.waitFor({ state: 'visible' });
+  const current = (await target.getAttribute('aria-checked')) === 'true';
+  if (current !== checked) await target.click();
+}
+
+/** Quita el overlay de anotación (por si la misma página encadena capturas). */
+export async function clearAnnotations(page: Page): Promise<void> {
+  await page.evaluate(() => document.getElementById('didacta-shots-annotations')?.remove());
+}
+
+export interface ShotOptions {
+  /** Elementos a resaltar en rojo, como en las capturas originales. */
+  annotations?: AnnotationSpec[];
+  /** Desplaza la página para que este elemento quede a la vista antes de disparar. */
+  scrollTo?: Locator;
+  /** Captura la página entera en vez del viewport. Por defecto, viewport. */
+  fullPage?: boolean;
+}
+
+/**
+ * Escribe `<out>/<recorrido>[/en]/<nombre>.png`.
+ *
+ * `name` es el nombre de fichero SIN extensión y se conserva entre idiomas:
+ * la documentación referencia `01-setup-intro.png` en las dos.
+ */
+export async function shot(
+  page: Page,
+  walkthrough: Walkthrough,
+  name: string,
+  options: ShotOptions = {},
+): Promise<string> {
+  if (options.scrollTo) {
+    await options.scrollTo.first().scrollIntoViewIfNeeded();
+  }
+  await settle(page);
+  if (options.annotations?.length) {
+    await annotate(page, options.annotations);
+  }
+
+  const dir = outputDir(walkthrough);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: options.fullPage ?? false });
+  await clearAnnotations(page);
+  // eslint-disable-next-line no-console
+  console.log(`[shots] ${walkthrough}/${CATALOG === 'en' ? 'en/' : ''}${name}.png`);
+  return file;
+}
+
+/**
+ * Comprueba que la página está renderizada en el idioma que se está
+ * capturando. `LocaleSync` puede reescribir la cookie con `profile.locale` y
+ * devolver la UI a español sin avisar (ver `apps/web/src/components/locale-sync.tsx`);
+ * si eso pasa la captura inglesa sale en español y nadie se entera hasta que
+ * la mira un humano. Aquí revienta en el acto.
+ */
+export async function assertLocale(page: Page, expected: string): Promise<void> {
+  const lang = await page.evaluate(() => document.documentElement.lang);
+  if (lang !== expected) {
+    throw new Error(
+      `[shots] La página está renderizada en "${lang}" y se esperaba "${expected}". ` +
+        'Revisa el locale del PERFIL (user.locale), no solo la cookie.',
+    );
+  }
+}

--- a/apps/e2e/shots/reset-instance.sh
+++ b/apps/e2e/shots/reset-instance.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) VA360 LABS S.L.
+# SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+#
+# Deja la instancia como el primer arranque de un self-hoster: base de datos
+# migrada, con RLS y grants, CERO tenants, y la API reiniciada contra ella.
+#
+# Por qué hace falta reiniciar la API y no basta con vaciar la base:
+#   1. el registro de módulos se siembra en el bootstrap de NestJS — con la BD
+#      recién vaciada bajo una API viva, cualquier `/admin/modules/...` devuelve
+#      500 «No Module found»;
+#   2. el token de un solo uso de `POST /setup/init` lo emite `SetupTokenService`
+#      en `onApplicationBootstrap` y SOLO si no hay ningún tenant. Sin reinicio
+#      no hay token, y sin token el asistente responde 403.
+#
+# Uso:
+#   source shots/env.example.sh          # o tu propio env
+#   bash shots/reset-instance.sh
+#
+# Al terminar imprime el `export SHOTS_SETUP_TOKEN=…` que necesita la tanda de
+# capturas.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PG_CONTAINER="${SHOTS_PG_CONTAINER:-didacta-e2e-postgres}"
+PG_USER="${SHOTS_PG_USER:-didacta}"
+PG_DB="${SHOTS_PG_DB:-didacta}"
+API_PORT="${SHOTS_API_PORT:-4000}"
+API_LOG="${SHOTS_API_LOG:-$REPO_ROOT/apps/e2e/shots-output/api.log}"
+MAILPIT_CONTAINER="${SHOTS_MAILPIT_CONTAINER:-didacta-shots-mailpit}"
+MAILPIT_SMTP_PORT="${SHOTS_MAILPIT_SMTP_PORT:-1027}"
+MAILPIT_HTTP_PORT="${SHOTS_MAILPIT_HTTP_PORT:-8027}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "ERROR: DATABASE_URL no está seteada. Sourcea tu env antes (ver shots/env.example.sh)." >&2
+  exit 1
+fi
+
+say() { printf '\n\033[1m▸ %s\033[0m\n' "$1"; }
+
+# ─── 1. Parar la API que esté escuchando en el puerto ────────────────────────
+say "Parando la API en :$API_PORT (si la hay)"
+if command -v netstat >/dev/null 2>&1; then
+  # `netstat -ano` es lo único que funciona igual en Git Bash y en PowerShell.
+  API_PIDS="$(netstat -ano 2>/dev/null | grep -E "[:.]${API_PORT}[[:space:]]+.*LISTENING" | awk '{print $NF}' | sort -u || true)"
+else
+  API_PIDS="$(lsof -ti ":${API_PORT}" 2>/dev/null || true)"
+fi
+for pid in $API_PIDS; do
+  echo "  matando PID $pid"
+  if command -v taskkill >/dev/null 2>&1; then
+    taskkill //F //PID "$pid" >/dev/null 2>&1 || true
+  else
+    kill "$pid" 2>/dev/null || true
+  fi
+done
+
+# ─── 2. Base de datos limpia ─────────────────────────────────────────────────
+say "Vaciando el esquema public de $PG_CONTAINER"
+docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -v ON_ERROR_STOP=1 \
+  -c 'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;' >/dev/null
+
+say "Aplicando migraciones"
+node "$REPO_ROOT/node_modules/prisma/build/index.js" migrate deploy \
+  --schema "$REPO_ROOT/packages/database/prisma/schema.prisma"
+
+say "Aplicando RLS y grants"
+docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -v ON_ERROR_STOP=1 -f - \
+  < "$REPO_ROOT/packages/database/prisma/rls.sql" >/dev/null
+docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -v ON_ERROR_STOP=1 -f - \
+  < "$REPO_ROOT/packages/database/prisma/grants.sql" >/dev/null
+
+# OJO: no se corre `db:seed`. El recorrido empieza en el asistente de
+# configuración, y el seed crearía un tenant que lo cerraría para siempre.
+
+# ─── 3. Mailpit propio ───────────────────────────────────────────────────────
+say "Mailpit ($MAILPIT_CONTAINER) en :$MAILPIT_SMTP_PORT / :$MAILPIT_HTTP_PORT"
+if ! docker ps --format '{{.Names}}' | grep -qx "$MAILPIT_CONTAINER"; then
+  docker rm -f "$MAILPIT_CONTAINER" >/dev/null 2>&1 || true
+  docker run -d --name "$MAILPIT_CONTAINER" \
+    -p "127.0.0.1:${MAILPIT_SMTP_PORT}:1025" \
+    -p "127.0.0.1:${MAILPIT_HTTP_PORT}:8025" \
+    axllent/mailpit:latest >/dev/null
+fi
+curl -sf -X DELETE "http://localhost:${MAILPIT_HTTP_PORT}/api/v1/messages" >/dev/null 2>&1 || true
+
+# ─── 4. Arrancar la API y capturar el token del asistente ────────────────────
+say "Arrancando la API"
+mkdir -p "$(dirname "$API_LOG")"
+: > "$API_LOG"
+(
+  cd "$REPO_ROOT/apps/api"
+  nohup node dist/main.js >> "$API_LOG" 2>&1 &
+  echo $! > "$REPO_ROOT/apps/e2e/shots-output/api.pid"
+)
+
+printf '  esperando /healthz'
+for _ in $(seq 1 60); do
+  if curl -sf "http://localhost:${API_PORT}/healthz" >/dev/null 2>&1; then
+    printf ' ok\n'
+    break
+  fi
+  printf '.'
+  sleep 1
+done
+
+# La web NO la gestiona este script (se compila y se arranca una vez, ver
+# README). Lo que sí hace es avisar si se ha caído: sin ella no hay capturas.
+WEB_URL="${SHOTS_BASE_URL:-http://localhost:3010}"
+if ! curl -sf "${WEB_URL}/healthz" >/dev/null 2>&1; then
+  echo "ERROR: la web no responde en ${WEB_URL}. Arráncala antes (ver shots/README.md)." >&2
+  exit 1
+fi
+
+SETUP_TOKEN="$(grep -o 'Setup token[^:]*: [A-Za-z0-9_-]\+' "$API_LOG" | tail -n1 | awk '{print $NF}' || true)"
+if [[ -z "$SETUP_TOKEN" ]]; then
+  echo "ERROR: no se encontró el token de setup en $API_LOG." >&2
+  echo "       ¿La instancia tenía ya un tenant? SetupTokenService solo emite token si hay cero." >&2
+  exit 1
+fi
+
+cat <<EOF
+
+╭──────────────────────────────────────────────────────────────────────╮
+│ Instancia virgen lista.                                              │
+╰──────────────────────────────────────────────────────────────────────╯
+
+  export SHOTS_SETUP_TOKEN='$SETUP_TOKEN'
+
+Ahora lanza las capturas (ver shots/README.md):
+
+  SHOTS_LOCALE=es-ES node ../../node_modules/@playwright/test/cli.js \\
+    test --config playwright.shots.config.ts
+
+EOF

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -10,6 +10,12 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"]
   },
-  "include": ["tests/**/*", "helpers/**/*", "playwright.config.ts"],
+  "include": [
+    "tests/**/*",
+    "helpers/**/*",
+    "shots/**/*",
+    "playwright.config.ts",
+    "playwright.shots.config.ts"
+  ],
   "exclude": ["node_modules", "test-results", "playwright-report"]
 }


### PR DESCRIPTION
## Qué hace

Las 40 capturas de los dos recorridos visuales de [`didacta-docs`](https://github.com/va360labs/didacta-docs) se hacían **a mano** y solo existían en español. Este PR trae el generador: un proyecto de Playwright aparte, dentro de `apps/e2e/`, que las produce solas contra una instalación real, en **español y en inglés**, con viewport fijo.

El proceso manual se acaba aquí: si mañana cambia la interfaz, se vuelve a lanzar.

> Los PNG **no** se versionan en este repo (su sitio es `didacta-docs`); caen en `apps/e2e/shots-output/`, que se añade a `.gitignore`. Las capturas generadas con este script van en **didacta-docs PR #1**.

## Cómo se lanza

```bash
source apps/e2e/shots/env.example.sh

# 1. Instancia virgen (cero tenants) + API reiniciada + Mailpit limpio.
#    Imprime el token de un solo uso del asistente de configuración.
bash apps/e2e/shots/reset-instance.sh
export SHOTS_SETUP_TOKEN='…'

# 2. Tanda (≈35 s las 40 capturas)
cd apps/e2e
SHOTS_LOCALE=es-ES node ../../node_modules/@playwright/test/cli.js \
  test --config playwright.shots.config.ts
```

Para el inglés: **volver a resetear** (el asistente solo se completa una vez por instancia) y repetir con `SHOTS_LOCALE=en-US`.

### Qué hay que tener levantado

| Pieza | Detalle |
| --- | --- |
| Postgres | `didacta-e2e-postgres` en `127.0.0.1:5442` (`pgvector/pgvector:pg16`) |
| API | `apps/api/dist/main.js` compilada — la arranca `reset-instance.sh` |
| Web | `next start -p 3010` ya compilada (`API_INTERNAL_URL` se hornea en el build) |
| Mailpit | lo crea `reset-instance.sh` (`didacta-shots-mailpit`, SMTP `:1027`, web `:8027`) |
| Internet | una captura llama a la API real de Stripe para retratar su error |

Todo está en `apps/e2e/shots/README.md`.

## Recuento

| Recorrido | ES | EN |
| --- | --- | --- |
| `recorrido-visual` (asistente → primer certificado) | 22 | 22 |
| `notificaciones-y-pagos` (SMTP, Stripe, membresía, `/unete`) | 18 | 18 |
| **Total** | **40** | **40** |

## Decisiones

**Viewport fijo 1440×900, `deviceScaleFactor: 1`.** Es el tamaño de las 40 originales y lo que hace comparables la tanda española y la inglesa. Ojo: `browser.newContext()` **no** hereda el bloque `use` de la config; el viewport se pasa a mano en `lib/browser.ts`.

**El idioma se fija en el PERFIL, no solo en la cookie.** `LocaleSync` lee `GET /me/profile` y, si el locale del perfil no coincide con la cookie `didacta_locale`, **reescribe la cookie con el del perfil**. Poner solo la cookie a `en-US` hace que la página parpadee y vuelva a español. Cada recorrido llama a `PATCH /me/profile` nada más existir la sesión, y `assertLocale()` corta la ejecución si `<html lang>` no es el esperado — una tanda inglesa no puede salir en español sin que nadie se entere.

**Selectores por catálogo i18n, no por texto literal.** `lib/i18n.ts` lee los mismos JSON que consume la web (`apps/web/src/i18n/messages/<es|en>/*.json`). Un solo recorrido sirve para los dos idiomas y una clave que falte en `en` falla con un error explícito en vez de con un timeout opaco.

**Nada de `networkidle`.** Con sesión iniciada la app abre dos canales SSE (`/messaging/stream` y `/me/notifications/stream`): la red no queda ociosa **nunca** y cada captura se comía 30 s de timeout. `settle()` espera por el DOM (sin esqueletos, imágenes decodificadas, 400 ms sin mutaciones). La tanda pasó de no terminar a 35 s.

**Datos neutros (regla whitelabel).** `lib/config.ts` es la única fuente de la organización, las cuentas y el contenido: `Academia Demo`, `Admin Demo`, `admin@example.com`, `alumna@example.com`. Ninguna marca, dominio ni dato de cliente. La foto de perfil y el logo se generan en memoria (degradado) reutilizando `helpers/png.ts`, así que no entra ningún binario al repo.

**Mismos datos en los dos idiomas.** Lo que se traduce es la interfaz, no lo que teclea el operador. Además las páginas `.en.md` de la documentación citan textualmente `Academia Demo` / `Admin Demo` / `Alumna Demo`: traducir el contenido dejaría el texto inglés describiendo algo que no se ve.

**El SMTP se pone y se quita.** El enlace de «define tu contraseña» viaja por email, así que el primer recorrido configura el SMTP por API antes de invitar a la alumna y lo **borra** justo después: el segundo recorrido tiene que empezar con la pestaña Notificaciones realmente vacía.

**Las claves de Stripe son inventadas.** No hace falta cuenta: la captura 12 del segundo recorrido documenta el error con el que Stripe rechaza una clave inválida, y para eso la llamada tiene que ser real (`balance.retrieve`, solo lectura).

## Hallazgos de i18n encontrados al revisar la tanda inglesa

Los tres son de producto, no del generador. **No se arreglan en este PR** (queda fuera de su alcance) pero quedan localizados.

1. **El email de prueba de SMTP está cableado en español.** `apps/api/src/admin/admin-smtp.controller.ts:255-262` construye asunto y cuerpo con literales (`Prueba de SMTP — …`, `Si recibiste este correo…`) sin pasar por i18n ni mirar el locale del destinatario. Mismo patrón en `apps/api/src/modules/tenant-settings.controller.ts:286-287`. Se ve en `notificaciones-y-pagos/en/06-mailpit-bandeja.png`: la interfaz de Mailpit está en inglés y el correo, en español, con el admin en `locale='en-US'`.

2. **La traducción inglesa de `ADMIN_STRIPE_KEY_REJECTED` se come el mensaje de Stripe.** La API devuelve `message: "Stripe rechazó la clave: <mensaje real de Stripe>"` con `code: ADMIN_STRIPE_KEY_REJECTED` (`apps/api/src/admin/admin-stripe.controller.ts:200-204`). En español no hay entrada en el catálogo y se muestra el mensaje completo (`Invalid API Key provided: sk_test_***…0000`); en inglés, `apps/web/src/i18n/messages/en/errorsApiAdmin.json:22` lo sustituye por `"Stripe rejected the key."` a secas y el operador pierde el diagnóstico. Comparar `notificaciones-y-pagos/12-pagos-probar-conexion-error.png` con su `en/`.

3. **La pestaña «Aula virtual» de `/admin/configuracion` no se traduce.** `apps/web/src/modules/zoom-live/index.ts:22-23` declara `label: 'Aula virtual'` (y su `description`) como literal en el `adminConfigTabs` de la extensión web, así que se queda en español dentro de la barra de pestañas inglesa. El elemento equivalente del sidebar sí se traduce (`nav.json`). El core ya tiene el camino bueno: si la extensión omite `label`, `apps/web/src/app/(app)/admin/configuracion/page.tsx` cae a `adminMarca.configTabs.<key>`. Se ve en las capturas `en/01`, `en/07`, `en/10`, `en/11` y `en/12` de `notificaciones-y-pagos`.

Ninguna captura inglesa tiene claves crudas (`ns.algo`) ni copy español fuera de estos tres puntos y del contenido de demo, que es igual en las dos tandas a propósito.

## Verificación

- `tsc -p apps/e2e/tsconfig.json --noEmit` ✅ (se amplía `include` con `shots/**` y la nueva config).
- `prettier --check` ✅ sobre los ficheros nuevos.
- 3 tandas completas (2 en español, 1 en inglés) desde BD virgen: **40/40 capturas** cada una, sin fallos.
- Las 80 imágenes revisadas a ojo antes de publicarlas.
