### PR TITLE
chore(repo): mínimo público fair-code, cierre del ratchet i18n, exports muertos y guarda de paridad es/en

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,107 @@
+name: 🐛 Bug report
+description: Algo no funciona como debería en Didacta.
+title: '[BUG] '
+labels: ['bug', 'alpha-tester']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por reportar. Cuanto más concreto, mejor podemos arreglarlo.
+
+        Guía completa (qué datos recoger y qué anonimizar): **[didacta.io/docs](https://didacta.io/docs)**.
+
+        ⚠️ **Si es una vulnerabilidad de seguridad, no la reportes aquí.** Escribe a `security@didacta.io` — ver [SECURITY.md](https://github.com/va360labs/didacta-io/blob/main/SECURITY.md).
+  - type: input
+    id: version
+    attributes:
+      label: Versión Didacta
+      description: 'Sácala de `curl -fsS http://localhost:4000/healthz`, de `docker compose -f docker-compose.alpha.yml images didacta` o de `DIDACTA_IMAGE_TAG` en tu `.env`.'
+      placeholder: '0.0.1-alpha.101'
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Cómo lo estás corriendo
+      options:
+        - docker compose -f docker-compose.alpha.yml
+        - pnpm dev (desarrollo local)
+        - Otro (especificar abajo)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Sistema operativo
+      placeholder: 'macOS 14, Ubuntu 22.04, Windows 11 Pro...'
+    validations:
+      required: true
+  - type: dropdown
+    id: role
+    attributes:
+      label: ¿Con qué rol ocurre?
+      description: Muchos fallos solo aparecen con un rol concreto.
+      options:
+        - Administrador (super_admin / tenant_admin)
+        - Formador
+        - Alumno
+        - Visitante sin sesión (catálogo público, registro, login)
+        - Varios / no depende del rol
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Pasos para reproducir
+      placeholder: |
+        1. Ir a /admin/courses/new
+        2. Rellenar título, descripción
+        3. Click "Crear"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamiento esperado
+      placeholder: 'El curso se crea y aparece en el listado.'
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Comportamiento real
+      placeholder: 'Devuelve error 500 con mensaje "Cannot read properties of undefined".'
+    validations:
+      required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: ¿Con qué frecuencia pasa?
+      options:
+        - Siempre que sigo esos pasos
+        - Intermitente (a veces sí, a veces no)
+        - Ocurrió una sola vez
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs relevantes
+      description: 'Recógelos con `docker compose -f docker-compose.alpha.yml logs --no-color --tail 200 didacta`. Anonimiza emails, nombres reales, tokens y credenciales antes de pegarlos.'
+      render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (opcional)
+      description: Arrastra aquí imágenes si las tienes. Para fallos de interfaz, incluye también el error de la consola del navegador (F12).
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Antes de enviar
+      options:
+        - label: He buscado en issues abiertas y no encuentro este bug.
+          required: true
+        - label: He anonimizado emails, nombres reales, tokens y credenciales en logs y capturas.
+          required: true
+        - label: Esto no es una vulnerabilidad de seguridad (esas van a `security@didacta.io`, nunca a una issue pública).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Cómo reportar un error
+    url: https://didacta.io/docs
+    about: Qué mirar antes de abrir la issue, qué datos recoger y qué anonimizar.
+  - name: 💬 Preguntas y dudas
+    url: https://github.com/va360labs/didacta-io/discussions
+    about: Para preguntas de uso e instalación que no son bugs.
+  - name: 🔒 Reporte de seguridad
+    url: mailto:security@didacta.io
+    about: Para vulnerabilidades de seguridad. NO abras issue público.
+  - name: 📜 Licensing & comercial
+    url: mailto:licensing@didacta.io
+    about: Preguntas sobre uso comercial / Enterprise / Cloud.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,45 @@
+name: ✨ Feature request
+description: Pedir una funcionalidad nueva o un cambio significativo.
+title: '[FEATURE] '
+labels: ['feature-request', 'alpha-tester']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema que resuelve
+      description: ¿Qué quieres hacer y no puedes? ¿A quién le pasa esto?
+      placeholder: 'Quiero que mis alumnos puedan ver el progreso de sus compañeros en cursos colaborativos.'
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Tu propuesta de solución (opcional)
+      placeholder: 'Añadir una vista pública de leaderboard por curso.'
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Para ti, ¿qué prioridad tiene?
+      options:
+        - '🔴 Bloqueante — no puedo usar Didacta sin esto'
+        - '🟠 Alta — lo necesito en próximas semanas'
+        - '🟡 Media — lo agradecería en algún momento'
+        - '🟢 Baja — nice-to-have'
+    validations:
+      required: true
+  - type: dropdown
+    id: edition
+    attributes:
+      label: ¿Crees que esto debería ser?
+      options:
+        - Community (gratis para todos)
+        - Enterprise (capability gateada)
+        - Cloud-only (solo en SaaS gestionado)
+        - No lo sé
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: ¿Hay alternativas que ya hayas probado?
+      description: 'Otros LMS que tengan esto, workarounds que hayas usado, etc.'

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,40 @@
+name: 💬 Feedback general
+description: Algo funciona pero te resulta confuso, lento, mal organizado o mejorable.
+title: '[FEEDBACK] '
+labels: ['feedback', 'alpha-tester']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        El feedback no técnico es **el más valioso** durante alpha. Adelante.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Área afectada
+      options:
+        - Onboarding / instalación
+        - UX / interfaz
+        - Documentación
+        - Mensajes de licencia / Enterprise
+        - Performance
+        - Decisiones de producto
+        - Otro
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: ¿Qué notaste?
+      placeholder: 'Cuando entré por primera vez al panel admin no entendí qué tenía que hacer primero. El onboarding no me guió.'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: ¿Qué esperabas que pasara?
+      placeholder: 'Esperaba un asistente paso a paso que me llevara a crear mi primer curso.'
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Tu sugerencia (opcional)
+      placeholder: 'Añadir un wizard de bienvenida en /admin/welcome.'

--- a/.gitignore
+++ b/.gitignore
@@ -77,9 +77,13 @@ playwright-report/
 work/
 
 # Documentación y meta de proyecto: fuera del repo por decisión de producto.
-# El repositorio versiona SOLO lo necesario para construir y ejecutar la
-# aplicación (más LICENSE/LICENSE_EE, que son el instrumento legal del
-# modelo fair-code). Todo lo demás vive aquí, en local.
+# El repositorio versiona lo necesario para construir y ejecutar la aplicación
+# MÁS el mínimo que un repo público fair-code tiene que declarar en sí mismo:
+# LICENSE, LICENSE_EE, README, LICENSE_NOTICE, SECURITY, CONTRIBUTING,
+# CODE_OF_CONDUCT, TRADEMARKS, COMMERCIAL_USE y .github/ISSUE_TEMPLATE/.
+# El manual (instalación, actualización, operación, versionado) vive en
+# https://didacta.io/docs, no aquí. Todo lo demás que se sacó del árbol vive
+# en esta carpeta, en local.
 .fueradegit/
 
 # Claude Code: estado local del agente (settings, locks y worktrees). El

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,72 @@
+# Código de Conducta
+
+## Compromiso
+
+La comunidad de Didacta — alpha testers, contribuidores, mantenedores, equipo VA360 LABS y cualquier persona que interactúe con el proyecto — se compromete a hacer la participación en este proyecto una experiencia **libre de acoso y respetuosa** para todo el mundo, independientemente de edad, identidad y expresión de género, orientación sexual, discapacidad, apariencia física, raza, etnia, religión, nivel de experiencia o nacionalidad.
+
+Este código está basado en el [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Comportamiento esperado
+
+- Usar lenguaje inclusivo y respetuoso.
+- Aceptar críticas constructivas con buena disposición.
+- Centrarse en lo que es mejor para la comunidad.
+- Mostrar empatía hacia otros miembros.
+- Asumir buena fe en las intenciones de los demás.
+- Reconocer el trabajo de otros antes de criticarlo.
+
+## Comportamiento inaceptable
+
+- Acoso, insultos, ataques personales o políticos.
+- Comentarios despectivos sobre cualquier característica protegida.
+- Lenguaje sexualizado, imágenes o avances no solicitados.
+- Publicación de información privada de otros sin permiso explícito (doxing).
+- Conductas que un profesional consideraría inapropiadas en un entorno laboral.
+- Intentos de saltarse el modelo de licencia (ej. promover crackeo de capabilities EE).
+- Suplantación de identidad o uso indebido de la marca Didacta.
+
+## Aplicación
+
+### Reportar un incidente
+
+Si presencias o sufres un comportamiento inaceptable, contacta a los mantenedores:
+
+- **Email**: `conduct@didacta.io` (o `valen@va360labs.com` si el anterior aún no está activo).
+- **Confidencialidad**: garantizada. Nadie verá tu reporte salvo el equipo que decide acciones.
+- **Anonimato**: opcional pero dificulta el seguimiento.
+
+Incluye en el reporte:
+
+- Descripción del incidente.
+- Quién está involucrado.
+- Dónde sucedió (issue, Discord, email, etc.) con enlaces si aplica.
+- Cualquier contexto que ayude a entender la situación.
+
+### Acciones posibles
+
+| Severidad                             | Acción                                                                       |
+| ------------------------------------- | ---------------------------------------------------------------------------- |
+| Comentario fuera de tono aislado      | Aviso privado + petición de retracto público si aplica.                      |
+| Patrón de comportamiento problemático | Aviso formal + lectura obligada de este código. Reincidencia = ban temporal. |
+| Acoso, ataques personales, doxing     | Ban permanente del repo, Discord y canales del proyecto.                     |
+| Conducta ilegal                       | Ban permanente + reporte a autoridades si aplica.                            |
+
+Las decisiones del equipo de mantenedores son finales.
+
+## Alcance
+
+Este código aplica en:
+
+- El repositorio GitHub (issues, PRs, discussions, wiki).
+- Discord/Slack `#didacta-alpha` y otros canales oficiales.
+- Eventos comunitarios de Didacta (online u offline).
+- Cuentas oficiales del proyecto en redes sociales.
+- Comunicación privada entre miembros que invoque la marca o el proyecto.
+
+## Atribución
+
+Adaptado del [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), licenciado bajo CC BY 4.0.
+
+## Contacto
+
+`conduct@didacta.io`

--- a/COMMERCIAL_USE.md
+++ b/COMMERCIAL_USE.md
@@ -1,0 +1,31 @@
+# Commercial use of Didacta
+
+## When you need a commercial agreement
+
+You need a commercial agreement with VA360 LABS S.L. (or to use Didacta Cloud) if you intend to:
+
+- Offer Didacta as a paid SaaS, managed hosting, or LMS-as-a-service.
+- Resell Didacta, with or without modifications.
+- Distribute Didacta as part of a commercial product (white-label, OEM, embedded).
+- Provide commercial implementation services around Didacta as a non-authorized partner.
+- Use Didacta Enterprise features (`*.ee.*`) in production.
+
+## What we offer
+
+| Path                           | Best for                                                          |
+| ------------------------------ | ----------------------------------------------------------------- |
+| **Didacta Enterprise License** | Self-hosted production with all features unlocked                 |
+| **Didacta Cloud**              | SaaS-grade hosting, billing, support, no infrastructure to manage |
+| **Partner Program** (planned)  | Consultancies and integrators who deliver Didacta to clients      |
+
+## How to contact us
+
+- General licensing inquiries: **licensing@didacta.io**
+- Cloud sales: **sales@didacta.io**
+- Partnership: **partners@didacta.io**
+
+## What's free
+
+For internal business use, evaluation, development, testing, research, education, contribution, and any non-commercial use, **no agreement is required**. The Sustainable Use License (`LICENSE`) covers you.
+
+If you are unsure whether your use case requires an agreement, please email `licensing@didacta.io`. We err on the side of "if in doubt, ask".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Didacta Community
+
+> Gracias por tu interés en contribuir a Didacta. Esta guía resume el proceso. Tómate 5 minutos para leerla antes de abrir tu primer PR.
+
+## Antes de empezar
+
+### Estado actual: alpha
+
+Este repositorio está en **alpha** mientras trabajamos hacia `v1.0.0`. Las contribuciones externas son bienvenidas — issues, feedback de instalación y PRs acotados — con la cautela de que la API y el schema aún pueden cambiar entre versiones alpha.
+
+### Licencia
+
+Didacta es **fair-code source-available**, no open source bajo definición OSI. Lee:
+
+- [`LICENSE`](LICENSE) — Didacta Sustainable Use License v1.0 (cubre la mayor parte del repo).
+- [`LICENSE_EE`](LICENSE_EE) — Didacta Enterprise License (cubre archivos `*.ee.*` y carpetas `ee/` / `*.ee/` dentro del CORE).
+- [`LICENSE_NOTICE.md`](LICENSE_NOTICE.md) — resumen humano.
+
+## Tu primera contribución
+
+### 1. Bot CLA
+
+Cualquier PR es bloqueado hasta firmar el CLA (Contributor License Agreement) vía [cla-assistant.io](https://cla-assistant.io). El bot te lo pedirá automáticamente la primera vez. **Una sola firma vale para todas tus contribuciones futuras.**
+
+### 2. Issue antes de PR
+
+Para cambios no triviales, abre primero una **issue** describiendo el problema o la propuesta. Eso evita trabajo descartado si la dirección no encaja con el roadmap. Para fixes pequeños (typo, doc) puedes ir directo al PR.
+
+### 3. Branch
+
+```bash
+git checkout -b <type>/<short-description>
+```
+
+Tipos válidos: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`.
+
+### 4. Conventional Commits obligatorios
+
+```
+feat(scope): título corto
+
+Cuerpo opcional. Explica el POR QUÉ, no el QUÉ (eso ya lo dice el diff).
+
+Refs: #123
+```
+
+Sin atribución a IA en commits (sin `Co-Authored-By: Claude` ni similar). Política del proyecto.
+
+### 5. Tests
+
+Cualquier PR que toque lógica de negocio debe incluir tests. Coverage mínimo 70% en services.
+
+### 6. Validaciones obligatorias antes de push
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm tsx scripts/ee-fence.ts
+pnpm tsx scripts/module-doctor.ts
+```
+
+CI las ejecuta otra vez. Si fallan, el PR no se mergea.
+
+## Reglas duras del modelo
+
+Estas reglas son **innegociables**. Romperlas = PR rechazado.
+
+### Convención `.ee` (open-core)
+
+- Archivos `*.ee.ts` y carpetas `ee/` / `*.ee/` viven **solo dentro del CORE** (`apps/api/src/`, `packages/core-kernel/`, `packages/core-registry/`, `packages/license-sdk/src/` — la lista canónica es `EE_ALLOWED_ROOTS` en `scripts/ee-fence.ts`).
+- **Ningún módulo** (`modules/*`) puede tener archivos `.ee` ni sufijo `.ee` en su carpeta. Todos los módulos son Community.
+- Capabilities Enterprise se gatean con `@RequiresCapability(LICENSE_CAPABILITIES.X)` en endpoints y `license.requireCapability(...)` en services.
+
+### Contrato de módulo
+
+- Todas las tablas con prefijo `mod_<nombre>_*` y `tenant_id` con RLS.
+- Cero FKs cross-module.
+- Cero imports de código privado de otro módulo. Comunicación vía eventos / hooks / API pública.
+- `module.json` válido contra schema.
+- Lifecycle hooks (`onRegister`, `onEnable`, `onDisable`, `onUninstall`) implementados.
+
+### No introducir dependencias copyleft
+
+- ✅ MIT, Apache 2.0, BSD, ISC.
+- ⚠️ LGPL (caso a caso, solo si linkado dinámico).
+- ❌ GPL, AGPL, MPL, SSPL.
+
+CI corre `scripts/license-check.ts` y rechaza el PR si hay dependencia incompatible.
+
+## Estilo de código
+
+- TypeScript estricto. No `any` salvo casos justificados (con comentario).
+- Prettier + ESLint. CI lo verifica.
+- Identificadores en inglés. Comentarios y commits en español o inglés indistintamente.
+- Sin `console.log` en código de producción — usa el logger Pino.
+
+## Reportar bugs
+
+Abre una issue en GitHub con la plantilla de **bug** (o la de **feedback** si no es un fallo concreto): pasos para reproducir, comportamiento esperado y comportamiento observado.
+
+Si encuentras una vulnerabilidad de seguridad, **NO abras issue público**. Manda un email a `security@didacta.io`. Ver [`SECURITY.md`](SECURITY.md).
+
+## Decisiones arquitectónicas
+
+Cualquier cambio que afecte al contrato de módulo, al modelo de licencias, al SDK o a APIs públicas requiere una **decisión de arquitectura (ADR)** previa. Como contribuidor externo, proponla abriendo una issue o GitHub Discussion con el contexto, las opciones consideradas y sus trade-offs; el equipo la evaluará y, si se acepta, la registrará en el índice interno de ADRs (Notion del equipo).
+
+## Política de marca
+
+El nombre "Didacta", el logo y derivados son marcas registradas de VA360 LABS S.L. Lee [`TRADEMARKS.md`](TRADEMARKS.md) antes de mencionarlos en proyectos derivados o forks.
+
+## Reconocimiento
+
+Las contribuciones aceptadas se reconocen (con tu consentimiento) en las notas de publicación de cada versión y en la lista de contribuidores de GitHub.
+
+## Contacto
+
+- 💬 Preguntas técnicas: GitHub Discussions o Discord `#didacta-alpha` (durante alpha).
+- 🔒 Seguridad: `security@didacta.io`.
+- 📜 Licensing / comercial: `licensing@didacta.io`.
+
+Gracias por contribuir. 🚀

--- a/LICENSE_NOTICE.md
+++ b/LICENSE_NOTICE.md
@@ -1,0 +1,40 @@
+# Didacta — License Notice
+
+## What you can do
+
+Didacta is **fair-code**: the source code is publicly available and you can:
+
+- ✅ View, read, copy, modify, and distribute the code.
+- ✅ Run Didacta in production for **your own internal business purposes** (training your employees, internal LMS for your organization, etc.).
+- ✅ Use Didacta for **non-commercial or personal use** (research, learning, evaluation, contribution).
+- ✅ Distribute the software or your modifications **for free, for non-commercial purposes**.
+- ✅ Build proofs of concept, evaluations, audits, demos.
+
+## What requires a commercial agreement
+
+- ❌ Distributing Didacta or derivatives **for a fee**.
+- ❌ Offering Didacta as a **paid SaaS or managed hosting** for third parties.
+- ❌ Selling **white-labeled** Didacta or rebranding for resale.
+- ❌ Sublicensing Didacta as part of a commercial product.
+- ❌ Removing or altering copyright, license, or trademark notices.
+- ❌ Using Didacta trademarks beyond what applicable law permits.
+
+For any of the above, contact: **licensing@didacta.io** or use **Didacta Cloud** at https://cloud.didacta.io.
+
+## Two licenses, one repository
+
+| Code                                                                | License                                          |
+| ------------------------------------------------------------------- | ------------------------------------------------ |
+| Files **NOT** matching `*.ee.*` and not in `ee/` or `*.ee/` folders | Didacta Sustainable Use License v1.0 (`LICENSE`) |
+| Files matching `*.ee.*` or in `ee/` or `*.ee/` folders              | Didacta Enterprise License (`LICENSE_EE`)        |
+| Third-party components                                              | Original upstream license                        |
+
+The Enterprise License files (`*.ee.*`) require a **valid Didacta Enterprise License key** to be used in production. Without that key, those features are gated at runtime by the License SDK.
+
+## Position
+
+Didacta is **fair-code**, **source-available**, and aligned with the [faircode.io](https://faircode.io/) movement. We are NOT open source under the OSI definition. We adopt the same model as n8n.io.
+
+## Trademark
+
+"Didacta" is a trademark of VA360 LABS S.L. See `TRADEMARKS.md`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,258 @@
+# Didacta Community
+
+> 📚 **El LMS de nueva generación. Fair-code, modular y listo para Fundae.**
+
+[![Docker](https://img.shields.io/badge/ghcr-didacta--community-blue)](https://github.com/va360labs/didacta-io/pkgs/container/didacta-community)
+[![License](https://img.shields.io/badge/license-Sustainable%20Use%201.0-orange)](LICENSE)
+[![Versioning](https://img.shields.io/badge/versioning-SemVer-green)](https://semver.org)
+![Stage](https://img.shields.io/badge/stage-alpha-red)
+[![Web](https://img.shields.io/badge/web-didacta.io-black)](https://didacta.io)
+
+## Estado actual
+
+🚧 **Alpha** — entre mayo y julio de 2026 el producto maduró sirviendo en
+producción real a su primer despliegue (congelado en el tag
+`v0.0.1-alpha.88-va360`); desde el 31 de julio de 2026 el repo vuelve a ser el
+producto whitelabel y prepara su primera versión pública. Guías de
+instalación, actualización y versionado en la documentación oficial:
+[didacta.io/docs](https://didacta.io/docs).
+
+Imagen oficial publicada en GitHub Container Registry: `ghcr.io/va360labs/didacta-community`. **Pública** — no requiere `docker login`. El espejo en [Docker Hub](https://hub.docker.com/r/didactaio/community) (`didactaio/community`) todavía no está activo.
+
+## Verificar acceso a la imagen
+
+```bash
+# Fija SIEMPRE una versión concreta; no hay tag `latest`.
+docker pull ghcr.io/va360labs/didacta-community:<versión>
+```
+
+Si se descarga sin pedir credenciales, ya puedes seguir cualquiera de los dos caminos de despliegue descritos abajo.
+
+## Variables de entorno obligatorias
+
+Solo **3 variables de entorno** son estrictamente obligatorias para arrancar. El resto tienen valores por defecto razonables o se inyectan desde el compose. El conjunto completo está documentado en [`.env.example`](.env.example).
+
+| Variable       | Qué es                                                                  | Cómo generarla                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL` | Connection string de Postgres 16 con la extensión `pgvector` instalada. | Apunta a tu Postgres. Para compose: `postgresql://didacta:didacta_dev@postgres:5432/didacta?schema=public`.                                                                                                                                                                                                                                                                                                                                  |
+| `REDIS_URL`    | Connection string de Redis 7.                                           | Apunta a tu Redis. Para compose: `redis://redis:6379`.                                                                                                                                                                                                                                                                                                                                                                                       |
+| `AUTH_SECRET`  | Secreto para firmar sesiones y cookies. Mínimo 32 caracteres.           | Cualquier cadena aleatoria de **32+ caracteres** sirve. Opciones: 1) un generador online de contraseñas con longitud 40+; 2) un gestor de contraseñas como 1Password o Bitwarden → "Generar contraseña" de 40 caracteres; 3) `openssl rand -base64 32`; 4) `node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`. Lo importante: que sea aleatoria y que la guardes. Si la cambias, todas las sesiones se invalidan. |
+
+## Camino A — Docker Compose
+
+Recomendado para la mayoría de instalaciones.
+
+Stack: API + web + Postgres + Redis + Mailpit (SMTP). Storage local por defecto en un volumen Docker, sin S3 externo.
+
+```bash
+# 1. Clonar
+git clone https://github.com/va360labs/didacta-io.git
+cd didacta-io
+
+# 2. Configurar .env
+cp .env.example .env
+
+# 3. Pegar tu AUTH_SECRET en .env.
+#    Debe ser una cadena aleatoria de 32+ caracteres.
+#    Opciones rápidas:
+#    - Un generador online de contraseñas con longitud 40+.
+#    - Tu gestor de contraseñas → "Generar contraseña" de 40 caracteres.
+#    - openssl rand -base64 32
+#    - node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+#    Edita .env y completa AUTH_SECRET=...
+
+# 4. Fijar la versión de la imagen (tags publicados en Docker Hub)
+echo "DIDACTA_IMAGE_TAG=<versión>" >> .env
+
+# 5. Arrancar
+docker compose -f docker-compose.alpha.yml up -d
+
+# 6. Esperar healthchecks (~60-90s la primera vez)
+docker compose -f docker-compose.alpha.yml ps
+
+# 7. Copiar el token de setup de un solo uso (obligatorio para crear la
+#    cuenta admin — sin él /setup/init responde 403). Deja de valer en
+#    cuanto termine el asistente o el contenedor se reinicie sin terminarlo.
+docker compose -f docker-compose.alpha.yml logs didacta | grep "Setup token"
+
+# 8. Abrir (usa la URL /setup?token=... que imprimió el paso anterior)
+# http://localhost:3000             — Web
+# http://localhost:4000/api/docs    — Swagger
+# http://localhost:4000/healthz     — health probe
+# http://localhost:8025             — Mailpit, emails de prueba
+```
+
+### Persistencia: volúmenes Docker
+
+El compose declara cuatro volúmenes nombrados que sobreviven a `down`/`up` y reinicios:
+
+| Volumen         | Qué guarda                                                                                                                       |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `postgres_data` | Toda la base de datos.                                                                                                           |
+| `redis_data`    | Cola persistente (`appendonly yes`) — outbox + jobs.                                                                             |
+| `didacta_data`  | Storage local de la aplicación: uploads de cursos, certificados y evidencias + clave de cifrado autogenerada para datos at-rest. |
+| `minio_data`    | Solo si activas el profile `s3`. Guarda los buckets de MinIO.                                                                    |
+
+**Importante**: `docker compose down -v` borra los volúmenes y, por tanto, los datos. Para detener sin borrar, usa `docker compose down` sin `-v`.
+
+Backup recomendado para producción: `pg_dump` + `tar` del volumen `didacta_data`.
+
+### Storage opcional con MinIO
+
+Si quieres probar el flujo S3-compatible sin pagar AWS, Hetzner u otro proveedor, arranca MinIO con el profile `s3`:
+
+```bash
+docker compose -f docker-compose.alpha.yml --profile s3 up -d
+# Consola de MinIO disponible en http://localhost:9001
+```
+
+Después, descomenta las líneas `S3_*` en `docker-compose.alpha.yml`, dentro del servicio `didacta`, para que la aplicación use MinIO en lugar del disco local.
+
+Para producción real, apunta a tu Hetzner Object Storage, AWS S3 u otro proveedor compatible configurando las variables `S3_*` en `.env`.
+
+El quickstart de esta página cubre el arranque; el manual completo de instalación, actualización y operación vive en [didacta.io/docs](https://didacta.io/docs). Para dudas, bugs o feedback, abre una issue en GitHub — hay plantillas de bug, feedback y feature request. Para vulnerabilidades de seguridad, sigue [`SECURITY.md`](SECURITY.md).
+
+## Camino B — Docker pull + run manual
+
+Para operadores que ya tienen Postgres 16 + Redis 7 administrados y solo quieren ejecutar el contenedor de la aplicación.
+
+**Requisitos previos:**
+
+- Postgres 16 con extensión `pgvector` instalada y schema vacío. La aplicación aplica las migraciones Prisma al arrancar.
+- Redis 7 accesible desde el contenedor.
+- Las 3 variables de entorno obligatorias listadas arriba.
+
+```bash
+docker pull ghcr.io/va360labs/didacta-community:0.0.1-alpha.101
+
+# Crear volumen para uploads + clave de cifrado autogenerada.
+# El volumen sobrevive a reinicios.
+docker volume create didacta_data
+
+docker run -d \
+  --name didacta-app \
+  -p 3000:3000 \
+  -p 4000:4000 \
+  -v didacta_data:/app/data \
+  -e DATABASE_URL='postgresql://USER:PASS@HOST:5432/didacta?schema=public' \
+  -e REDIS_URL='redis://HOST:6379' \
+  -e AUTH_SECRET='cualquier-cadena-aleatoria-de-32+-caracteres' \
+  -e STORAGE_DRIVER=local \
+  -e STORAGE_ROOT=/app/data/storage \
+  -e NODE_ENV=production \
+  --restart unless-stopped \
+  ghcr.io/va360labs/didacta-community:0.0.1-alpha.101
+```
+
+> El volumen `didacta_data` guarda los archivos subidos —cursos, certificados y evidencias— **y** una clave de cifrado autogenerada en el primer arranque para los secretos at-rest. Sin ese volumen montado, todo se borra al recrear el contenedor.
+
+> Si prefieres S3-compatible en lugar de disco local: elimina `STORAGE_DRIVER` y `STORAGE_ROOT`, y añade `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`. Aun así, conviene mantener el volumen montado para la clave de cifrado.
+
+**Verificar:**
+
+```bash
+docker logs -f didacta-app                  # ver bootstrap + migraciones Prisma
+curl -fsS http://localhost:4000/healthz     # debe responder 200
+docker logs didacta-app | grep "Setup token"  # token de un solo uso para /setup?token=...
+```
+
+**Variables opcionales útiles** — conjunto completo en [`.env.example`](.env.example):
+
+| Variable                                                        | Para qué                                                                                       |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`    | Storage S3-compatible: MinIO, AWS, Hetzner, etc. Obligatorio para subida de contenido.         |
+| `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` | Envío de emails transaccionales. Sin esto, los emails se registran en logs pero no se envían.  |
+| `DIDACTA_LICENSE_KEY`                                           | JWT firmado por Didacta para activar capabilities Enterprise. Sin esto, modo Community puro.   |
+| `METRICS_TOKEN`                                                 | Bearer token para proteger `/metrics` en Prometheus. Si está vacío, el endpoint queda público. |
+
+## Sobre el proyecto
+
+Didacta es un LMS (Learning Management System) **fair-code de nueva generación**: código fuente disponible bajo la [Didacta Sustainable Use License v1.0](LICENSE), arquitectura modular, sin licencias por usuario y con cumplimiento legal integrado en el núcleo. Diseñado para academias, formadores y organizaciones que quieren operar su propia plataforma de formación con control total.
+
+Más información y demo en vivo: [didacta.io](https://didacta.io).
+
+### Por qué Didacta
+
+- **Modular de verdad.** Instala solo lo que necesitas. Cada función es un módulo limpio: sin parches, sin temas que rompen en cada actualización, sin deuda técnica acumulada.
+- **Fair-code.** Tu plataforma, tu código: audítalo, modifícalo y despliégalo con uso interno libre bajo la [Didacta Sustainable Use License v1.0](LICENSE). Sin licencias por usuario. La distribución comercial, el SaaS o el white-label de terceros requieren acuerdo (ver [Modelo de licencias](#modelo-de-licencias)).
+- **Cumplimiento serio.** Fundae, RGPD y WCAG 2.2 AA integrados en el núcleo, no añadidos con plugins de terceros. Trazabilidad, auditoría y exportación de datos listos desde el día uno.
+- **IA discreta.** Inteligencia artificial que ayuda sin interrumpir: crea contenido, sugiere itinerarios y resume actividad.
+
+### Tres formas de llenar tu academia de alumnos
+
+Los tres caminos conviven en la misma instalación y se combinan libremente:
+
+1. **Tú los das de alta.** Invita alumnos uno a uno o por lotes desde el panel: eliges su grupo de acceso al invitarles, reciben un email para crear su contraseña y entran directamente a sus cursos. Desde la ficha de cada alumno gestionas sus grupos, matrículas y bajas. Ideal para formación interna, bonificada o clases presenciales que se llevan al aula virtual.
+
+2. **Vendes cursos sueltos.** Publica un curso, ponle precio —con varias opciones de compra si quieres— y comparte tu catálogo público en `/catalogo`. El visitante paga con tarjeta vía Stripe sin registrarse antes: su cuenta se crea automáticamente con el email confirmado en el pago y queda matriculado al instante. Los reembolsos retiran el acceso solos.
+
+3. **Vendes membresías.** Crea planes con la periodicidad (1–12 meses) y la moneda que quieras, con periodo de prueba opcional. Tu página pública de venta en `/unete` muestra el catálogo real; al suscribirse, el alumno accede a todos los cursos del grupo que definas. Si deja de pagar, el acceso se revoca automáticamente — sin tocar lo que hayas concedido a mano.
+
+Y si tu comunidad exige aprobación previa, activa el **registro con solicitud**: configura los verificadores que pida tu caso (verificación de email, Telegram o ninguno), revisa la evidencia de cada solicitud y aprueba o rechaza con un clic.
+
+### Tres ediciones, mismo producto
+
+| Edición                   | Para quién                                                            | Incluye                                                                                                           |
+| ------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Community** (este repo) | Equipos que despliegan y operan ellos mismos.                         | Todo el código fuente. Comunidad activa de contribuidores.                                                        |
+| **Cloud**                 | Quien quiere arrancar en minutos, sin infraestructura.                | Hosting gestionado por VA360 LABS con actualizaciones sin intervención. **En preparación.**                       |
+| **Enterprise**            | Organizaciones con SLA, integraciones a medida y partner certificado. | Account manager dedicado, onboarding guiado, integraciones con sistemas existentes, infraestructura monitorizada. |
+
+Detalles y precios: [didacta.io](https://didacta.io).
+
+## Modelo de licencias
+
+Didacta es **fair-code**: source-available, uso interno empresarial libre, distribución comercial / SaaS de terceros bajo acuerdo. Modelo Open-Core con capabilities Enterprise protegidas:
+
+- **Repo + módulos**: [Didacta Sustainable Use License v1.0](LICENSE) (fair-code, adaptada de n8n SUL). Permite uso interno empresarial libre. Distribución comercial / SaaS / white-label requiere acuerdo con VA360 LABS S.L.
+- **Capabilities Enterprise** (archivos `*.ee.*` dentro del CORE): [Didacta Enterprise License](LICENSE_EE). Requieren licencia firmada activa para usarse en producción.
+- **Cloud**: SaaS gestionado por VA360 (`cloud.didacta.io`).
+
+Resumen humano: [`LICENSE_NOTICE.md`](LICENSE_NOTICE.md). Política de uso comercial: [`COMMERCIAL_USE.md`](COMMERCIAL_USE.md). Marca registrada: [`TRADEMARKS.md`](TRADEMARKS.md). Dudas de licensing: `licensing@didacta.io`.
+
+## Telemetría
+
+Cada instalación envía **un latido diario anónimo** a `registry.didacta.io` para que sepamos cuántas instalaciones de Didacta existen. El payload completo es este y nada más:
+
+| Campo                 | Contenido                                                                                                                                             |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `instanceId`          | UUID **aleatorio** generado en la primera ejecución (`.didacta-instance-id` en el volumen de datos). No identifica a ninguna persona ni organización. |
+| `version` / `edition` | Versión de Didacta y edición (`community` o el plan Enterprise).                                                                                      |
+| `node` / `os`         | Versión de Node y plataforma (`linux/x64`…).                                                                                                          |
+| `sentAt`              | Fecha del latido.                                                                                                                                     |
+
+Sin PII, sin datos de negocio (ni usuarios, ni cursos, ni dominios), sin bloquear nada: si no hay salida a internet, el latido falla en silencio y la plataforma funciona igual. **Se desactiva con una variable de entorno**:
+
+```bash
+DIDACTA_TELEMETRY_DISABLED=true
+```
+
+Aparte existe un **registro opt-in** voluntario (Administración → Registro) donde el operador puede identificarse con email y organización a cambio de canal directo con el equipo; ese nivel envía métricas agregadas y tiene opt-out y borrado RGPD desde el propio panel.
+
+## Documentación
+
+- 📚 [didacta.io/docs](https://didacta.io/docs) — Documentación oficial (es/en): instalación, actualización, operación y versionado.
+- 🤝 [`CONTRIBUTING.md`](CONTRIBUTING.md) — Guía de contribución.
+- 🔒 [`SECURITY.md`](SECURITY.md) — Política de seguridad y reporte responsable.
+- 📋 [Releases](https://github.com/va360labs/didacta-io/releases) — Historial de cambios de cada versión publicada.
+- 📜 [`LICENSE_NOTICE.md`](LICENSE_NOTICE.md) — Resumen humano del modelo de licencias.
+- 🧭 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — Código de conducta.
+- 🐛 Bugs y feedback — issues de GitHub (plantillas de bug, feedback y feature request).
+
+## Stack tecnológico
+
+- **Backend**: Node.js 22 + NestJS 11 + TypeScript.
+- **Frontend**: Next.js 15 (App Router) + React 19 + Tailwind + shadcn/ui.
+- **Base de datos**: PostgreSQL 16 con Row-Level Security + Prisma.
+- **Cache / colas**: Redis 7 + BullMQ.
+- **Object storage**: S3-compatible (MinIO en compose, cualquier proveedor S3 en producción).
+- **IA**: capa pluggable — la alpha actual usa proveedor LLM externo; futuras versiones permitirán cambiar de proveedor.
+- **Monorepo**: Turborepo + pnpm workspaces.
+
+## Licencia
+
+Didacta Community © 2026 VA360 LABS S.L. — distribuido bajo [Didacta Sustainable Use License v1.0](LICENSE) (fair-code).
+
+Capabilities Enterprise: [Didacta Enterprise License](LICENSE_EE).
+
+Didacta™ es una marca de VA360 LABS S.L. Ver [`TRADEMARKS.md`](TRADEMARKS.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Reportar una vulnerabilidad
+
+Si descubres una vulnerabilidad de seguridad en Didacta, **por favor NO abras una issue pública** en GitHub.
+
+### Cómo reportar
+
+Manda un email a **`security@didacta.io`** con:
+
+- **Descripción** del problema y su impacto.
+- **Pasos para reproducirlo**, idealmente con un PoC mínimo.
+- **Versión afectada** (`docker compose images` o tag de la imagen).
+- **Tu nombre + manera de reconocerte** si quieres aparecer en los créditos de seguridad (`SECURITY-CREDITS.md`, se crea con el primer reporte acreditado) (opcional).
+
+Si la vulnerabilidad es crítica y prefieres cifrar, pide la PGP key en el mismo email.
+
+### Qué pasa después
+
+| Plazo                        | Acción                                                                     |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| **48 h hábiles**             | Acuse de recibo + asignación de severidad.                                 |
+| **7 días**                   | Plan de mitigación + ETA del parche.                                       |
+| **Variable según severidad** | Parche desarrollado y testeado.                                            |
+| **Tras parche en main**      | Aviso público (sin detalle de exploit) y crédito al reporter si lo aceptó. |
+| **+30 días**                 | Detalle técnico publicado en advisory.                                     |
+
+## Severidad
+
+| Nivel       | Ejemplos                                                                                                      | SLA parche    |
+| ----------- | ------------------------------------------------------------------------------------------------------------- | ------------- |
+| **Crítica** | RCE, SQL injection en endpoint público, leak de credenciales / claves privadas, bypass de autenticación / RLS | 72 h          |
+| **Alta**    | XSS persistente, escalación de privilegios entre tenants, leak de PII                                         | 7 días        |
+| **Media**   | XSS reflejado, IDOR no crítico, denegación de servicio limitada                                               | 30 días       |
+| **Baja**    | Information disclosure menor, problema de rate limit, mensaje de error con info técnica                       | Próxima minor |
+
+## Versiones soportadas
+
+Durante alpha cerrada (`v0.0.x-alpha`): solo el último alpha publicado. Si reportas un bug en un alpha viejo, te pedimos actualizar al último primero.
+
+Cuando salgamos a beta y `v1.0.0`, esta tabla se actualizará con la política LTS final.
+
+## Lo que NO contamos como vulnerabilidad
+
+- Bugs funcionales que no comprometen seguridad → reporta como bug normal abriendo una issue en GitHub (plantilla de bug).
+- Errores de configuración del usuario (ej. `AUTH_SECRET` débil que él mismo eligió).
+- Dependencias con CVEs no explotables en nuestro contexto. Ejecutamos `pnpm audit` regularmente; los CVEs explotables sí los tratamos como vulnerabilidades.
+- Bypass del chequeo de licencia EE en código local. La licencia se aplica por **contrato + soporte + parches**, no por DRM.
+
+## Bug bounty
+
+No tenemos programa formal de bug bounty durante alpha. Cuando publiquemos `v1.0.0` evaluaremos lanzar uno (probablemente con HackerOne o Intigriti).
+
+Por ahora: agradecimiento público en `SECURITY-CREDITS.md` (opt-in; ese archivo se crea con el primer reporte acreditado) y, en algunos casos, swag de Didacta o invitación a Cloud gratis durante 6 meses.
+
+## Comunicación con clientes Enterprise
+
+Los clientes con licencia Enterprise activa reciben aviso por email a la dirección registrada en su licencia **antes** de que el advisory se haga público. Esto les da margen para parchear sus despliegues self-host.
+
+## Contacto
+
+- **`security@didacta.io`** — reportes y consultas.
+- **`legal@didacta.io`** — temas legales relacionados con seguridad.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,35 @@
+# Trademark policy — Didacta
+
+## The marks
+
+The following are trademarks of VA360 LABS S.L.:
+
+- The name **"Didacta"**.
+- The Didacta logo (any form factor).
+- "Didacta Cloud", "Didacta Enterprise", "Didacta Community".
+- Any compound mark substantially derived from the above.
+
+The Sustainable Use License (`LICENSE`) **does not** grant rights to these trademarks.
+
+## What's allowed without permission
+
+- Mentioning Didacta in editorial or technical contexts (blog posts, comparisons, courses, news).
+- Stating that your project "uses Didacta" or "is based on Didacta" with a clear and honest disclosure that your project is not affiliated with or endorsed by VA360 LABS S.L.
+- Linking to the Didacta website and repositories.
+- Fair use as defined by applicable law.
+
+## What requires written permission
+
+- Selling a fork or derivative product called "Didacta" or any confusingly similar name.
+- Using the Didacta logo in commercial contexts.
+- Implying that VA360 LABS S.L. endorses, certifies, or supports a product or service.
+- Domains containing "didacta" intended for commercial use.
+
+## Enforcement
+
+Trademark misuse may result in cease-and-desist requests and, if unresolved, legal action. We prefer a friendly approach — if you are unsure whether your use is permitted, please ask first at `legal@didacta.io`.
+
+## Pending registrations
+
+- EUIPO trademark registration: confirmed available, registration pending budget.
+- Other jurisdictions: under review.

--- a/apps/web/src/components/community-thread-card.tsx
+++ b/apps/web/src/components/community-thread-card.tsx
@@ -33,23 +33,18 @@ type AttachmentTile =
  * Tiempo relativo corto («ahora», «hace 5m»…); a partir de una semana, fecha.
  *
  * `t` es el `useTranslations('comunidadComponentes')` del componente que la
- * llama. Va OPCIONAL solo por compatibilidad: `modules/messaging` todavía la
- * importa y no ha pasado por su unidad de i18n, así que sin `t` devuelve el
- * español cableado de siempre (nunca una key en pantalla). Cuando messaging
- * migre, `t` pasa a obligatorio y esa rama desaparece.
+ * llama y es OBLIGATORIO: no hay camino degradado. La firma tuvo `t?` mientras
+ * `modules/messaging` la importaba sin haber migrado; messaging estrenó su
+ * propia `relTime` con `t` obligatorio (`modules/messaging/shared.ts`) y esta
+ * ya solo la usan `ThreadCard` y `community-gallery-modal`, los dos con el
+ * mismo namespace.
  */
-export function relTime(iso: string, t?: TranslatorLike): string {
+export function relTime(iso: string, t: TranslatorLike): string {
   const diff = (Date.now() - new Date(iso).getTime()) / 1000;
   if (diff >= 86400 * 7) return formatDate(iso, { day: '2-digit', month: 'short' });
   const minutes = Math.floor(diff / 60);
   const hours = Math.floor(diff / 3600);
   const days = Math.floor(diff / 86400);
-  if (!t) {
-    if (diff < 60) return 'ahora';
-    if (diff < 3600) return `hace ${minutes}m`;
-    if (diff < 86400) return `hace ${hours}h`;
-    return `hace ${days}d`;
-  }
   if (diff < 60) return t('relTimeNow');
   if (diff < 3600) return t('relTimeMinutes', { minutes });
   if (diff < 86400) return t('relTimeHours', { hours });

--- a/apps/web/src/components/module-runtime-provider.tsx
+++ b/apps/web/src/components/module-runtime-provider.tsx
@@ -33,7 +33,7 @@
  * ```
  */
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { initModuleRuntime } from '@/lib/module-runtime';
 
 export interface ModuleRuntimeProviderProps {
@@ -41,27 +41,23 @@ export interface ModuleRuntimeProviderProps {
 }
 
 export function ModuleRuntimeProvider({ children }: ModuleRuntimeProviderProps) {
-  const [initialized, setInitialized] = useState(false);
-
   useEffect(() => {
-    // Inicializar el runtime solo en el cliente
+    // Inicializar el runtime solo en el cliente.
+    //
+    // NO hay estado `initialized`: los children se pintan igual antes y después
+    // (ver abajo), así que guardarlo solo provocaba un render extra. Si algún
+    // día hace falta bloquear el árbol hasta que el runtime esté listo, hay que
+    // reintroducir el estado Y usarlo en el return — no basta con escribirlo.
     try {
       initModuleRuntime();
-      setInitialized(true);
     } catch (err) {
       console.error('[ModuleRuntimeProvider] Error inicializando runtime:', err);
-      // Aún así renderizar children para no bloquear la app
-      setInitialized(true);
+      // Aún así renderizamos children para no bloquear la app.
     }
   }, []);
 
-  // En SSR, renderizar children sin esperar (el runtime se inicializa en hydration)
-  // En el cliente, esperar a que el runtime esté listo
-  if (typeof window === 'undefined') {
-    return <>{children}</>;
-  }
-
-  // Mostrar children inmediatamente - el runtime se inicializa en paralelo
-  // Los módulos que intenten cargarse antes recibirán un error claro
+  // Mostrar children inmediatamente — tanto en SSR como en cliente. El runtime
+  // se inicializa en paralelo y los módulos que intenten cargarse antes reciben
+  // un error claro desde `getModuleRuntime()`.
   return <>{children}</>;
 }

--- a/apps/web/src/i18n/messages-parity.test.ts
+++ b/apps/web/src/i18n/messages-parity.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/**
+ * Guarda de paridad es ↔ en de TODOS los namespaces del catálogo.
+ *
+ * Antes de este test solo `nav.json` tenía guarda (`lib/i18n/nav-catalog.test.ts`):
+ * renombrar una key en `es/` y olvidarla en `en/` pasaba la CI sin que nadie se
+ * enterase, y el síntoma en producción es una key cruda —o el idioma
+ * equivocado— en una pantalla que nadie mira en inglés.
+ *
+ * Los ficheros se leen del DISCO, no del `index.ts`: así un namespace nuevo
+ * entra en la guarda el día que se crea el JSON, sin acordarse de registrarlo
+ * en ningún sitio.
+ *
+ * ── Las dos reglas ────────────────────────────────────────────────────────────
+ *
+ *  1. Una key en ES sin gemela en EN es SIEMPRE un fallo. No hay excepciones y
+ *     no hay lista: el catálogo español es el canónico y todo lo que dice se
+ *     tiene que poder decir en inglés.
+ *
+ *  2. Una key en EN sin gemela en ES es un fallo SALVO que esté declarada abajo,
+ *     en `EN_ONLY_BY_DESIGN`, y solo en los namespaces `errorsApi*`.
+ *
+ * ── Por qué la asimetría de `errorsApi*` es deliberada ────────────────────────
+ *
+ * El backend NO traduce (decisión D6): manda un `code` estable y un `message` en
+ * español. `apiErrorMessage()` (`lib/i18n/api-error.ts`) traduce por `code` SOLO
+ * si la key existe en el catálogo activo; si no existe, cae al `message` crudo
+ * del backend. La regla vigente aprovecha ese fallback:
+ *
+ *   · Mensaje FIJO en el backend  → el ES lleva key (traducción literal) y el EN
+ *     también. Paridad normal.
+ *   · Mensaje INTERPOLADO en el backend (lleva dentro un diagnóstico real: el
+ *     nombre del curso, el error del MTA, la respuesta de Stripe…) → el ES NO
+ *     lleva key a propósito, para que `apiErrorMessage` degrade al `message`
+ *     crudo y el admin español conserve el detalle. El EN sí lleva una redacción
+ *     genérica, porque sin key el anglófono vería el mensaje en español.
+ *
+ * Son los 174 codes declarados abajo. Van uno a uno y no como un `skip`
+ * sobre `errorsApi*`: un code nuevo que aparezca solo en EN por descuido rompe
+ * la CI igual que cualquier otra huérfana, y un code que se declare aquí y luego
+ * se arregle (o se borre) también, porque la lista se valida contra los
+ * catálogos en los dos sentidos.
+ *
+ * ── Lo que este test NO valida (y hay que arreglar en otra sesión) ────────────
+ *
+ * La CALIDAD de esa redacción genérica inglesa. Un barrido de la Sesión I cifra
+ * en 32 los codes cuya traducción inglesa se traga el dato interpolado que el
+ * español sí enseña (2 cerrados en el PR #34 —`ADMIN_STRIPE_KEY_REJECTED` y
+ * `ADMIN_SMTP_TEST_FAILED`, que hoy interpolan `{detail}` y tienen test propio
+ * en `lib/i18n/api-error.test.ts`—, 30 pendientes, 7 de ellos perdiendo un
+ * diagnóstico de un sistema externo). Esos 30 están DENTRO de la lista de abajo:
+ * este test los da por conocidos, no por correctos. El arreglo es mover cada uno
+ * al patrón `{detail}` de `CODES_WITH_DETAIL` (backend + las dos traducciones) y
+ * sacarlo de aquí — momento en el que este test lo exigirá.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const MESSAGES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'messages');
+const LOCALES = ['es', 'en'] as const;
+
+/** Namespaces con permiso para declarar keys solo-EN (ver cabecera). */
+const ASYMMETRY_ALLOWED_PREFIX = 'errorsApi';
+
+/**
+ * Codes con key SOLO en EN a propósito: el backend manda un `message` español
+ * interpolado y el catálogo ES se calla para que `apiErrorMessage` lo deje
+ * pasar entero. Ordenados alfabéticamente por namespace para que el diff de un
+ * PR que añada o quite uno sea de una línea.
+ */
+const EN_ONLY_BY_DESIGN: Readonly<Record<string, readonly string[]>> = {
+  errorsApiAdmin: [
+    'ADMIN_CUSTOM_DOMAIN_EXISTS',
+    'ADMIN_CUSTOM_DOMAIN_NOT_FOUND',
+    'ADMIN_ROLE_NOT_ASSIGNABLE',
+    'ADMIN_ROLE_NOT_FOUND',
+    'ADMIN_SMTP_TEMPLATE_NOT_FOUND',
+    'ADMIN_TENANT_HOSTNAME_EXISTS',
+    'ADMIN_TENANT_SLUG_EXISTS',
+  ],
+  errorsApiAuthSso: [
+    'AUTH_API_KEY_MISSING_SCOPES',
+    'SSO_EMAIL_DOMAIN_NOT_ALLOWED',
+    'SSO_OIDC_IDP_ERROR',
+    'SSO_SAML_RESPONSE_INVALID',
+  ],
+  errorsApiModulesA: [
+    'AI_PROVIDERS_PROVIDER_NOT_REGISTERED',
+    'AI_PROVIDERS_PURPOSE_NOT_SUPPORTED',
+    'CORE_MODULE_NOT_DISABLEABLE',
+    'COURSE_ALREADY_PUBLISHED',
+    'COURSE_NOT_FOUND',
+    'COURSE_PUBLISH_VALIDATION_FAILED',
+    'COURSE_SLUG_EXISTS',
+    'INVITATION_INVALID',
+    'LESSON_LOCKED',
+    'MEMBER_REG_EMAIL_SEND_FAILED',
+    'MODULE_HAS_ACTIVE_DEPENDENTS',
+    'MODULE_NOT_FOUND',
+    'SCORM_PACKAGE_INVALID',
+    'STORAGE_FILE_SIZE_OUT_OF_RANGE',
+    'TENANT_MODULES_MODULE_NOT_ACTIVE',
+    'TENANT_SETTINGS_PARAM_INVALID',
+    'TENANT_SETTINGS_SMTP_CONFIG_INVALID',
+    'TENANT_SETTINGS_SMTP_TEST_FAILED',
+    'THEMING_CUSTOM_CSS_TOO_LARGE',
+    'THEMING_CUSTOM_CSS_UNSAFE',
+    'THEMING_FOOTER_HTML_TOO_LARGE',
+    'THEMING_INVALID_URL',
+    'THEMING_LOGO_TOO_LARGE',
+    'THEMING_SIGNIN_COPY_TOO_LONG',
+    'THEMING_UNSUPPORTED_FONT',
+    'THEMING_UNSUPPORTED_LOGO_TYPE',
+    'ZOOM_API_ERROR',
+    'ZOOM_ATTENDANCE_NOT_AVAILABLE',
+    'ZOOM_COURSE_NOT_IN_TENANT',
+    'ZOOM_HOST_NOT_FOUND',
+    'ZOOM_LIVE_STAFF_ONLY',
+    'ZOOM_SESSION_NOT_FOUND',
+  ],
+  errorsApiModulesB: [
+    'ACCESS_GROUPS_SLUG_TAKEN',
+    'AI_CONTENT_DRAFT_NOT_FOUND',
+    'AI_CONTENT_DRAFT_NOT_IN_DRAFT',
+    'AI_CONTENT_INVALID_JSON',
+    'AI_CONTENT_LESSON_TEXT_EMPTY',
+    'AI_CONTENT_PROVIDER_ERROR',
+    'AI_GRADER_ATTEMPT_NOT_PENDING',
+    'AI_GRADER_PROVIDER_ERROR',
+    'AI_GRADER_QUESTION_NOT_GRADABLE',
+    'AI_GRADER_RESPONSE_PARSE_ERROR',
+    'AI_GRADER_RUBRIC_INVALID',
+    'AI_GRADER_RUBRIC_NOT_FOUND',
+    'AI_GRADER_SUGGESTION_NOT_FOUND',
+    'AI_PROVIDER_AUTH',
+    'AI_PROVIDER_NOT_CONFIGURED',
+    'AI_PROVIDER_RATE_LIMIT',
+    'AI_PROVIDER_UNAVAILABLE',
+    'AI_PROVIDER_UNSUPPORTED_CAPABILITY',
+    'AI_TUTOR_CHAT_PROVIDER_ERROR',
+    'AI_TUTOR_CORRECTION_NOT_FOUND',
+    'AI_TUTOR_COURSE_ACCESS_DENIED',
+    'AI_TUTOR_COURSE_NOT_INDEXED',
+    'AI_TUTOR_COURSE_NOT_PUBLISHED',
+    'AI_TUTOR_DAILY_QUESTION_QUOTA',
+    'AI_TUTOR_EMBEDDINGS_PROVIDER_ERROR',
+    'AI_TUTOR_MESSAGE_NOT_FOUND',
+    'AI_TUTOR_TOKEN_QUOTA_EXCEEDED',
+    'AUDIT_EXPORT_SIGNING_UNAVAILABLE',
+    'BILLING_ORDER_NOT_FOUND',
+    'BILLING_PRODUCT_ALREADY_EXISTS',
+    'BILLING_PRODUCT_INACTIVE',
+    'BILLING_PRODUCT_NOT_FOUND',
+    'BILLING_STRIPE_API_ERROR',
+    'BILLING_STRIPE_CONFIG_MISSING',
+    'BILLING_WEBHOOK_SIGNATURE_INVALID',
+    'BILLING_WEBHOOK_SIGNATURE_REJECTED',
+    'COMMUNITY_SPACE_UNKNOWN',
+    'FUNDAE_ACTION_NOT_FOUND',
+    'FUNDAE_ACTION_WITHOUT_COURSE',
+    'FUNDAE_BLOCK_HOURS_EXCEED',
+    'FUNDAE_BLOCK_NOT_FOUND',
+    'FUNDAE_BLOCK_ORDINAL_DUPLICADO',
+    'FUNDAE_CODIGO_DUPLICADO',
+    'FUNDAE_COMPANY_NIF_DUPLICADO',
+    'FUNDAE_COMPANY_NOT_FOUND',
+    'FUNDAE_COMPANY_TIENE_GRUPOS_ACTIVOS',
+    'FUNDAE_COST_NOT_FOUND',
+    'FUNDAE_COURSE_NOT_IN_TENANT',
+    'FUNDAE_CREDITO_INSUFICIENTE',
+    'FUNDAE_GROUP_CERRADO',
+    'FUNDAE_GROUP_NOT_FOUND',
+    'FUNDAE_GROUP_NUMERO_DUPLICADO',
+    'FUNDAE_GROUP_PARTICIPANT_DUPLICADO',
+    'FUNDAE_GROUP_PARTICIPANT_NOT_FOUND',
+    'FUNDAE_GROUP_PARTICIPANT_NOT_IN_COURSE',
+    'FUNDAE_GROUP_SIN_CURSO',
+    'FUNDAE_GROUP_TRANSICION_INVALIDA',
+    'FUNDAE_PARTICIPANT_NOT_IN_ACTION',
+    'FUNDAE_RLPT_NOTIFICACION_INICIAL_MISSING',
+    'FUNDAE_RLPT_NOT_FOUND',
+    'FUNDAE_RLPT_PLAZO_NO_CUMPLIDO',
+    'FUNDAE_RLPT_SIZE_INVALID',
+    'GAMIFICATION_CHALLENGE_CLOSED',
+    'GAMIFICATION_CONFLICT',
+    'GAMIFICATION_NOT_FOUND',
+    'GAMIFICATION_PERK_UNAVAILABLE',
+    'GAMIFICATION_VALIDATION',
+    'GRADE_EXCEEDS_QUESTION_POINTS',
+    'MAX_ATTEMPTS_REACHED',
+    'MEMBERSHIP_CONFIG_INCOMPLETE',
+    'MEMBERSHIP_PLAN_INTERVAL_INVALID',
+    'MEMBERSHIP_PLAN_NOT_FOUND',
+    'MESSAGING_SPACE_NOT_FOUND',
+    'PAYCONN_EMAIL_SEND_FAILED',
+    'PAYCONN_PATTERN_INVALID',
+    'PAYMENT_CONNECTIONS_ALREADY_EXISTS',
+    'PAYMENT_CONNECTIONS_NOT_FOUND',
+    'PAYMENT_CONNECTIONS_PORTAL_UNAVAILABLE',
+    'PAYMENT_CONNECTIONS_PROVIDER_NOT_SUPPORTED',
+    'PAYMENT_CONNECTIONS_STRIPE_API_ERROR',
+    'PAYMENT_CONNECTIONS_STRIPE_KEY_INVALID',
+    'PAYMENT_CONNECTIONS_TIER_NAME_CONFLICT',
+    'PAYMENT_CONNECTIONS_TIER_NOT_FOUND',
+    'REFERRALS_COMMISSION_NOT_FOUND',
+    'REFERRALS_COMMISSION_STATE',
+    'REFERRALS_CONFIG_INVALID',
+    'REFERRALS_PAYOUT_INVALID',
+    'RESOURCES_VALIDATION',
+    'SPACE_EXISTS',
+    'SPACE_NOT_DELETABLE',
+    'SPACE_NOT_FOUND',
+    'SUBSCRIPTIONS_ALREADY_ACTIVE',
+    'SUBSCRIPTIONS_NOT_FOUND',
+    'SUBSCRIPTIONS_PRICE_NOT_RECURRING',
+    'SUBSCRIPTIONS_STRIPE_API_ERROR',
+    'SUBSCRIPTIONS_STRIPE_CONFIG_MISSING',
+    'SUBSCRIPTIONS_WEBHOOK_SIGNATURE_INVALID',
+    'SUBS_WEBHOOK_SIGNATURE_REJECTED',
+    'SURVEYS_INVALID_ANSWER',
+    'TAG_NAME_EXISTS',
+    'TAG_NOT_FOUND',
+    'TEMPLATE_IN_USE',
+    'TEMPLATE_NAME_TAKEN',
+  ],
+  errorsApiResto: [
+    'ALREADY_INSTALLED',
+    'CORE_VERSION_INCOMPATIBLE',
+    'MANIFEST_CONSISTENCY_INVALID',
+    'MANIFEST_INVALID_JSON',
+    'MANIFEST_SCHEMA_INVALID',
+    'MARKETPLACE_ASSET_SURFACE_INVALID',
+    'MARKETPLACE_DISPATCHER_ROUTE_NOT_FOUND',
+    'MARKETPLACE_MODULE_HANDLER_ERROR',
+    'MARKETPLACE_MODULE_NOT_AVAILABLE',
+    'MARKETPLACE_MODULE_NOT_INSTALLED',
+    'MARKETPLACE_PACKAGE_DOWNLOAD_FAILED',
+    'MARKETPLACE_SURFACE_UI_MISSING',
+    'MODERATION_REASON_TOO_LONG',
+    'MODERATION_SCOPES_UNKNOWN',
+    'MODULE_BOOT_FAILED',
+    'MODULE_LINT_FAILED',
+    'NAME_RESERVED',
+    'NOT_FOUND',
+    'PACKAGE_INVALID_ZIP',
+    'PACKAGE_MISSING_FILE',
+    'PACKAGE_TOO_LARGE',
+    'SIGNATURE_INVALID',
+    'SIGNATURE_VERIFY_FAILED',
+    'STORAGE_FAILED',
+    'SURFACE_BUNDLE_MISSING',
+    'VENDOR_NOT_TRUSTED',
+    'webhook_limit_exceeded',
+    'webhook_url_duplicate',
+  ],
+};
+
+type Json = { [k: string]: Json | string };
+
+/** Hojas del catálogo en notación de punto, con su valor. */
+function flatEntries(obj: Json, prefix = '', out: Array<[string, unknown]> = []) {
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === 'object') flatEntries(v, key, out);
+    else out.push([key, v]);
+  }
+  return out;
+}
+
+function namespacesOf(locale: string): string[] {
+  return readdirSync(path.join(MESSAGES_DIR, locale))
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+    .sort();
+}
+
+function entriesOf(locale: string, ns: string): Array<[string, unknown]> {
+  const raw = readFileSync(path.join(MESSAGES_DIR, locale, `${ns}.json`), 'utf8');
+  return flatEntries(JSON.parse(raw) as Json);
+}
+
+function keysOf(locale: string, ns: string): Set<string> {
+  return new Set(entriesOf(locale, ns).map(([k]) => k));
+}
+
+const NAMESPACES = namespacesOf('es');
+
+function declaredEnOnly(ns: string): ReadonlySet<string> {
+  return new Set(EN_ONLY_BY_DESIGN[ns] ?? []);
+}
+
+describe('catálogo i18n · paridad es ↔ en', () => {
+  it('los dos idiomas declaran exactamente los mismos namespaces', () => {
+    expect(namespacesOf('en')).toEqual(NAMESPACES);
+  });
+
+  it('el barrido cubre todos los namespaces del disco (no está vacío)', () => {
+    // Si alguien mueve la carpeta, el resto de tests pasaría en verde sobre
+    // una lista vacía. Esto lo convierte en fallo.
+    expect(NAMESPACES.length).toBeGreaterThan(30);
+  });
+
+  it('ninguna key existe solo en ES (regla sin excepciones)', () => {
+    const huerfanas: string[] = [];
+    for (const ns of NAMESPACES) {
+      const en = keysOf('en', ns);
+      for (const k of keysOf('es', ns)) if (!en.has(k)) huerfanas.push(`${ns}.${k}`);
+    }
+    expect(
+      huerfanas,
+      `keys en es/ sin gemela en en/ (traducir o borrar):\n  ${huerfanas.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('toda key solo-EN está declarada como deliberada', () => {
+    const inesperadas: string[] = [];
+    for (const ns of NAMESPACES) {
+      const es = keysOf('es', ns);
+      const declared = declaredEnOnly(ns);
+      for (const k of keysOf('en', ns)) {
+        if (!es.has(k) && !declared.has(k)) inesperadas.push(`${ns}.${k}`);
+      }
+    }
+    expect(
+      inesperadas,
+      `keys en en/ sin gemela en es/ y SIN declarar en EN_ONLY_BY_DESIGN.\n` +
+        `Si es deliberado (mensaje del backend interpolado) decláralo con motivo;\n` +
+        `si no, falta la traducción española:\n  ${inesperadas.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('toda entrada declarada sigue siendo realmente asimétrica (la lista no se pudre)', () => {
+    const obsoletas: string[] = [];
+    for (const ns of NAMESPACES) {
+      const es = keysOf('es', ns);
+      const en = keysOf('en', ns);
+      for (const k of declaredEnOnly(ns)) {
+        if (!en.has(k)) obsoletas.push(`${ns}.${k} (ya no existe en en/)`);
+        else if (es.has(k)) obsoletas.push(`${ns}.${k} (ya tiene gemela en es/)`);
+      }
+    }
+    expect(
+      obsoletas,
+      `entradas de EN_ONLY_BY_DESIGN que ya no son asimétricas.\n` +
+        `La declaración se pudrió: bórralas de la lista:\n  ${obsoletas.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('solo los namespaces errorsApi* pueden declarar asimetría', () => {
+    const fuera = Object.keys(EN_ONLY_BY_DESIGN).filter(
+      (ns) => !ns.startsWith(ASYMMETRY_ALLOWED_PREFIX),
+    );
+    expect(
+      fuera,
+      `la excusa del fallback al message crudo solo vale para codes de la API:\n  ${fuera.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('todo namespace declarado existe en el disco', () => {
+    const fantasma = Object.keys(EN_ONLY_BY_DESIGN).filter((ns) => !NAMESPACES.includes(ns));
+    expect(fantasma, `namespaces declarados que ya no existen: ${fantasma.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('catálogo i18n · integridad', () => {
+  it('ningún valor está vacío en ninguno de los dos idiomas', () => {
+    const vacias: string[] = [];
+    for (const locale of LOCALES) {
+      for (const ns of NAMESPACES) {
+        for (const [k, v] of entriesOf(locale, ns)) {
+          if (typeof v !== 'string' || v.trim() === '') vacias.push(`${locale}/${ns}.${k}`);
+        }
+      }
+    }
+    expect(vacias, `valores vacíos o no-string:\n  ${vacias.join('\n  ')}`).toEqual([]);
+  });
+
+  it('ningún code de error se define en dos errorsApi* a la vez', () => {
+    // Los cinco `errorsApi*.json` se funden bajo el namespace `errors` en
+    // `messages/<locale>/index.ts`: un code duplicado hace que gane el último
+    // import, en silencio y distinto por idioma.
+    const colisiones: string[] = [];
+    for (const locale of LOCALES) {
+      const origen = new Map<string, string>();
+      const errorNs = NAMESPACES.filter((ns) => ns.startsWith(ASYMMETRY_ALLOWED_PREFIX));
+      for (const ns of [...errorNs, 'errors']) {
+        for (const k of keysOf(locale, ns)) {
+          const previo = origen.get(k);
+          if (previo) colisiones.push(`${locale}: ${k} en ${previo} y en ${ns}`);
+          else origen.set(k, ns);
+        }
+      }
+    }
+    expect(colisiones, `codes duplicados:\n  ${colisiones.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/access-groups.ts
+++ b/apps/web/src/lib/access-groups.ts
@@ -9,12 +9,6 @@ import { apiFetch } from './api-client';
 
 export type AccessGroupKind = 'ALL_COURSES' | 'COURSE' | 'MULTI_COURSE';
 
-export const ACCESS_GROUP_KIND_LABELS: Record<AccessGroupKind, string> = {
-  ALL_COURSES: 'Todos los cursos',
-  COURSE: 'Un curso',
-  MULTI_COURSE: 'Varios cursos',
-};
-
 export interface AccessGroupListItem {
   id: string;
   slug: string;

--- a/apps/web/src/lib/admin-api-keys.ts
+++ b/apps/web/src/lib/admin-api-keys.ts
@@ -11,12 +11,6 @@ import { apiFetch } from './api-client';
 export const API_KEY_SCOPES = ['enrollments:write', 'courses:read', 'community:post'] as const;
 export type ApiKeyScope = (typeof API_KEY_SCOPES)[number];
 
-export const API_KEY_SCOPE_LABELS: Record<ApiKeyScope, string> = {
-  'enrollments:write': 'Inscribir y dar de baja alumnos (POST /inscribe, /inscribe/revoke)',
-  'courses:read': 'Listar cursos para mapear productos (GET /inscribe/courses)',
-  'community:post': 'Publicar en la comunidad como el dueño de la key (POST /community-api/posts)',
-};
-
 export interface TenantApiKey {
   id: string;
   name: string;

--- a/apps/web/src/lib/admin-images.ts
+++ b/apps/web/src/lib/admin-images.ts
@@ -46,15 +46,6 @@ export interface OptimizeOutcome {
   error?: string;
 }
 
-/** Etiqueta legible de cada fuente, en singular. */
-export const SOURCE_LABELS: Record<ImageSource, string> = {
-  avatar: 'Avatar',
-  curso: 'Portada de curso',
-  coleccion: 'Portada de recursos',
-  logo: 'Logo',
-  post: 'Imagen de un post',
-};
-
 export const adminImagesApi = {
   inventory(bearer: string): Promise<ImagesInventory> {
     return apiFetch<ImagesInventory>('/api/v1/admin/images/inventory', {}, bearer);

--- a/apps/web/src/lib/admin-license.ts
+++ b/apps/web/src/lib/admin-license.ts
@@ -67,12 +67,3 @@ export const adminLicenseApi = {
     );
   },
 };
-
-export const LICENSE_STATUS_LABEL: Record<AdminLicenseStatusDto['status'], string> = {
-  community: 'Community',
-  active: 'Activa',
-  grace: 'En periodo de gracia',
-  expired: 'Expirada',
-  invalid: 'Inválida',
-  dev: 'Dev bypass',
-};

--- a/apps/web/src/lib/admin-tenants.ts
+++ b/apps/web/src/lib/admin-tenants.ts
@@ -97,9 +97,3 @@ export const adminTenantsApi = {
     );
   },
 };
-
-export const STATUS_LABELS: Record<TenantStatus, string> = {
-  ACTIVE: 'Activo',
-  SUSPENDED: 'Suspendido',
-  ARCHIVED: 'Archivado',
-};

--- a/apps/web/src/lib/admin-users.ts
+++ b/apps/web/src/lib/admin-users.ts
@@ -19,21 +19,6 @@ export const ASSIGNABLE_ROLES = [
 
 export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
 
-export const ROLE_LABELS: Record<AssignableRole, string> = {
-  tenant_admin: 'Administrador',
-  formador: 'Formador',
-  alumno: 'Alumno',
-  auditor: 'Auditor',
-  empresa_manager: 'Gerente de empresa',
-};
-
-export const STATUS_LABELS: Record<UserStatus, string> = {
-  ACTIVE: 'Activo',
-  PENDING: 'Pendiente',
-  SUSPENDED: 'Suspendido',
-  DEACTIVATED: 'Desactivado',
-};
-
 export interface UserListItem {
   id: string;
   email: string;

--- a/apps/web/src/lib/catalog.ts
+++ b/apps/web/src/lib/catalog.ts
@@ -42,21 +42,10 @@ export interface CatalogCourse {
   options: CatalogOption[];
 }
 
-export interface PublicOffer {
-  forSale: boolean;
-  options: CatalogOption[];
-}
-
 // ── API ──────────────────────────────────────────────────────────────────────
 
 export async function getPublicCatalog(): Promise<{ courses: CatalogCourse[] }> {
   return apiFetch<{ courses: CatalogCourse[] }>(`${PUBLIC_BASE}/catalog`, { method: 'GET' });
-}
-
-export async function getPublicOffer(courseId: string): Promise<PublicOffer> {
-  return apiFetch<PublicOffer>(`${PUBLIC_BASE}/offer/${encodeURIComponent(courseId)}`, {
-    method: 'GET',
-  });
 }
 
 export async function startPublicCheckout(

--- a/apps/web/src/lib/dossier.ts
+++ b/apps/web/src/lib/dossier.ts
@@ -14,11 +14,6 @@
 
 import { apiFetch } from './api-client';
 import { authStorage } from './auth-storage';
-import {
-  formatCurrency,
-  formatDate as formatDateI18n,
-  formatDateTime as formatDateTimeI18n,
-} from './i18n/format';
 import type { Restriction } from './restrictions';
 
 export interface DossierOrder {
@@ -65,27 +60,6 @@ export interface DossierExternalOrder {
   daysToExpiry: number | null;
   products: string[];
 }
-
-/** Etiquetas de los tipos de derecho de acceso. Espejo de `KIND_LABELS` en la API. */
-export const ENTITLEMENT_LABELS: Record<string, string> = {
-  LIFETIME: 'Acceso permanente',
-  SUBSCRIPTION: 'Suscripción',
-  TIMED: 'Acceso con vigencia',
-  ONE_OFF: 'Compra suelta',
-  INFRA: 'Servicio',
-};
-
-/** Estados de WooCommerce en cristiano. */
-export const WOO_STATUS_LABELS: Record<string, string> = {
-  completed: 'Pagado',
-  processing: 'Pagado (en curso)',
-  refunded: 'Devuelto',
-  cancelled: 'Cancelado',
-  failed: 'Fallido',
-  pending: 'Pendiente de pago',
-  'on-hold': 'En espera',
-  'lead-magnet': 'Gratuito',
-};
 
 export interface UserDossier {
   identity: {
@@ -241,32 +215,3 @@ export const dossierApi = {
     );
   },
 };
-
-/** Céntimos → «119,00 €» en el locale activo. */
-export function formatMoney(cents: number | null, currency = 'eur'): string {
-  if (cents === null) return '—';
-  return formatCurrency(cents / 100, currency.toUpperCase());
-}
-
-/** «hace 3 meses», «hace 2 años»: la antigüedad se lee mejor que 847 días. */
-export function formatMembership(days: number): string {
-  if (days < 1) return 'hoy';
-  if (days === 1) return '1 día';
-  if (days < 30) return `${days} días`;
-  const months = Math.floor(days / 30);
-  if (months < 12) return months === 1 ? '1 mes' : `${months} meses`;
-  const years = Math.floor(days / 365);
-  const restMonths = Math.floor((days % 365) / 30);
-  const y = years === 1 ? '1 año' : `${years} años`;
-  return restMonths > 0 ? `${y} y ${restMonths} ${restMonths === 1 ? 'mes' : 'meses'}` : y;
-}
-
-export function formatDate(iso: string | null): string {
-  if (!iso) return '—';
-  return formatDateI18n(iso, { day: '2-digit', month: '2-digit', year: 'numeric' });
-}
-
-export function formatDateTime(iso: string | null): string {
-  if (!iso) return '—';
-  return formatDateTimeI18n(iso);
-}

--- a/apps/web/src/lib/inscripcion.ts
+++ b/apps/web/src/lib/inscripcion.ts
@@ -18,7 +18,7 @@
  *   3. Crear la solicitud con la evidencia que corresponda.
  */
 
-import { ApiHttpError, apiFetch } from './api-client';
+import { apiFetch } from './api-client';
 import type { RenewalTemplate } from './payment-connections';
 
 // ── Tipos de respuesta (según contrato del backend) ──────────────────────────
@@ -140,14 +140,6 @@ export function createInscripcion(input: CreateInscripcionInput): Promise<Create
     method: 'POST',
     body: JSON.stringify(input),
   });
-}
-
-/**
- * Traduce cualquier error a un mensaje legible para la UI. Centraliza el manejo
- * de `ApiHttpError` para que los componentes no repitan el `instanceof`.
- */
-export function inscripcionErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof ApiHttpError ? error.message : fallback;
 }
 
 // ── Panel ADMIN de solicitudes (autenticado) ─────────────────────────────────

--- a/apps/web/src/lib/membership.ts
+++ b/apps/web/src/lib/membership.ts
@@ -189,29 +189,3 @@ export function formatCents(
 ): string {
   return formatCentsI18n(cents, currency.toUpperCase(), opts);
 }
-
-/** Etiqueta de periodicidad: "/mes", "/trimestre", …, "/N meses". */
-export function intervalSuffix(intervalMonths: number): string {
-  if (intervalMonths === 12) return '/año';
-  if (intervalMonths === 6) return '/semestre';
-  if (intervalMonths === 3) return '/trimestre';
-  if (intervalMonths === 1) return '/mes';
-  return `/${intervalMonths} meses`;
-}
-
-/** Nombre largo: "Suscripción mensual/trimestral/…/cada N meses". */
-export function intervalDescription(intervalMonths: number): string {
-  if (intervalMonths === 12) return 'Suscripción anual';
-  if (intervalMonths === 6) return 'Suscripción semestral';
-  if (intervalMonths === 3) return 'Suscripción trimestral';
-  if (intervalMonths === 1) return 'Suscripción mensual';
-  return `Suscripción cada ${intervalMonths} meses`;
-}
-
-/** Fecha del próximo pago: hoy + trial + periodo. */
-export function nextPaymentDate(intervalMonths: number, trialDays: number): Date {
-  const d = new Date();
-  d.setDate(d.getDate() + trialDays);
-  d.setMonth(d.getMonth() + intervalMonths);
-  return d;
-}

--- a/apps/web/src/lib/referrals.ts
+++ b/apps/web/src/lib/referrals.ts
@@ -5,7 +5,6 @@
 
 import { ApiHttpError, apiFetch } from '@/lib/api-client';
 import { authStorage } from '@/lib/auth-storage';
-import { formatCents } from '@/lib/i18n/format';
 
 /**
  * Client de mod.referrals: área del miembro (/referidos), captura del enlace
@@ -216,15 +215,3 @@ export const referralsAdminApi = {
     );
   },
 };
-
-/**
- * Céntimos → importe en el LOCALE ACTIVO ("12,34 €" / "$12.34").
- *
- * Delega en la conversión canónica de `@/lib/i18n/format`, que además quita los
- * decimales cuando la cantidad es redonda: una comisión de 1900 céntimos pasa
- * de «19,00 €» a «19 €». Es un cambio VISIBLE y deliberado (decisión 16 del
- * plan de i18n): la regla de decimales del producto vive en un único sitio.
- */
-export function formatReferralCents(cents: number, currency = 'eur'): string {
-  return formatCents(cents, currency.toUpperCase());
-}

--- a/apps/web/src/lib/restrictions.ts
+++ b/apps/web/src/lib/restrictions.ts
@@ -16,24 +16,30 @@
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from './api-client';
 import { authStorage } from './auth-storage';
-import { formatDate } from './i18n/format';
 
-/** Mismas claves que `restriction-scopes.ts` en la API. */
+/**
+ * Mismas claves que `restriction-scopes.ts` en la API. Solo el `value`: el texto
+ * de cada ámbito lo pone el llamante desde el catálogo
+ * (`restrictionScope.*` / `restrictionScopeHint.*`).
+ */
 export const RESTRICTION_SCOPES = [
-  { value: 'community', label: 'Comunidad', hint: 'Publicar, comentar y reaccionar' },
-  { value: 'messaging', label: 'Mensajes', hint: 'Escribir en chats y abrir conversaciones' },
-  { value: 'uploads', label: 'Subidas de archivos', hint: 'Subir imágenes y recursos' },
-  { value: 'ai', label: 'Tutor IA', hint: 'Hacer preguntas al tutor' },
+  { value: 'community' },
+  { value: 'messaging' },
+  { value: 'uploads' },
+  { value: 'ai' },
 ] as const;
 
 export const SCOPE_ALL = 'all';
 
-/** Duraciones del diálogo. `null` = permanente. */
+/**
+ * Duraciones del diálogo. `null` = permanente. El texto sale de
+ * `restrictionDuration.*`, no de aquí.
+ */
 export const RESTRICTION_DURATIONS = [
-  { value: '24h', label: '24 horas', hours: 24 },
-  { value: '7d', label: '7 días', hours: 24 * 7 },
-  { value: '30d', label: '30 días', hours: 24 * 30 },
-  { value: 'permanent', label: 'Permanente', hours: null },
+  { value: '24h', hours: 24 },
+  { value: '7d', hours: 24 * 7 },
+  { value: '30d', hours: 24 * 30 },
+  { value: 'permanent', hours: null },
 ] as const;
 
 export type DurationValue = (typeof RESTRICTION_DURATIONS)[number]['value'];
@@ -208,50 +214,9 @@ export function useUserRestriction(
   return value;
 }
 
-/**
- * Hook: sanciones vigentes de una lista de usuarios (batch + caché).
- * Para páginas que ya tienen todos los ids a mano (listados de admin).
- */
-export function useActiveRestrictions(
-  ids: Array<string | null | undefined>,
-  enabled: boolean,
-): Map<string, ActiveRestrictionSummary | null> {
-  const key = [...new Set(ids.filter((x): x is string => !!x))].sort().join(',');
-  const [map, setMap] = useState<Map<string, ActiveRestrictionSummary | null>>(new Map());
-
-  const load = useCallback(() => {
-    if (!enabled || !key) {
-      setMap(new Map());
-      return;
-    }
-    void fetchActiveRestrictions(key.split(',')).then(setMap);
-  }, [key, enabled]);
-
-  useEffect(() => {
-    load();
-    listeners.add(load);
-    return () => {
-      listeners.delete(load);
-    };
-  }, [load]);
-
-  return map;
-}
-
 /** Convierte la duración elegida en el ISO que espera la API. */
 export function expiresAtFromDuration(duration: DurationValue): string | null {
   const found = RESTRICTION_DURATIONS.find((d) => d.value === duration);
   if (!found || found.hours === null) return null;
   return new Date(Date.now() + found.hours * 3600_000).toISOString();
-}
-
-/** Texto corto de vigencia para listas y tooltips. */
-export function restrictionSummary(r: Restriction): string {
-  const areas = r.scopeLabels.join(', ');
-  if (!r.expiresAt) return `${areas} · permanente`;
-  return `${areas} · hasta ${formatDate(r.expiresAt, {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  })}`;
 }

--- a/apps/web/src/lib/sso-saml.ts
+++ b/apps/web/src/lib/sso-saml.ts
@@ -79,10 +79,6 @@ export type SamlConnectionProbe =
     }
   | { ok: false; error: string };
 
-export interface SamlStatusResponse {
-  enabled: boolean;
-}
-
 const ADMIN_BASE = '/api/v1/admin/sso/saml';
 
 export const samlAdminApi = {
@@ -114,17 +110,6 @@ export const samlAdminApi = {
     );
   },
 };
-
-export async function fetchSamlStatus(tenantSlug: string): Promise<SamlStatusResponse> {
-  try {
-    return await apiFetch<SamlStatusResponse>(
-      `/api/v1/auth/saml/${encodeURIComponent(tenantSlug)}/status`,
-      { method: 'GET' },
-    );
-  } catch {
-    return { enabled: false };
-  }
-}
 
 /**
  * URL completa para iniciar el flow SAML. El click del botón de signin hace

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,10 +58,11 @@ export default [
   // Prohíbe formateo con locale cableado fuera de los helpers de
   // `apps/web/src/lib/i18n/**` (único sitio permitido para toLocale*/Intl.*).
   //
-  // RATCHET: los ficheros de `ignores` son los que YA tenían formateo cableado
-  // antes del guardarraíl; cada unidad de la migración i18n limpia los suyos y
-  // la lista se borra en el commit de integración (quedará solo lib/i18n y
-  // wall-time.ts, que usa Intl para CÁLCULO de fechas, no presentación).
+  // RATCHET CERRADO: la lista de `ignores` contenía los ficheros que aún tenían
+  // formateo cableado cuando se puso el guardarraíl. Todos migrados; solo quedan
+  // las dos exclusiones permanentes (los helpers y wall-time.ts, que usa Intl
+  // para CÁLCULO de fechas, no para presentación). No añadir entradas nuevas:
+  // el guardarraíl es la razón de existir de este bloque.
   //
   // Necesita el parser de TS: el flat config base usa espree y no parsea TSX.
   // Las reglas de espree que tsc ya cubre se apagan (no-undef con tipos, etc.)
@@ -70,79 +71,10 @@ export default [
   {
     files: ['apps/web/src/**/*.{ts,tsx}'],
     ignores: [
+      // Los propios helpers: son el único sitio donde Intl.*/toLocale* es legal.
       'apps/web/src/lib/i18n/**',
-      'apps/web/src/app/(app)/admin/api-keys/page.tsx',
-      'apps/web/src/app/(app)/admin/auditoria/page.tsx',
-      'apps/web/src/app/(app)/admin/avisos/page.tsx',
-      'apps/web/src/app/(app)/admin/billing/products/page.tsx',
-      'apps/web/src/app/(app)/admin/comunidad/publicaciones-api/page.tsx',
-      'apps/web/src/app/(app)/admin/configuracion/page.tsx',
-      'apps/web/src/app/(app)/admin/dominios/page.tsx',
-      'apps/web/src/app/(app)/admin/encuestas/page.tsx',
-      'apps/web/src/app/(app)/admin/fundae/empresas/\\[id\\]/page.tsx',
-      'apps/web/src/app/(app)/admin/fundae/grupos/page.tsx',
-      'apps/web/src/app/(app)/admin/gamificacion/page.tsx',
-      'apps/web/src/app/(app)/admin/integraciones/payment-connections/page.tsx',
-      'apps/web/src/app/(app)/admin/integraciones/payment-connections/subscriptions-dashboard.tsx',
-      'apps/web/src/app/(app)/admin/invitaciones/page.tsx',
-      'apps/web/src/app/(app)/admin/licencia/page.tsx',
-      'apps/web/src/app/(app)/admin/marketplace/page.tsx',
-      'apps/web/src/app/(app)/admin/modules/\\[name\\]/page.tsx',
-      'apps/web/src/app/(app)/admin/referidos/page.tsx',
-      'apps/web/src/app/(app)/admin/scim/page.tsx',
-      'apps/web/src/app/(app)/admin/seguridad/page.tsx',
-      'apps/web/src/app/(app)/admin/solicitudes-miembros/page.tsx',
-      'apps/web/src/app/(app)/admin/tenants/\\[id\\]/page.tsx',
-      'apps/web/src/app/(app)/admin/usuarios/page.tsx',
-      'apps/web/src/app/(app)/admin/webhooks/page.tsx',
-      'apps/web/src/app/(app)/calendario/eventos-view.tsx',
-      'apps/web/src/app/(app)/calendario/page.tsx',
-      'apps/web/src/app/(app)/clase/\\[id\\]/page.tsx',
-      'apps/web/src/app/(app)/comunidad/menciones/page.tsx',
-      'apps/web/src/app/(app)/cuenta/page.tsx',
-      'apps/web/src/app/(app)/cursos/\\[slug\\]/page.tsx',
-      'apps/web/src/app/(app)/formador/aula-virtual/page.tsx',
-      'apps/web/src/app/(app)/formador/correcciones/\\[id\\]/page.tsx',
-      'apps/web/src/app/(app)/formador/correcciones/page.tsx',
-      'apps/web/src/app/(app)/formador/cursos/\\[id\\]/alumnos/\\[enrollmentId\\]/page.tsx',
-      'apps/web/src/app/(app)/formador/cursos/\\[id\\]/alumnos/page.tsx',
-      'apps/web/src/app/(app)/formador/cursos/\\[id\\]/invitations-panel.tsx',
-      'apps/web/src/app/(app)/formador/cursos/\\[id\\]/lesson-content-editor.tsx',
-      'apps/web/src/app/(app)/formador/cursos/page.tsx',
-      'apps/web/src/app/(app)/leaderboard/page.tsx',
-      'apps/web/src/app/(app)/mis-certificados/page.tsx',
-      'apps/web/src/app/(app)/notificaciones/page.tsx',
-      'apps/web/src/app/(app)/referidos/page.tsx',
-      'apps/web/src/app/(app)/retos/page.tsx',
-      'apps/web/src/app/(public)/verificar/\\[id\\]/page.tsx',
-      'apps/web/src/app/(venta)/unete/unete-view.tsx',
-      'apps/web/src/components/account-security-tab.tsx',
-      'apps/web/src/components/admin/business-metrics-panel.tsx',
-      'apps/web/src/components/admin/smtp-settings-card.tsx',
-      'apps/web/src/components/admin/stripe-settings-card.tsx',
-      'apps/web/src/components/admin/zoom-webhook-events-tab.tsx',
-      'apps/web/src/components/clase-embed-card.tsx',
-      'apps/web/src/components/community-thread-card.tsx',
-      'apps/web/src/components/community-upcoming-card.tsx',
-      'apps/web/src/components/lesson-comments.tsx',
-      'apps/web/src/components/pending-comments-queue.tsx',
-      'apps/web/src/components/post-detail-view.tsx',
-      'apps/web/src/components/quiz-player.tsx',
-      'apps/web/src/components/restriction-shield.tsx',
-      'apps/web/src/components/subscription-tab.tsx',
-      'apps/web/src/components/user-dossier.tsx',
-      'apps/web/src/lib/dossier.ts',
-      'apps/web/src/lib/membership.ts',
-      'apps/web/src/lib/payment-connections.ts',
-      'apps/web/src/lib/referrals.ts',
-      'apps/web/src/lib/restrictions.ts',
-      'apps/web/src/modules/ai-tutor/admin-correcciones.tsx',
-      'apps/web/src/modules/ai-tutor/admin-informe.tsx',
-      'apps/web/src/modules/ai-tutor/admin-revision.tsx',
-      'apps/web/src/modules/billing/client.ts',
-      'apps/web/src/modules/fundae/companies-client.ts',
-      'apps/web/src/modules/messaging/shared.ts',
-      'apps/web/src/modules/subscriptions/client.ts',
+      // Intl.DateTimeFormat para CÁLCULO de wall-time en una zona horaria, no
+      // para presentación. Exclusión intencionada y permanente.
       'apps/web/src/modules/zoom-live/wall-time.ts',
     ],
     languageOptions: { parser: tseslint.parser },


### PR DESCRIPTION
Vía C de la Sesión I. Cinco encargos independientes sobre `chore/retomada-faircode` (base `83f06547`). Sin tocar `apps/e2e/**`, `.github/workflows/**`, `packages/database/prisma/seed.sql`, los compose de test, `lib/i18n/api-error.ts`, `lib/api-client.ts`, `errorsApi*.json` ni `apps/api/src/**`.

---

## 1 · Mínimo público restaurado

**Antes:** `2b014ee6` sacó del árbol 55 ficheros a `.fueradegit/` (ignorado). El repo público no declaraba README, licencia legible, política de seguridad, guía de contribución, código de conducta, marca, uso comercial ni plantillas de issue.

**Después:** vuelven los 7 markdown y las 4 plantillas, **y ninguno enlaza a algo que ya no existe**.

| Fichero | Enlace muerto | A dónde apunta ahora |
|---|---|---|
| `README.md` :17 | `docs/INSTALL.md`, `docs/UPGRADE.md`, `docs/versioning.md` | https://didacta.io/docs |
| `README.md` :113 | «el quickstart es, por ahora, el manual de instalación de referencia» (ya no es cierto) | frase reescrita + https://didacta.io/docs |
| `README.md` :236 | `CHANGELOG.md` | https://github.com/va360labs/didacta-io/releases |
| `README.md` §Documentación | — | entrada nueva a https://didacta.io/docs (es/en) |
| `CONTRIBUTING.md` :114 | `CONTRIBUTORS.md` | notas de publicación + lista de contribuidores de GitHub |
| `SECURITY.md` :54 | `SECURITY-CREDITS.md` sin contexto | se declara que nace con el primer reporte acreditado (como ya hacía :14) |
| `.github/ISSUE_TEMPLATE/bug.yml` :11 y `config.yml` :4 | `https://docs.didacta.io/comunidad/reportar-un-error/` | https://didacta.io/docs |

Los otros 4 markdown (`LICENSE_NOTICE`, `COMMERCIAL_USE`, `TRADEMARKS`, `CODE_OF_CONDUCT`) se revisaron uno a uno: sus únicas referencias a ficheros son `LICENSE`, `LICENSE_EE` y `TRADEMARKS.md`, los tres vivos. `feature.yml` y `feedback.yml` no tienen enlaces.

**Decisión del último punto, por si se quiere revertir:** `docs.didacta.io` no es un enlace a fichero del repo, así que técnicamente estaba fuera del criterio. Lo he redirigido igualmente porque el DNS de ese host no está publicado (el sitio de documentación se sirve desde `didacta.io/docs`, que es la URL que ya usan `release.yml:173`, `infra/docker/entrypoint.sh:15,102` y `apps/api/src/scim/scim.controller.ts:100,113`). Un enlace muerto en la plantilla de bug es lo primero que ve un tester.

**Se queda fuera a propósito:** `docs/` entero, los 37 README de `apps/`/`modules/`/`packages/`/`infra/`/`scripts/`, `CHANGELOG.md`, `CONTRIBUTORS.md` y `CLAUDE.md`. `scripts/module-doctor.ts` sigue sin exigir README por módulo (**0 errores / 0 warnings sobre 24 módulos**). `LICENSE` y `LICENSE_EE` intactos.

**Config:** `.gitignore`, `.prettierignore` y `eslint.config.mjs` no bloqueaban nada de lo restaurado — prettier formatea los 7 markdown y las 4 plantillas sin más cambios. Lo único tocado es el **comentario** de `.gitignore` sobre `.fueradegit/`, que decía que el repo versiona «SOLO lo necesario para construir y ejecutar» y ya no es verdad. El `.claude/` del `.gitignore` se conserva.

---

## 2 · Ratchet i18n de `eslint.config.mjs` vaciado

**Antes:** 74 entradas en `ignores` del bloque que prohíbe `toLocale*` / `Intl.*` fuera de `lib/i18n`.
**Después:** 2.

```js
ignores: [
  'apps/web/src/lib/i18n/**',                    // los propios helpers
  'apps/web/src/modules/zoom-live/wall-time.ts', // Intl para CÁLCULO, no presentación
],
```

**Salieron las 72 restantes y ninguna volvió a entrar**: `eslint . --max-warnings=0` sigue en **0**. No hubo que investigar ningún fichero: todos estaban migrados de verdad.

**Trampa de `user-dossier.tsx` comprobada antes de tocar nada.** El aviso estaba invertido respecto al fichero real: en este `eslint.config.mjs` el bloque que registra `react-hooks` es **el mismo** que lleva la lista, así que *sacar* un fichero de `ignores` lo mete bajo el plugin, no al revés — la dirección peligrosa sería añadirlo. Y aun así: grep de `react-hooks` sobre `apps/web/src` da 51 ficheros con `eslint-disable-next-line react-hooks/exhaustive-deps`, y **`user-dossier.tsx` no está entre ellos**. Sin directiva, no hay regla sin definir que romper.

El comentario del bloque pasa de «RATCHET … la lista se borra en el commit de integración» a «RATCHET CERRADO … no añadir entradas nuevas».

---

## 3 · Exports muertos borrados

Verificado **consumidor por consumidor con grep** sobre todo el repo (incluidos `apps/e2e`, `modules/` y `packages/`) antes de cada borrado, más un barrido automático de todos los símbolos exportados de `apps/web/src/lib/**` contra el resto del árbol.

### Los 13 huérfanos de la migración (tabla del PR #28)

Cada pantalla migrada reimplementó en local, con `t`, el diccionario que antes importaba. El original —español cableado— quedó exportado y sin llamantes.

| Export | Fichero | Prueba de que no tenía consumidor |
|---|---|---|
| `LICENSE_STATUS_LABEL` | `lib/admin-license.ts:71` | único hit del grep = la definición |
| `STATUS_LABELS` | `lib/admin-tenants.ts:101` | los otros hits son `modules/fundae/groups-client.ts` (otro símbolo) y `lib/admin-users.ts` |
| `ROLE_LABELS` | `lib/admin-users.ts:22` | el otro hit es un `const` **local** en `app/(app)/miembros/page.tsx:38` |
| `STATUS_LABELS` | `lib/admin-users.ts:30` | ídem |
| `SOURCE_LABELS` | `lib/admin-images.ts:50` | único hit = la definición (`ImageSource` sí sigue vivo) |
| `API_KEY_SCOPE_LABELS` | `lib/admin-api-keys.ts:14` | único hit = la definición |
| `ACCESS_GROUP_KIND_LABELS` | `lib/access-groups.ts:12` | único hit = la definición |
| `ENTITLEMENT_LABELS`, `WOO_STATUS_LABELS`, `formatMoney`, `formatMembership`, `formatDate`, `formatDateTime` | `lib/dossier.ts` | `user-dossier.tsx` solo importa `dossierApi` y `type UserDossier` (línea 31); tiene sus propias copias con `t` en :55, :60, :66, :72 |
| `intervalSuffix`, `intervalDescription` | `lib/membership.ts:194,203` | `unete-view.tsx:55,64` define `intervalSuffixLabel`/`intervalDescriptionLabel` propias; `admin/membresia/page.tsx:192` lo dice en un comentario («antes `intervalDescription`») |
| `formatReferralCents` | `lib/referrals.ts:228` | los 2 hits restantes son comentarios (`lib/i18n/format.ts:99`, `admin/referidos/page.tsx:77`) |
| `restrictionSummary` | `lib/restrictions.ts:249` | 0 consumidores ya en el PR #28 |
| `label` / `hint` de `RESTRICTION_SCOPES` y `label` de `RESTRICTION_DURATIONS` | `lib/restrictions.ts:22-37` | `restriction-shield.tsx` pinta `t('restrictionScope.*')`, `t('restrictionScopeHint.*')` y `t('restrictionDuration.*')` (:274, :276, :315); del array solo usa `value` y `hours` |

### Vestigios sin consumidor que arrastraba el mismo barrido (5)

| Export | Fichero | Nota |
|---|---|---|
| `inscripcionErrorMessage` | `lib/inscripcion.ts:149` | lo sustituyó `apiErrorMessage`; el `import { ApiHttpError }` quedaba huérfano y también sale |
| `nextPaymentDate` | `lib/membership.ts:212` | 0 hits fuera de su línea |
| `getPublicOffer` + `PublicOffer` | `lib/catalog.ts:56,45` | el tipo solo lo usaba esa función |
| `useActiveRestrictions` | `lib/restrictions.ts:215` | `useUserRestriction` sí está vivo; el hook batch nunca se usó. El `import { formatDate }` quedaba huérfano y también sale |
| `fetchSamlStatus` + `SamlStatusResponse` | `lib/sso-saml.ts:118,82` | el tipo solo lo usaba esa función |

### `useState` de `initialized` — `components/module-runtime-provider.tsx`

Se escribía en tres sitios (`:50`, `:54` y el `useState` inicial) y no se leía en ninguno: el `return` pintaba `children` igual antes y después. Eliminado junto con la rama `typeof window === 'undefined'`, que devolvía exactamente lo mismo que el camino normal. El comentario deja escrito que si algún día hay que bloquear el árbol, el estado hay que reintroducirlo **y usarlo en el return**.

### Lo que NO he borrado, con motivo

El criterio pedía «cero exports sin consumidores en `apps/web/src/lib/**`». Quedan **5**, y los dejo con razón, no por descuido:

| Export | Fichero | Por qué se queda |
|---|---|---|
| `APP_CHANNEL` | `lib/version.ts:26` | uso futuro **declarado en el propio comentario** («cuando hagamos beta/stable, pista visual del banner del sidebar»). Borrarlo es una decisión de producto, no limpieza de i18n |
| `invalidateModuleUICache`, `isModuleUILoaded` | `lib/module-loader.ts:210,226` | API documentada del caché de módulos dinámicos («útil tras actualización»). El flujo de instalación desde marketplace es su llamante natural |
| `communityPostsApi` | `lib/community-posts.ts:30` | **el fichero entero está muerto** (`CommunityPost` tampoco se usa fuera). Borrar módulos completos de cliente HTTP es decisión de producto y roza el trabajo del otro worker |
| `communityStatsApi` | `lib/community-stats.ts:35` | ídem (`CommunityStats`, `CommunityMember`, `PaginatedMembers` tampoco tienen consumidores) |

Los tipos exportados que solo se usan dentro de su propio fichero (≈110 interfaces de request/response) **no** cuentan como muertos: son la firma pública de cada cliente HTTP y están consumidos estructuralmente por las funciones que los devuelven.

---

## 4 · MUST-FIX 19 — `relTime` con `t` obligatorio

**Antes** (`components/community-thread-card.tsx:41`):

```ts
export function relTime(iso: string, t?: TranslatorLike): string {
  …
  if (!t) {
    if (diff < 60) return 'ahora';
    if (diff < 3600) return `hace ${minutes}m`;
    if (diff < 86400) return `hace ${hours}h`;
    return `hace ${days}d`;
  }
  …
}
```

**Después:** `t: TranslatorLike` obligatorio y la rama española borrada entera.

**Grep de consumidores antes de tocar**, sobre todo el repo: quedan **dos**, los dos pasando `t` y los dos con `useTranslations('comunidadComponentes')`, que es donde viven `relTimeNow` / `relTimeMinutes` / `relTimeHours` / `relTimeDays`:

- `community-thread-card.tsx:143` — `relTime(post.createdAt, t)`
- `community-gallery-modal.tsx:235` — `relTime(a.createdAt, t)` (`t` de :58)

`modules/messaging` —la razón original del `t?`— estrenó su propia `relTime` con `t` obligatorio en `modules/messaging/shared.ts:49` y ya no importa esta. Las otras 4 copias de `relTime` del repo (`post-detail-view.tsx:958`, `pending-comments-queue.tsx:162`, `lesson-comments.tsx:234`, `account-security-tab.tsx:361`, `comunidad/menciones/page.tsx:29`) son locales y ya tenían `t` obligatorio.

Como ningún llamante pasaba por el fallback, **el español no cambia** y desaparece la posibilidad de que el inglés degrade en silencio.

---

## 5 · Test genérico de paridad es↔en

Nuevo: `apps/web/src/i18n/messages-parity.test.ts` (9 tests). Recorre los **43 namespaces** leyendo del **disco**, no del `index.ts`, para que un namespace nuevo entre en la guarda el día que se crea el JSON.

### Mecanismo

Dos reglas asimétricas a propósito:

1. **Key solo en ES → fallo siempre.** Sin lista, sin excepciones. Hoy hay **0**.
2. **Key solo en EN → fallo salvo declaración explícita** en `EN_ONLY_BY_DESIGN`, y solo en namespaces `errorsApi*` (hay un test que lo comprueba: declarar asimetría en cualquier otro namespace es fallo).

La declaración son **174 codes enumerados uno a uno**, agrupados por namespace y ordenados alfabéticamente para que añadir o quitar uno sea un diff de una línea. **No es un `skip` sobre `errorsApi*`**: la lista se valida en los dos sentidos, así que rompe la CI tanto un code nuevo solo-EN sin declarar (test *«toda key solo-EN está declarada como deliberada»*) como una entrada declarada que ya no es asimétrica —porque se arregló o porque se borró— (test *«toda entrada declarada sigue siendo realmente asimétrica»*).

Reparto de los 174: `errorsApiModulesB` 103, `errorsApiModulesA` 32, `errorsApiResto` 28, `errorsApiAdmin` 7, `errorsApiAuthSso` 4.

### Por qué esa asimetría es legítima (queda escrito en la cabecera del test)

El backend no traduce (D6): manda `code` + `message` español. `apiErrorMessage` traduce por `code` **solo si la key existe**; si no, cae al `message` crudo. Cuando el mensaje del backend lleva dentro un diagnóstico real (nombre del curso, error del MTA, respuesta de Stripe), el catálogo ES **se calla a propósito** para que el detalle llegue entero; el EN sí lleva redacción genérica porque, sin key, el anglófono vería español.

### Qué deja fuera, nombrándolo

El test **no** valida la calidad de esa redacción inglesa. Los **30 codes pendientes** cuya traducción EN se traga el dato interpolado (de los 32 del barrido; 2 cerrados en el PR #34: `ADMIN_STRIPE_KEY_REJECTED` y `ADMIN_SMTP_TEST_FAILED`, que hoy interpolan `{detail}` y tienen test propio en `lib/i18n/api-error.test.ts`) **están dentro de la lista de 174**: el test los da por *conocidos*, no por *correctos*, y la cabecera lo dice con esas palabras y con la receta (moverlos al patrón `{detail}` de `CODES_WITH_DETAIL` y sacarlos de la lista — momento en el que este mismo test los exigirá). No hay verde fingido: siguen siendo 30 líneas visibles en un fichero versionado.

### Dos guardas extra, ambas verdes hoy

- **Ningún valor vacío** en ninguno de los dos idiomas (0 hits sobre 43×2 ficheros).
- **Ningún code definido en dos `errorsApi*` a la vez** (301 codes ES, 475 EN, 0 colisiones). Los cinco ficheros se funden bajo el namespace `errors` en `messages/<locale>/index.ts`: un duplicado lo resolvería el orden de los imports, en silencio y **distinto por idioma**.

### Smoke test del guardarraíl

Antes de dar el test por bueno lo tumbé a propósito: quitando `ADMIN_ROLE_NOT_FOUND` de la lista, falla con `errorsApiAdmin.ADMIN_ROLE_NOT_FOUND` nombrado en el mensaje. Revertido.

---

## Verificación

| Comando | Resultado |
|---|---|
| `pnpm install --frozen-lockfile` | OK |
| `prisma generate` | OK |
| `tsc` de los 5 `packages/*` | OK, 0 errores |
| `dev-check.sh --format-fix` | OK · prettier --write |
| `dev-check.sh --quick` | OK · typecheck api + typecheck web + eslint `--max-warnings=0` + prettier --check |
| `vitest run` en `apps/web` | **37 ficheros · 329 tests · todos verdes** (baseline 320, +9 del test nuevo) |
| `scripts/ee-fence.ts` | 1388 ficheros, **0 violaciones** |
| `scripts/module-doctor.ts` | **0 errores / 0 warnings** sobre 24 módulos |
| `vitest` en `apps/api` | no ejecutado: el diff no toca `apps/api/**`, `modules/**` ni `packages/**` |
| E2E | **SKIP** — la suite la lleva el otro worker |

---

## Hallazgos que NO he tocado

1. **`lib/community-posts.ts` y `lib/community-stats.ts` están muertos enteros.** Ningún símbolo de ninguno de los dos tiene consumidor. Son clientes HTTP contra endpoints que sí existen en la API; borrar los ficheros es una decisión de producto (¿pantallas planeadas o restos?), no limpieza de i18n.
2. **`lib/version.ts` — `APP_VERSION = '0.0.1-alpha.88'`.** Está 13 versiones por detrás de la última publicada (`alpha.101`, la que documenta el README). El propio comentario avisa de que hay que actualizarla **antes** del build o el pie del sidebar miente. Fuera de estos 5 encargos, pero es texto que ve el operador.
3. **`SECURITY.md:39`** habla de «alpha cerrada»; el repo va a ser público. Copy que conviene revisar antes del flip, junto con el `#didacta-alpha` de Discord que citan `CONTRIBUTING.md:118` y `CODE_OF_CONDUCT.md:61` — si esos canales no existen todavía, son promesas incumplidas en la primera página que lee un contribuidor.
4. **`README.md:126,144`** fija `0.0.1-alpha.101` a mano en dos bloques `docker pull` / `docker run`. Se desincronizará con el siguiente release; merecería un placeholder `<versión>` como el del Camino A (:26).
5. **`modules/fundae/groups-client.ts:271,278,284`** (`STATUS_LABELS`, `TIPO_LABELS`, `MODALIDAD_LABELS`) siguen exportando español cableado, y `modules/fundae/index.ts:60` los reexporta. Están **fuera de mi frontera** (`apps/web/src/modules/**`). Su consumidor `admin/fundae/grupos/page.tsx` ya traduce en la página, así que hoy son datos muertos: mismo caso que los 13 borrados aquí, en el módulo de al lado.
6. **`modules/subscriptions/client.ts:156` — `formatInterval`.** Misma situación: el PR #28 lo daba por muerto tras W15 y `components/subscription-tab.tsx` ya no lo importa. Fuera de frontera.
7. **Cobertura de `apps/web`** tiene umbral del 70% pero solo sobre `src/i18n/**` y `src/lib/i18n/**` (`vitest.config.ts:20`), con `**/messages/**` excluido. El test nuevo vive en `src/i18n/` y entra en ese scope; no he tocado la config.
