### PR TITLE
fix(e2e): el arnés levanta el producto entero — de 25 rojos a 7 flaky con causa trazada

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,28 @@ name: E2E
 # E2E con Playwright se corre en local sobre Docker Desktop antes de mergear
 # Este workflow queda como `workflow_dispatch`
 # para poder lanzarlo manualmente si se quiere validar en runner Linux real.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# El arnés (infra, entorno y preparación de la base) vive en `scripts/`, NO en
+# este fichero:
+#
+#   scripts/e2e-env.sh    → única fuente de verdad de las variables
+#   scripts/e2e-stack.sh  → docker compose, esquema, seeds y arranque
+#   apps/e2e/global-setup → verifica que el producto está entero antes de correr
+#
+# Antes cada job repetía la lista de variables a mano y la receta de arranque
+# estaba duplicada entre aquí y la documentación local. Ninguna de las dos
+# copias levantaba el producto completo: faltaban los espacios de sistema de
+# `prisma/seed.sql`, el onboarding del admin sembrado, Redis (la mensajería
+# realtime degradaba a no-op silencioso) y los secretos de los webhooks de
+# pago. Eso son decenas de tests en rojo que parecen bugs de producto.
+#
+# La infraestructura es `docker-compose.test.yml`, el MISMO compose que en
+# local: mismos puertos, mismo usuario/base y —clave— mismos NOMBRES de
+# contenedor, que es lo que necesita `catalogo-publico.spec.ts` para su
+# `docker exec … psql`. Con los `services:` de Actions ese nombre es
+# autogenerado y el spec no podía funcionar.
+# ─────────────────────────────────────────────────────────────────────────────
 
 on:
   workflow_dispatch:
@@ -19,55 +41,7 @@ jobs:
   e2e:
     name: Playwright golden path
     runs-on: ubuntu-latest
-    timeout-minutes: 25
-
-    services:
-      postgres:
-        # pgvector, no postgres:16 a secas: la migración baseline hace
-        # CREATE EXTENSION vector y falla con P3018 sin ella. Misma imagen
-        # que docker-compose.alpha.yml (instalación de referencia).
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_USER: didacta
-          POSTGRES_PASSWORD: didacta
-          POSTGRES_DB: didacta
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
-    env:
-      DATABASE_URL: postgresql://didacta:didacta@localhost:5432/didacta?schema=public
-      JWT_SECRET: e2e-test-secret-must-be-at-least-32-chars-long-aaaa
-      JWT_REFRESH_SECRET: e2e-refresh-secret-must-be-32-chars-long-bbbb
-      # AUTH_SECRET es el nombre canónico que lee apps/api/src/auth/auth.config.ts
-      # (mín. 32 caracteres). El api falla a bootear sin esta env.
-      AUTH_SECRET: e2e-auth-secret-must-be-at-least-32-chars-long-cccc
-      AUTH_URL: http://localhost:4000
-      # Master key AES-256-GCM (64 chars hex) para TenantSettings cifrado.
-      # Obligatoria en NODE_ENV=production desde el PR A0; sin ella el api no
-      # bootea. En CI usamos un valor determinístico — no es secreto real.
-      TENANT_SETTINGS_ENC_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
-      NODE_ENV: production
-      # El registro público está cerrado por defecto (ver auth.service). Los
-      # specs E2E lo usan para fabricar usuarios de prueba → se reabre solo aquí.
-      AUTH_SIGNUP_ENABLED: 'true'
-      PORT: 4000
-      API_INTERNAL_URL: http://localhost:4000
-      BOOTSTRAP_PASSWORD: E2eAdminPassword123!
-      BOOTSTRAP_EMAIL: e2e-admin@example.test
-      BOOTSTRAP_TENANT_SLUG: demo
-      # El puerto real de `next start` está fijo en el script (`-p 3010`, ver
-      # apps/web/package.json) — PORT no lo cambia. E2E_BASE_URL/E2E_API_URL
-      # tienen que apuntar ahí (mismo criterio que el job "setup-wizard").
-      E2E_BASE_URL: http://localhost:3010
-      E2E_API_URL: http://localhost:3010
-      E2E_TENANT_SLUG: demo
-      E2E_ADMIN_EMAIL: e2e-admin@example.test
-      E2E_ADMIN_PASSWORD: E2eAdminPassword123!
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -84,58 +58,26 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Cargar el entorno canónico del arnés
+        run: bash scripts/e2e-env.sh --github-env >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
         run: pnpm --filter @didacta/database db:generate
 
-      - name: Apply migrations
-        run: pnpm --filter @didacta/database db:migrate:deploy
+      - name: Levantar la infra de test (postgres + redis)
+        run: bash scripts/e2e-stack.sh up
 
-      - name: Aplicar políticas RLS y roles de runtime (didacta_app/didacta_super)
-        run: |
-          # Desde RLS F3 el boot de la API hace `SET LOCAL ROLE didacta_super`
-          # para el acceso global sancionado (ver tenant-context.storage.ts) —
-          # ese rol solo existe tras correr grants.sql. Mismo paso que
-          # infra/docker/entrypoint.sh#run_migrations y que el job
-          # "setup-wizard" de este mismo archivo, sin el cual la API no llega
-          # a levantar (rol inexistente).
-          # psql no acepta `?schema=public` (param propio de Prisma).
-          ADMIN_PSQL_URL="${DATABASE_URL%%\?*}"
-          psql "$ADMIN_PSQL_URL" -v ON_ERROR_STOP=1 -f packages/database/prisma/rls.sql
-          psql "$ADMIN_PSQL_URL" -v ON_ERROR_STOP=1 -f packages/database/prisma/grants.sql
-
-      - name: Seed admin user
-        run: pnpm --filter @didacta/database db:seed
+      - name: Preparar la base (esquema + RLS + grants + seeds + espacios)
+        run: bash scripts/e2e-stack.sh db
 
       - name: Build workspace
         run: pnpm build
 
-      - name: Start API
-        run: pnpm --filter @didacta/api start &
-        env:
-          PORT: 4000
-
-      - name: Start Web
-        run: pnpm --filter @didacta/web start &
-
-      - name: Wait for services
-        run: |
-          # API liveness: el endpoint canónico es /healthz (no /api/v1/health).
-          # Probamos contra el api directamente (4000) y el web (3010, ver
-          # apps/web/package.json#start) en paralelo para no avanzar si
-          # alguno no respondió.
-          for i in {1..60}; do
-            if curl -sf http://localhost:4000/healthz > /dev/null \
-              && curl -sf http://localhost:3010 > /dev/null; then
-              echo "API + Web up"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Services no respondieron tras 120s"
-          exit 1
+      - name: Arrancar api y web y esperar a que respondan
+        run: bash scripts/e2e-stack.sh start
 
       - name: Install Playwright browsers
         run: pnpm --filter @didacta/e2e exec playwright install --with-deps chromium
@@ -148,7 +90,16 @@ jobs:
         # (admin-email-templates, clase-en-comunidad, community-api-posts,
         # admin-smtp-settings). Corren en el job "mfa-enforcement" de abajo,
         # con su propio stack.
+        #
+        # setup-wizard.spec.ts no hace falta excluirlo: se auto-skipea cuando
+        # no hay E2E_SETUP_TOKEN, que es justo el caso de este job.
         run: pnpm --filter @didacta/e2e exec playwright test --grep-invert "Auth · MFA"
+
+      - name: Logs del stack si algo falló
+        if: failure()
+        run: |
+          echo '── api ──'; tail -n 200 .e2e-stack/api.log || true
+          echo '── web ──'; tail -n 200 .e2e-stack/web.log || true
 
       - name: Upload Playwright report
         if: always()
@@ -161,45 +112,12 @@ jobs:
   setup-wizard:
     name: Playwright wizard de setup (token de un solo uso)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     # Job separado del golden path: el wizard de /setup solo se puede
     # completar UNA vez por instancia (el primer tenant la cierra para
-    # siempre), así que necesita su propia base de datos SIN seed — el
-    # golden path arranca con `db:seed`, que ya crea un tenant y deja la
-    # instancia inicializada antes de que la API levante.
-    services:
-      postgres:
-        # pgvector: ver comentario equivalente en el job "e2e" de arriba.
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_USER: didacta
-          POSTGRES_PASSWORD: didacta
-          POSTGRES_DB: didacta
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
-    env:
-      DATABASE_URL: postgresql://didacta:didacta@localhost:5432/didacta?schema=public
-      JWT_SECRET: e2e-test-secret-must-be-at-least-32-chars-long-aaaa
-      JWT_REFRESH_SECRET: e2e-refresh-secret-must-be-32-chars-long-bbbb
-      AUTH_SECRET: e2e-auth-secret-must-be-at-least-32-chars-long-cccc
-      AUTH_URL: http://localhost:4000
-      TENANT_SETTINGS_ENC_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
-      NODE_ENV: production
-      # El puerto real de `next start` está fijo en el script (`-p 3010`,
-      # ver apps/web/package.json) — PORT no lo cambia. E2E_BASE_URL tiene
-      # que apuntar ahí, no al valor legacy de otros jobs de este workflow.
-      API_PORT: 4000
-      API_INTERNAL_URL: http://localhost:4000
-      E2E_BASE_URL: http://localhost:3010
-      E2E_API_DIRECT_URL: http://localhost:4000
-
+    # siempre), así que necesita su propia base de datos SIN seed. Por eso usa
+    # `e2e-stack.sh schema` en vez de `db`.
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
@@ -215,50 +133,26 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Cargar el entorno canónico del arnés
+        run: bash scripts/e2e-env.sh --github-env >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
         run: pnpm --filter @didacta/database db:generate
 
-      - name: Apply migrations
-        run: pnpm --filter @didacta/database db:migrate:deploy
+      - name: Levantar la infra de test (postgres + redis)
+        run: bash scripts/e2e-stack.sh up
 
-      - name: Aplicar políticas RLS y roles de runtime (didacta_app/didacta_super)
-        run: |
-          # La app conecta como el rol bootstrap (igual que el job "e2e" de
-          # arriba), pero desde RLS F3 el boot hace `SET LOCAL ROLE
-          # didacta_super` para el acceso global sancionado (ver
-          # tenant-context.storage.ts) — ese rol solo existe tras correr
-          # grants.sql. Mismo paso que infra/docker/entrypoint.sh#run_migrations,
-          # sin el cual la API no llega a levantar (rol inexistente).
-          # psql no acepta `?schema=public` (param propio de Prisma).
-          ADMIN_PSQL_URL="${DATABASE_URL%%\?*}"
-          psql "$ADMIN_PSQL_URL" -v ON_ERROR_STOP=1 -f packages/database/prisma/rls.sql
-          psql "$ADMIN_PSQL_URL" -v ON_ERROR_STOP=1 -f packages/database/prisma/grants.sql
+      - name: Preparar SOLO el esquema (sin seed — la instancia debe estar virgen)
+        run: bash scripts/e2e-stack.sh schema
 
       - name: Build workspace
         run: pnpm build
 
-      - name: Start API (log a fichero para extraer el token de setup)
-        run: pnpm --filter @didacta/api start > /tmp/api.log 2>&1 &
-
-      - name: Start Web
-        run: pnpm --filter @didacta/web start &
-
-      - name: Wait for services
-        run: |
-          for i in {1..60}; do
-            if curl -sf http://localhost:4000/healthz > /dev/null \
-              && curl -sf http://localhost:3010 > /dev/null; then
-              echo "API + Web up"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Services no respondieron tras 120s"
-          cat /tmp/api.log
-          exit 1
+      - name: Arrancar api y web y esperar a que respondan
+        run: bash scripts/e2e-stack.sh start
 
       - name: Extraer el token de setup de los logs
         run: |
@@ -268,7 +162,7 @@ jobs:
           # un objeto JSON con el mensaje en `.msg` (posible \n interno escapado).
           TOKEN=$(node -e "
             const fs = require('fs');
-            const lines = fs.readFileSync('/tmp/api.log', 'utf8').split('\n').filter(Boolean);
+            const lines = fs.readFileSync('.e2e-stack/api.log', 'utf8').split('\n').filter(Boolean);
             for (const line of lines) {
               let obj;
               try { obj = JSON.parse(line); } catch { continue; }
@@ -280,8 +174,8 @@ jobs:
             process.exit(1);
           ")
           if [ -z "$TOKEN" ]; then
-            echo "No se encontró el token de setup en /tmp/api.log"
-            cat /tmp/api.log
+            echo "No se encontró el token de setup en .e2e-stack/api.log"
+            cat .e2e-stack/api.log
             exit 1
           fi
           echo "E2E_SETUP_TOKEN=${TOKEN}" >> "$GITHUB_ENV"
@@ -290,6 +184,9 @@ jobs:
         run: pnpm --filter @didacta/e2e exec playwright install --with-deps chromium
 
       - name: Run E2E — wizard de setup
+        # El global-setup detecta solo que la instancia está virgen
+        # (GET /setup/status → initialized:false) y se limita a comprobar el
+        # entorno, sin buscar un admin sembrado que aquí no existe.
         run: pnpm --filter @didacta/e2e exec playwright test tests/setup-wizard.spec.ts
 
       - name: Upload Playwright report
@@ -303,51 +200,16 @@ jobs:
   mfa-enforcement:
     name: Playwright MFA enforcement (LMS-109)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     # Job separado del golden path: DIDACTA_REQUIRE_MFA_ADMIN=true (política
     # opt-in, default off — ver apps/api/src/auth/mfa-config.ts) bloquearía
     # con 403 mfa_required a varios specs del golden path que hacen signin()
     # de admin sin pasar por el flujo MFA. Mismo esquema que el job "e2e"
-    # (DB seedeada), solo que con la política activa y acotado a los 2 specs
+    # (base sembrada), solo que con la política activa y acotado a los 2 specs
     # que la ejercitan.
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_USER: didacta
-          POSTGRES_PASSWORD: didacta
-          POSTGRES_DB: didacta
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
     env:
-      DATABASE_URL: postgresql://didacta:didacta@localhost:5432/didacta?schema=public
-      JWT_SECRET: e2e-test-secret-must-be-at-least-32-chars-long-aaaa
-      JWT_REFRESH_SECRET: e2e-refresh-secret-must-be-32-chars-long-bbbb
-      AUTH_SECRET: e2e-auth-secret-must-be-at-least-32-chars-long-cccc
-      AUTH_URL: http://localhost:4000
-      TENANT_SETTINGS_ENC_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
-      NODE_ENV: production
-      AUTH_SIGNUP_ENABLED: 'true'
-      # La única diferencia real con el job "e2e": activa la política de
-      # enforcement que estos 2 specs ejercitan.
       DIDACTA_REQUIRE_MFA_ADMIN: 'true'
-      API_PORT: 4000
-      API_INTERNAL_URL: http://localhost:4000
-      BOOTSTRAP_PASSWORD: E2eAdminPassword123!
-      BOOTSTRAP_EMAIL: e2e-admin@example.test
-      BOOTSTRAP_TENANT_SLUG: demo
-      E2E_BASE_URL: http://localhost:3010
-      E2E_API_URL: http://localhost:3010
-      E2E_TENANT_SLUG: demo
-      E2E_ADMIN_EMAIL: e2e-admin@example.test
-      E2E_ADMIN_PASSWORD: E2eAdminPassword123!
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -364,45 +226,26 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Cargar el entorno canónico del arnés
+        run: bash scripts/e2e-env.sh --github-env >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
         run: pnpm --filter @didacta/database db:generate
 
-      - name: Apply migrations
-        run: pnpm --filter @didacta/database db:migrate:deploy
+      - name: Levantar la infra de test (postgres + redis)
+        run: bash scripts/e2e-stack.sh up
 
-      - name: Aplicar políticas RLS y roles de runtime (didacta_app/didacta_super)
-        run: |
-          ADMIN_PSQL_URL="${DATABASE_URL%%\?*}"
-          psql "$ADMIN_PSQL_URL" -v ON_ERROR_STOP=1 -f packages/database/prisma/rls.sql
-          psql "$ADMIN_PSQL_URL" -v ON_ERROR_STOP=1 -f packages/database/prisma/grants.sql
-
-      - name: Seed admin user
-        run: pnpm --filter @didacta/database db:seed
+      - name: Preparar la base (esquema + RLS + grants + seeds + espacios)
+        run: bash scripts/e2e-stack.sh db
 
       - name: Build workspace
         run: pnpm build
 
-      - name: Start API
-        run: pnpm --filter @didacta/api start &
-
-      - name: Start Web
-        run: pnpm --filter @didacta/web start &
-
-      - name: Wait for services
-        run: |
-          for i in {1..60}; do
-            if curl -sf http://localhost:4000/healthz > /dev/null \
-              && curl -sf http://localhost:3010 > /dev/null; then
-              echo "API + Web up"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Services no respondieron tras 120s"
-          exit 1
+      - name: Arrancar api y web y esperar a que respondan
+        run: bash scripts/e2e-stack.sh start
 
       - name: Install Playwright browsers
         run: pnpm --filter @didacta/e2e exec playwright install --with-deps chromium
@@ -416,6 +259,10 @@ jobs:
         # vez de mostrar el form de alta. Playwright NO respeta el orden de
         # argumentos del CLI (ordena los ficheros alfabéticamente pese al
         # orden dado aquí), así que van en pasos separados para forzarlo.
+        #
+        # El global-setup ve DIDACTA_REQUIRE_MFA_ADMIN y no toca al admin: si
+        # completara el ciclo setup→enable dejaría a mfa-setup.spec.ts sin el
+        # estado inicial que ejercita.
         run: |
           pnpm --filter @didacta/e2e exec playwright test tests/mfa-setup.spec.ts
           pnpm --filter @didacta/e2e exec playwright test tests/mfa-enforcement.spec.ts

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ evidencias/
 .quality/
 doc/
 apps/e2e/test-results-demo-nav/
+
+# Estado de ejecución del arnés E2E (scripts/e2e-stack.sh): logs y PIDs.
+.e2e-stack/

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -1,0 +1,261 @@
+/**
+ * Arranque único de la suite E2E.
+ *
+ * Existe por un motivo concreto: hasta ahora el arnés NUNCA levantaba el
+ * producto entero, y las piezas que faltaban no fallaban — degradaban en
+ * silencio. El resultado era una tanda con decenas de tests en rojo cuyos
+ * síntomas (redirecciones a `/onboarding`, listas vacías, 401 en webhooks,
+ * realtime que no llega) parecían bugs de producto y no lo eran.
+ *
+ * Este fichero convierte cada una de esas degradaciones silenciosas en un
+ * fallo ruidoso ANTES de correr un solo test, y deja el entorno en el estado
+ * que la suite da por supuesto:
+ *
+ *   1. api y web responden.
+ *   2. Redis configurado — sin él la mensajería realtime es un no-op silencioso.
+ *   3. Cupo de rate limit con margen — con Redis activo el limiter deja de
+ *      fallar abierto y el cupo público por defecto (30 req/min COMPARTIDOS
+ *      por todo el tráfico anónimo) estrangula la suite.
+ *   4. Secretos de webhooks de pago presentes.
+ *   5. Espacios de sistema sembrados (`prisma/seed.sql`).
+ *   6. Onboarding cerrado para los admins sembrados.
+ *
+ * La receta completa para dejar el stack en pie está en `scripts/e2e-stack.sh`.
+ */
+
+import { completeOnboarding, ONBOARDING_AVATAR_URL, signin, SMOKE_API_URL } from './helpers/api';
+
+/** Techo mínimo de rate limit por minuto para que una tanda serie no se ahogue. */
+const MIN_RATE_LIMIT_PER_MIN = 1_000;
+
+/** Espacios de sistema que crea `packages/database/prisma/seed.sql`. */
+const SYSTEM_SPACE_SLUGS = ['general', 'anuncios', 'preguntas', 'recursos'];
+
+/** Cuánto esperamos a que api y web respondan antes de rendirnos. */
+const READINESS_TIMEOUT_MS = 120_000;
+const READINESS_POLL_MS = 1_000;
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:3010';
+const API_URL = process.env.E2E_API_URL ?? BASE_URL;
+const API_DIRECT_URL = process.env.E2E_API_DIRECT_URL ?? 'http://localhost:4000';
+
+/** Los tres secretos sin los cuales los webhooks de pago responden 401. */
+const REQUIRED_PAYMENT_SECRETS = [
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'SUBSCRIPTIONS_WEBHOOK_SECRET',
+] as const;
+
+function fail(what: string, why: string): never {
+  throw new Error(
+    `\n[arnés E2E] ${what}\n\n${why}\n\n` +
+      `Receta completa del stack:  bash scripts/e2e-stack.sh all\n` +
+      `Entorno canónico:           scripts/e2e-env.sh\n`,
+  );
+}
+
+async function waitForService(url: string, label: string): Promise<void> {
+  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+  let last = '';
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      // Cualquier respuesta HTTP vale: lo que comprobamos es que hay alguien
+      // escuchando y sirviendo, no que la ruta concreta devuelva 200.
+      if (res.status > 0) return;
+    } catch (err) {
+      last = (err as Error).message;
+    }
+    await new Promise((r) => setTimeout(r, READINESS_POLL_MS));
+  }
+  fail(
+    `${label} no responde en ${url}.`,
+    `Tras ${READINESS_TIMEOUT_MS / 1000}s sigue sin contestar (último error: ${last || 'timeout'}).`,
+  );
+}
+
+function assertRealtimeBackendConfigured(): void {
+  if (process.env['REDIS_URL']) return;
+  fail(
+    'Falta REDIS_URL.',
+    'Sin Redis, `messaging-realtime.publisher` degrada a no-op SILENCIOSO: los\n' +
+      'mensajes se guardan pero no se publican, y los specs de chat/mensajes\n' +
+      'fallan esperando algo que nunca llega. Es la degradación que más tiempo\n' +
+      'cuesta diagnosticar, así que el arnés se niega a correr sin ella.',
+  );
+}
+
+function assertPaymentSecretsConfigured(): void {
+  const missing = REQUIRED_PAYMENT_SECRETS.filter((name) => !process.env[name]);
+  if (missing.length === 0) return;
+  fail(
+    `Faltan secretos de webhooks de pago: ${missing.join(', ')}.`,
+    'Los specs de suscripciones y referidos FIRMAN sus propios webhooks con\n' +
+      'estos valores. Sin ellos la API responde 401 y el fallo parece de\n' +
+      'negocio. Son secretos sintéticos, no claves reales.',
+  );
+}
+
+/**
+ * Comprueba el cupo efectivo leyendo `X-RateLimit-Limit` de una petición
+ * pública real. `/auth/signin` no pasa por JwtAuthGuard, así que el
+ * interceptor global sí llega a ejecutarse y a escribir los headers.
+ */
+async function assertRateLimitHeadroom(): Promise<void> {
+  const res = await fetch(`${API_URL}/api/v1/auth/signin`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tenantSlug: 'no-existe-a-proposito', email: 'x@x.test', password: 'x' }),
+  });
+  const header = res.headers.get('x-ratelimit-limit');
+  if (!header) {
+    // Camino degradado DELIBERADO: si el interceptor no llegó a correr no hay
+    // cupo que comprobar, y abortar aquí dejaría la suite entera rehén de que
+    // `/auth/signin` siga siendo la sonda buena. Se avisa en vez de callar, y
+    // `tests/arnes-contrato.spec.ts` sí exige la cabecera: así la degradación
+    // sale como UN test rojo con nombre, no como un arranque abortado.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[arnés E2E] Sin cabecera X-RateLimit-Limit en /auth/signin: no se pudo comprobar\n' +
+        '            el cupo. Lo verifica igualmente "Contrato del arnés E2E".',
+    );
+    return;
+  }
+  const limit = Number.parseInt(header, 10);
+  if (Number.isFinite(limit) && limit >= MIN_RATE_LIMIT_PER_MIN) return;
+  fail(
+    `El cupo de rate limit público es ${limit} req/min — demasiado bajo para la suite.`,
+    'Con REDIS_URL activo el limiter deja de fallar abierto y entra en vigor el\n' +
+      'cupo del plan community: 30 req/min PÚBLICAS compartidas por todo el\n' +
+      'tráfico anónimo (bucket "anonymous"). Una tanda serie hace muchísimo más\n' +
+      'que eso: cada signin() de cada spec cuenta.\n\n' +
+      'Sube el techo con las variables que ya expone la API:\n' +
+      `  RATE_LIMIT_COMMUNITY_PUBLIC_PER_MIN >= ${MIN_RATE_LIMIT_PER_MIN}\n` +
+      `  RATE_LIMIT_COMMUNITY_AUTH_PER_MIN   >= ${MIN_RATE_LIMIT_PER_MIN}`,
+  );
+}
+
+/** Cierra el onboarding del admin sembrado y devuelve su token. */
+async function prepareAdmin(
+  tenantSlug: string,
+  email: string,
+  password: string,
+  baseUrl?: string,
+): Promise<string> {
+  let session;
+  try {
+    session = await signin({ tenantSlug, email, password }, baseUrl);
+  } catch (err) {
+    fail(
+      `No se pudo iniciar sesión como ${email} en el tenant "${tenantSlug}".`,
+      `${(err as Error).message}\n\n` +
+        'La base no está sembrada, o lo está con otras credenciales.\n' +
+        'Siémbrala con:  bash scripts/e2e-stack.sh db',
+    );
+  }
+  const token = session.tokens.accessToken;
+  await completeOnboarding(token, baseUrl);
+  return token;
+}
+
+/** Verifica por API que `seed.sql` corrió: los 4 espacios de sistema existen. */
+async function assertSystemSpacesSeeded(bearer: string): Promise<void> {
+  const res = await fetch(`${API_URL}/api/v1/modules/community/spaces`, {
+    headers: { Authorization: `Bearer ${bearer}` },
+  });
+  if (!res.ok) {
+    fail(
+      `GET /modules/community/spaces devolvió ${res.status}.`,
+      'Sin este endpoint no se puede verificar el sembrado de espacios.',
+    );
+  }
+  const body = (await res.json()) as Array<{ slug: string }> | { spaces?: Array<{ slug: string }> };
+  const spaces = Array.isArray(body) ? body : (body.spaces ?? []);
+  const present = new Set(spaces.map((s) => s.slug));
+  const missing = SYSTEM_SPACE_SLUGS.filter((slug) => !present.has(slug));
+  if (missing.length === 0) return;
+  fail(
+    `Faltan espacios de sistema: ${missing.join(', ')}.`,
+    '`packages/database/prisma/seed.sql` no se ha aplicado. Lo aplica\n' +
+      '`infra/docker/entrypoint.sh` en el contenedor de producto, pero `db:seed`\n' +
+      'por sí solo NO lo hace: `mod_community_space` se queda a 0 filas y todo\n' +
+      'lo de comunidad y espacios falla por datos que no existen.\n\n' +
+      'Aplícalo con:  bash scripts/e2e-stack.sh db',
+  );
+}
+
+/**
+ * ¿La instancia ya tiene al menos un tenant? Se lo preguntamos al producto
+ * (`GET /setup/status`) en vez de deducirlo de una variable de entorno: el job
+ * del wizard de `/setup` corre a propósito contra una instancia VIRGEN, y ahí
+ * no hay admin sembrado que preparar. Distinguirlo por estado real evita un
+ * interruptor de "sáltate el arranque" que tarde o temprano se deja puesto.
+ */
+async function isInstanceInitialized(): Promise<boolean> {
+  const res = await fetch(`${API_URL}/api/v1/setup/status`);
+  if (!res.ok) return false;
+  const body = (await res.json()) as { initialized?: boolean };
+  return body.initialized === true;
+}
+
+export default async function globalSetup(): Promise<void> {
+  await waitForService(`${API_DIRECT_URL}/healthz`, 'La API');
+  await waitForService(`${BASE_URL}/signin`, 'La web');
+
+  assertRealtimeBackendConfigured();
+  assertPaymentSecretsConfigured();
+  await assertRateLimitHeadroom();
+
+  if (!(await isInstanceInitialized())) {
+    // eslint-disable-next-line no-console
+    console.info(
+      '[arnés E2E] Instancia sin inicializar (no hay tenants): sólo comprobaciones de entorno.\n' +
+        '            Es el estado que necesita el wizard de /setup — ver el job "setup-wizard".',
+    );
+    return;
+  }
+
+  // La política de MFA obligatoria para admins (opt-in, default off) hace que
+  // el token del signin llegue sin verificar. Preparar el onboarding desde
+  // aquí obligaría a completar el ciclo setup→enable y dejaría a
+  // `mfa-setup.spec.ts` sin el estado inicial que ejercita, así que en ese
+  // stack la preparación la hacen los propios specs.
+  if (process.env['DIDACTA_REQUIRE_MFA_ADMIN'] === 'true') {
+    // eslint-disable-next-line no-console
+    console.info(
+      '[arnés E2E] DIDACTA_REQUIRE_MFA_ADMIN activo: la preparación del admin la\n' +
+        '            hacen los specs de MFA, que son los que ejercitan ese flujo.',
+    );
+    return;
+  }
+
+  const tenantSlug = process.env.E2E_TENANT_SLUG ?? 'demo';
+  const email = process.env.E2E_ADMIN_EMAIL;
+  const password = process.env.E2E_ADMIN_PASSWORD;
+  if (!email || !password) {
+    fail(
+      'Faltan E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD.',
+      'Son las credenciales del admin que siembra `seed.ts`. Sin ellas ningún\n' +
+        'spec puede autenticarse.',
+    );
+  }
+
+  const adminToken = await prepareAdmin(tenantSlug, email, password);
+  await assertSystemSpacesSeeded(adminToken);
+
+  // El tenant de smoke tiene su propio admin sembrado. Se le habla por la API
+  // DIRECTA en 127.0.0.1 porque el Host manda sobre el `tenantSlug` del body
+  // (ver SMOKE_API_URL en helpers/api.ts); esta llamada verifica de paso que
+  // el segundo tenant existe y es alcanzable, que es justo lo que necesitan
+  // `redesign-smoke` y `mobile-nav`.
+  const smokeSlug = process.env.E2E_SMOKE_TENANT_SLUG ?? 'e2e-smoke';
+  const smokeEmail = process.env.E2E_SMOKE_ADMIN_EMAIL;
+  if (smokeEmail) {
+    await prepareAdmin(smokeSlug, smokeEmail, password, SMOKE_API_URL);
+  }
+
+  // eslint-disable-next-line no-console
+  console.info(
+    `[arnés E2E] Listo · tenant=${tenantSlug} · smoke=${smokeSlug} · avatar=${ONBOARDING_AVATAR_URL}`,
+  );
+}

--- a/apps/e2e/helpers/api.ts
+++ b/apps/e2e/helpers/api.ts
@@ -7,6 +7,41 @@ import { authenticator } from 'otplib';
 
 export const API_URL = process.env.E2E_API_URL ?? 'http://localhost:3000';
 
+/** Tenant principal del arnés — el que siembra `seed.ts` con BOOTSTRAP_*. */
+export const TENANT_SLUG = process.env.E2E_TENANT_SLUG ?? 'demo';
+
+/**
+ * Segundo tenant, sembrado por `scripts/e2e-stack.sh db` con el mismo
+ * `seed.ts`. Existe para los specs que afirman estados vacíos ("No hay grupos
+ * disponibles", "No tienes conversaciones todavía"): en `demo` dejan de ser
+ * ciertos a mitad de suite porque otros specs crean grupos, clases y mensajes.
+ */
+export const SMOKE_TENANT_SLUG = process.env.E2E_SMOKE_TENANT_SLUG ?? 'e2e-smoke';
+
+/**
+ * Base para hablar con el tenant de smoke. Es la API DIRECTA y por 127.0.0.1
+ * a propósito: el alta y el login resuelven el tenant por el Host header y esa
+ * resolución GANA sobre el `tenantSlug` del body (`resolveTenantIdFromHost` en
+ * apps/api/src/auth/auth.controller.ts:165). A través del rewrite de Next el
+ * Host que llega a la API es siempre `localhost:4000` → tenant principal, así
+ * que por ahí el segundo tenant sería inalcanzable.
+ *
+ * Sólo afecta al ALTA: una vez emitido, el JWT lleva el tenantId y el
+ * navegador puede trabajar con normalidad contra E2E_BASE_URL.
+ */
+export const SMOKE_API_URL = process.env.E2E_SMOKE_API_URL ?? 'http://127.0.0.1:4000';
+
+/**
+ * Avatar con el que el arnés cierra el onboarding. Ruta relativa de storage —
+ * el mismo formato que acepta `PATCH /me/profile` desde la UI. No se sube
+ * ningún fichero: al gate de onboarding sólo le importa que el campo no sea
+ * null (ver `missingOnboardingFields` en apps/api/src/auth/me.controller.ts).
+ */
+export const ONBOARDING_AVATAR_URL = '/api/v1/storage/file/avatars/e2e-harness.png';
+
+/** Nombre de respaldo si el usuario llegara sin `name` al onboarding. */
+export const ONBOARDING_FALLBACK_NAME = 'Usuario E2E';
+
 interface Tokens {
   accessToken: string;
   refreshToken: string;
@@ -21,6 +56,12 @@ interface AuthUser {
   tenantSlug: string;
   roles: string[];
   mfaEnabled: boolean;
+  /**
+   * Lo devuelven `/auth/signin` y `/auth/signup` (auth.service.ts). Es el
+   * campo que mira el gate de `apps/web/src/app/(app)/layout.tsx`: mientras
+   * sea null o undefined, TODA ruta autenticada acaba en `/onboarding`.
+   */
+  onboardingCompletedAt?: string | null;
 }
 
 interface AuthResponse {
@@ -60,7 +101,7 @@ function extractOtpSecret(otpauthUrl: string): string {
 
 async function api<T>(
   path: string,
-  init: { method?: string; body?: unknown; bearer?: string } = {},
+  init: { method?: string; body?: unknown; bearer?: string; baseUrl?: string } = {},
 ): Promise<T> {
   // Solo setear Content-Type cuando enviamos body. Fastify rechaza con
   // 400 "Body cannot be empty when content-type is set to 'application/json'"
@@ -70,7 +111,7 @@ async function api<T>(
   if (init.body !== undefined) headers['Content-Type'] = 'application/json';
   if (init.bearer) headers['Authorization'] = `Bearer ${init.bearer}`;
 
-  const res = await fetch(`${API_URL}${path}`, {
+  const res = await fetch(`${init.baseUrl ?? API_URL}${path}`, {
     method: init.method ?? 'GET',
     headers,
     body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
@@ -87,21 +128,116 @@ async function api<T>(
   return body as T;
 }
 
-export async function signup(args: {
-  tenantSlug: string;
-  email: string;
-  password: string;
-  name?: string;
-}): Promise<AuthResponse> {
-  return api<AuthResponse>('/api/v1/auth/signup', { method: 'POST', body: args });
+export async function signup(
+  args: {
+    tenantSlug: string;
+    email: string;
+    password: string;
+    name?: string;
+  },
+  baseUrl?: string,
+): Promise<AuthResponse> {
+  return api<AuthResponse>('/api/v1/auth/signup', { method: 'POST', body: args, baseUrl });
 }
 
-export async function signin(args: {
-  tenantSlug: string;
-  email: string;
-  password: string;
-}): Promise<AuthResponse> {
-  return api<AuthResponse>('/api/v1/auth/signin', { method: 'POST', body: args });
+export async function signin(
+  args: {
+    tenantSlug: string;
+    email: string;
+    password: string;
+  },
+  baseUrl?: string,
+): Promise<AuthResponse> {
+  return api<AuthResponse>('/api/v1/auth/signin', { method: 'POST', body: args, baseUrl });
+}
+
+interface OnboardingStatus {
+  completed: boolean;
+  completedAt: string | null;
+  missing: string[];
+}
+
+/**
+ * Cierra el onboarding de primera vez del usuario del token, por el MISMO
+ * camino que la UI: rellena lo que falte con `PATCH /me/profile` y confirma
+ * con `POST /me/onboarding/complete`.
+ *
+ * Por qué existe: el gate de `apps/web/src/app/(app)/layout.tsx:92` desvía
+ * TODA ruta autenticada a `/onboarding` mientras `onboardingCompletedAt` sea
+ * falsy, y los usuarios que siembra `seed.ts` (y los que los specs crean con
+ * `signup`) nacen con el campo a null. Es la causa única de la mayoría de los
+ * fallos que parecían de producto: el test navegaba a `/comunidad` y acababa
+ * en el asistente.
+ *
+ * Idempotente: si ya estaba cerrado devuelve el timestamp existente sin
+ * re-auditar (lo garantiza el propio endpoint).
+ */
+export async function completeOnboarding(bearer: string, baseUrl?: string): Promise<string> {
+  const status = await api<OnboardingStatus>('/api/v1/me/onboarding/status', { bearer, baseUrl });
+  if (status.completed && status.completedAt) return status.completedAt;
+
+  if (status.missing.length > 0) {
+    const patch: Record<string, string> = {};
+    if (status.missing.includes('name')) patch['name'] = ONBOARDING_FALLBACK_NAME;
+    if (status.missing.includes('avatar')) patch['avatarUrl'] = ONBOARDING_AVATAR_URL;
+    await api('/api/v1/me/profile', { method: 'PATCH', body: patch, bearer, baseUrl });
+  }
+
+  const done = await api<{ onboardingCompletedAt: string }>('/api/v1/me/onboarding/complete', {
+    method: 'POST',
+    bearer,
+    baseUrl,
+  });
+  return done.onboardingCompletedAt;
+}
+
+/** Contraseña de los usuarios que el arnés fabrica. Sintética, de un solo uso. */
+export const E2E_USER_PASSWORD = 'E2eTestPassword123!';
+
+/**
+ * Alumno real, recién creado y con el onboarding cerrado, dentro del tenant
+ * de smoke (`E2E_SMOKE_TENANT_SLUG`).
+ *
+ * Lo usan los specs que afirman estados VACÍOS de la app ("No hay grupos
+ * disponibles", "No tienes conversaciones todavía", "No hay eventos
+ * programados"). En el tenant principal esas frases son mentira a mitad de
+ * suite, porque otros specs van creando grupos, clases y mensajes; en el
+ * tenant de smoke nadie escribe, así que el estado vacío es cierto de verdad.
+ *
+ * `label` sólo entra en el email para que los fallos sean rastreables.
+ */
+export async function createSmokeStudent(label: string): Promise<AuthResponse> {
+  return signupOnboarded(
+    {
+      tenantSlug: SMOKE_TENANT_SLUG,
+      email: `e2e-${label}-${Date.now()}@example.test`,
+      password: E2E_USER_PASSWORD,
+      name: 'Alumna E2E',
+    },
+    SMOKE_API_URL,
+  );
+}
+
+/**
+ * `signup` + onboarding cerrado, devolviendo el `user` YA con
+ * `onboardingCompletedAt` puesto para que se pueda inyectar tal cual.
+ *
+ * NO se mete esto dentro de `signup()` a propósito: `onboarding.spec.ts`
+ * necesita justo lo contrario — un alumno recién creado con el onboarding
+ * todavía abierto para verificar el gate por avatar y el 422.
+ */
+export async function signupOnboarded(
+  args: {
+    tenantSlug: string;
+    email: string;
+    password: string;
+    name?: string;
+  },
+  baseUrl?: string,
+): Promise<AuthResponse> {
+  const created = await signup(args, baseUrl);
+  const onboardingCompletedAt = await completeOnboarding(created.tokens.accessToken, baseUrl);
+  return { ...created, user: { ...created.user, onboardingCompletedAt } };
 }
 
 /**
@@ -620,7 +756,14 @@ export async function listCoursesViaApi(args: {
   return { courses: body?.courses ?? [], status: res.status };
 }
 
-export async function adminTokenForBootstrap(tenantSlug: string): Promise<string> {
+/**
+ * Sesión completa del admin sembrado: token ya elevado si hacía falta MFA, y
+ * el `user` tal cual lo devuelve la API (con `tenantId` y `onboardingCompletedAt`,
+ * que es lo que necesita `injectSession` para no acabar en `/onboarding`).
+ */
+export async function adminSessionForBootstrap(
+  tenantSlug: string,
+): Promise<{ accessToken: string; user: AuthUser }> {
   const adminSeedEmail = process.env.E2E_ADMIN_EMAIL;
   const adminSeedPassword = process.env.E2E_ADMIN_PASSWORD;
   if (!adminSeedEmail || !adminSeedPassword) {
@@ -638,7 +781,11 @@ export async function adminTokenForBootstrap(tenantSlug: string): Promise<string
     const verified = await setupMfaAndVerify(adminToken);
     adminToken = verified.accessToken;
   }
-  return adminToken;
+  return { accessToken: adminToken, user: adminSession.user };
+}
+
+export async function adminTokenForBootstrap(tenantSlug: string): Promise<string> {
+  return (await adminSessionForBootstrap(tenantSlug)).accessToken;
 }
 
 export interface BootstrapResult {

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -4,6 +4,12 @@ const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:3010';
 
 export default defineConfig({
   testDir: './tests',
+  // Verifica que el stack está entero ANTES de correr nada y deja el entorno
+  // en el estado que los specs dan por supuesto (onboarding cerrado, espacios
+  // de sistema sembrados, Redis y cupo de rate limit con margen). Ver el
+  // comentario largo en global-setup.ts: cada comprobación de ahí corresponde
+  // a una degradación que antes fallaba en silencio.
+  globalSetup: require.resolve('./global-setup'),
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/apps/e2e/tests/admin-tenants.spec.ts
+++ b/apps/e2e/tests/admin-tenants.spec.ts
@@ -36,6 +36,19 @@ test.describe('Super_admin tenants CRUD (HU-SA-001)', () => {
     const newSlug = `e2e-tenant-${stamp}`;
     const newHostname = `e2e-${stamp}.localhost`;
 
+    // El alta de tenants adicionales es una capacidad de pago
+    // (`feat:multi_tenant.real`): en Community el techo es UN tenant y crear
+    // el segundo devuelve 402. Se lo preguntamos al producto en vez de darlo
+    // por hecho — la instalación de referencia del arnés corre con licencia
+    // Community, así que el camino que se ejercita de verdad es el del gate.
+    const capacityRes = await fetch(`${API_URL}/api/v1/admin/tenants/capacity`, { headers });
+    expect(capacityRes.ok, 'capacity → 200').toBe(true);
+    const capacity = (await capacityRes.json()) as {
+      canCreate: boolean;
+      capabilityActive: boolean;
+      capability: string;
+    };
+
     // Create.
     const created = await fetch(`${API_URL}/api/v1/admin/tenants`, {
       method: 'POST',
@@ -47,6 +60,24 @@ test.describe('Super_admin tenants CRUD (HU-SA-001)', () => {
         primaryHostname: newHostname,
       }),
     });
+
+    if (!capacity.canCreate) {
+      // Camino Community: el gate de licencia responde 402 con la capacidad
+      // que haría falta, y no se crea nada. Es la mitad del contrato que esta
+      // instalación puede ejercitar de verdad.
+      expect(created.status, 'sin la capacidad EE, crear un tenant → 402').toBe(402);
+      const gate = (await created.json()) as { capability?: string };
+      expect(gate.capability).toBe(capacity.capability);
+      const after = (await (
+        await fetch(`${API_URL}/api/v1/admin/tenants`, { headers })
+      ).json()) as Array<{ slug: string }>;
+      expect(
+        after.some((t) => t.slug === newSlug),
+        'el tenant NO se creó',
+      ).toBe(false);
+      return;
+    }
+
     expect(created.ok, 'create → 200').toBe(true);
     const tenant = (await created.json()) as { id: string; slug: string; status: string };
     expect(tenant.slug).toBe(newSlug);

--- a/apps/e2e/tests/admin-tutor-revision.spec.ts
+++ b/apps/e2e/tests/admin-tutor-revision.spec.ts
@@ -88,7 +88,12 @@ test.describe('Tutor IA · revisión de respuestas (API)', () => {
     const res = await fetch(`${API_URL}/api/v1/admin/ai-tutor/answers`, {
       headers: { Authorization: `Bearer ${alumno.tokens.accessToken}` },
     });
-    expect(res.status).toBe(401);
+    // 403, no 401: el alumno SÍ está autenticado; lo que le falta es el rol.
+    // El backend lo dice con código propio y devolver 401 sería mentirle al
+    // cliente (reintentaría el login). El test de arriba, "sin sesión", sí
+    // espera 401 y es el que marca la diferencia entre los dos casos.
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { code?: string }).code).toBe('AI_TUTOR_REVIEW_ADMIN_REQUIRED');
   });
 
   test('revisar una respuesta que no existe devuelve 404 con código propio', async () => {

--- a/apps/e2e/tests/arnes-contrato.spec.ts
+++ b/apps/e2e/tests/arnes-contrato.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import {
+  adminSessionForBootstrap,
+  API_URL,
+  createSmokeStudent,
+  SMOKE_API_URL,
+  SMOKE_TENANT_SLUG,
+  TENANT_SLUG,
+} from '../helpers/api';
+
+/**
+ * Contrato del arnés: comprueba que el stack levantó el producto ENTERO.
+ *
+ * Por qué existe. Las piezas que faltaban en el arnés no fallaban: degradaban
+ * en silencio, y el síntoma aparecía a treinta ficheros de distancia. Sin los
+ * espacios de sistema, los specs de comunidad fallaban «por UI». Sin cerrar el
+ * onboarding del admin, cualquier ruta autenticada acababa en el asistente y
+ * el fallo parecía de la página de destino. Sin Redis, la mensajería realtime
+ * era un no-op y los tests esperaban un mensaje que nadie iba a publicar.
+ *
+ * Cada `test` de aquí es una de esas condiciones. Si el stack está mal
+ * montado, rompe UNA cosa con un mensaje que dice qué falta, en vez de dejar
+ * veinticinco rojos que parecen bugs de producto.
+ *
+ * Los tres primeros cubren además los caminos DEGRADADOS que `global-setup.ts`
+ * deja abiertos a propósito (instancia virgen y MFA obligatorio): aquí se
+ * afirma el estado que esos caminos dan por bueno, así que si alguien deja
+ * puesta una de esas condiciones en el stack del golden path, se ve.
+ */
+
+/** Espacios que crea `packages/database/prisma/seed.sql` para cada tenant. */
+const SYSTEM_SPACE_SLUGS = ['general', 'anuncios', 'preguntas', 'recursos'];
+
+/** Mismo suelo que exige `global-setup.ts` para no estrangular la tanda. */
+const MIN_RATE_LIMIT_PER_MIN = 1_000;
+
+const PG_CONTAINER = process.env.E2E_PG_CONTAINER ?? 'didacta-postgres-test';
+const PG_USER = process.env.E2E_PG_USER ?? 'didacta_test';
+const PG_DB = process.env.E2E_PG_DB ?? 'didacta_test';
+
+test.describe('Contrato del arnés E2E', () => {
+  test('la instancia está inicializada y sin la política de MFA obligatoria', async () => {
+    // Es el estado que asume el golden path. Con `initialized:false`
+    // (instancia virgen) o con DIDACTA_REQUIRE_MFA_ADMIN activo,
+    // `global-setup.ts` se salta la preparación del admin a propósito — y
+    // entonces media suite falla por el gate de onboarding sin decir por qué.
+    const status = (await (await fetch(`${API_URL}/api/v1/setup/status`)).json()) as {
+      initialized: boolean;
+    };
+    expect(status.initialized, 'la base está sembrada (bash scripts/e2e-stack.sh db)').toBe(true);
+    expect(
+      process.env['DIDACTA_REQUIRE_MFA_ADMIN'],
+      'el golden path corre SIN la política de MFA obligatoria (tiene su propio job)',
+    ).not.toBe('true');
+  });
+
+  test('el rate limit está activo y con margen para una tanda entera', async () => {
+    // Con REDIS_URL el limiter deja de fallar abierto. Que cuente es lo que
+    // queremos (es el código de producción); lo que no puede es estrangular:
+    // el cupo público por defecto son 30 req/min COMPARTIDAS por todo el
+    // tráfico anónimo, y cada signin() de cada spec cae en ese bucket.
+    const res = await fetch(`${API_URL}/api/v1/auth/signin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tenantSlug: 'no-existe', email: 'x@x.test', password: 'x' }),
+    });
+    const limit = res.headers.get('x-ratelimit-limit');
+    expect(limit, 'el interceptor de rate limit escribe sus cabeceras').not.toBeNull();
+    expect(Number.parseInt(limit!, 10)).toBeGreaterThanOrEqual(MIN_RATE_LIMIT_PER_MIN);
+
+    // `remaining < limit` prueba que Redis está contando de verdad: en el
+    // camino failsafe (sin Redis) el servicio devuelve `remaining === limit`.
+    const remaining = Number.parseInt(res.headers.get('x-ratelimit-remaining') ?? '-1', 10);
+    expect(remaining, 'Redis está contando (si no, remaining seria igual al limite)').toBeLessThan(
+      Number.parseInt(limit!, 10),
+    );
+  });
+
+  test('los espacios de sistema de seed.sql existen en el tenant principal', async () => {
+    const { accessToken } = await adminSessionForBootstrap(TENANT_SLUG);
+    const res = await fetch(`${API_URL}/api/v1/modules/community/spaces`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as
+      | Array<{ slug: string }>
+      | { spaces?: Array<{ slug: string }> };
+    const slugs = (Array.isArray(body) ? body : (body.spaces ?? [])).map((s) => s.slug);
+    for (const slug of SYSTEM_SPACE_SLUGS) {
+      expect(slugs, `falta el espacio de sistema "${slug}" — ¿se aplicó seed.sql?`).toContain(slug);
+    }
+  });
+
+  test('el admin sembrado tiene el onboarding cerrado', async () => {
+    const { accessToken } = await adminSessionForBootstrap(TENANT_SLUG);
+    const res = await fetch(`${API_URL}/api/v1/me/onboarding/status`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const status = (await res.json()) as { completed: boolean };
+    expect(
+      status.completed,
+      'sin esto el gate de (app)/layout.tsx desvía toda ruta autenticada a /onboarding',
+    ).toBe(true);
+  });
+
+  test('el tenant de smoke existe, es alcanzable y NO es el principal', async () => {
+    expect(SMOKE_TENANT_SLUG).not.toBe(TENANT_SLUG);
+    const alumna = await createSmokeStudent('contrato');
+    expect(alumna.user.tenantSlug, 'el alta cayó en el tenant de smoke').toBe(SMOKE_TENANT_SLUG);
+    expect(alumna.user.onboardingCompletedAt, 'con el onboarding ya cerrado').toBeTruthy();
+    // Que se resuelva por Host y no por el slug del body es justo lo que hace
+    // que haga falta SMOKE_API_URL: ver el comentario en helpers/api.ts.
+    expect(SMOKE_API_URL).not.toBe(API_URL);
+  });
+
+  test('el Postgres del stack responde por el mismo camino que usa catalogo-publico', () => {
+    // `catalogo-publico.spec.ts` siembra por `docker exec … psql` contra el
+    // contenedor POR NOMBRE. Apuntaba a uno que no existía y sus dos tests
+    // fallaban por eso. Aquí se comprueba el camino, no el dato.
+    const out = execFileSync(
+      'docker',
+      ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DB, '-t', '-A', '-c', 'SELECT 1'],
+      { encoding: 'utf8' },
+    ).trim();
+    expect(
+      out,
+      `docker exec ${PG_CONTAINER} no responde — ¿está levantado el compose de test?`,
+    ).toBe('1');
+  });
+
+  test('los secretos de webhooks de pago son coherentes entre la API y los specs', () => {
+    // Los specs FIRMAN sus propios webhooks. Si el nombre que lee el spec y el
+    // que valida la API divergen, la firma no cuadra y el 400 parece un fallo
+    // de negocio. Pasó: sólo estaba puesto E2E_BILLING_WEBHOOK_SECRET.
+    const apiSide = process.env['STRIPE_WEBHOOK_SECRET'];
+    expect(apiSide, 'STRIPE_WEBHOOK_SECRET (lado API)').toBeTruthy();
+    expect(process.env['E2E_STRIPE_WEBHOOK_SECRET'], 'lo usan membership-trial y referrals').toBe(
+      apiSide,
+    );
+    expect(process.env['E2E_BILLING_WEBHOOK_SECRET'], 'lo usa catalogo-publico').toBe(apiSide);
+  });
+});

--- a/apps/e2e/tests/branding-logo.spec.ts
+++ b/apps/e2e/tests/branding-logo.spec.ts
@@ -53,13 +53,23 @@ test.describe('Branding · uploader de logo del tenant', () => {
     expect(theme.logoUrl).toMatch(/^\/api\/v1\/modules\/theming\/tenants\/[\w-]+\/logo\?v=\d+$/);
 
     // 2. El endpoint público (sin auth) devuelve el blob con Content-Type
-    //    correcto. Es WebP y no PNG: el logo se optimiza al subirlo igual que
-    //    el resto de imágenes de la plataforma.
+    //    correcto. Es PNG a propósito, NO WebP: el logo acaba en la cabecera de
+    //    todos los emails del tenant y los clientes de correo ignoran el canal
+    //    alfa del WebP (rectángulo negro con las letras recortadas). Por eso
+    //    `theming.service.ts` pide `format: 'png'` al optimizador — ver el
+    //    commit d01a5dc4 "el logo del tenant se guarda en PNG, no en WebP".
+    //    Este spec seguía afirmando WebP, o sea el comportamiento anterior.
     const publicGet = await request.get(`${API_URL}${theme.logoUrl!.split('?')[0]}`);
     expect(publicGet.ok()).toBe(true);
-    expect(publicGet.headers()['content-type']).toContain('image/webp');
+    expect(publicGet.headers()['content-type']).toContain('image/png');
     const buffer = await publicGet.body();
+    // Y sí se recomprime: la fixture entra sin comprimir (deflate nivel 0, ver
+    // helpers/png.ts) y sale muy por debajo. Esto es lo que de verdad prueba
+    // que el optimizador corrió, más que el content-type.
     expect(buffer.length).toBeGreaterThan(10);
+    expect(buffer.length, 'el PNG sale recomprimido, no tal cual').toBeLessThan(
+      Buffer.from(logoPngBase64, 'base64').length,
+    );
 
     // 3. El admin abre /admin/branding y ve el preview del logo subido.
     await page.goto('/signin');

--- a/apps/e2e/tests/catalogo-publico.spec.ts
+++ b/apps/e2e/tests/catalogo-publico.spec.ts
@@ -240,13 +240,20 @@ test.describe('Viaje 2 público — catálogo y compra anónima (F4)', () => {
     ).toBe(`COMPLETED|${userId}`);
 
     // El bridge matriculó (source PURCHASE) — el evento va por outbox: poll.
+    // La ventana es holgada a propósito. Con REDIS_URL (el entorno del arnés y
+    // el de producción) el outbox NO despacha en proceso: encola en BullMQ y
+    // lo resuelve un worker. En una máquina ociosa tarda milisegundos, pero a
+    // mitad de una tanda completa el job puede quedarse esperando su turno y
+    // 30 s se agotaban de vez en cuando — un rojo que no era del producto.
+    // Mismo criterio que `drip-tier-grupo.spec.ts`, que ya esperaba 110 s por
+    // esta misma razón.
     await expect
       .poll(
         () =>
           sql(
             `SELECT status || '|' || source FROM mod_learning_enrollment WHERE tenant_id='${tid}' AND user_id='${userId}' AND course_id='${course.id}'`,
           ),
-        { timeout: 30_000 },
+        { timeout: 90_000 },
       )
       .toBe('ACTIVE|PURCHASE');
 

--- a/apps/e2e/tests/clase-asistencia.spec.ts
+++ b/apps/e2e/tests/clase-asistencia.spec.ts
@@ -109,7 +109,9 @@ test.describe('mod.zoom-live · asistencia real (ADR-018)', () => {
       `${API_URL}/api/v1/modules/zoom-live/sessions/${session.id}/attendance`,
       { headers: alumnoHeaders },
     );
-    expect(forbidden.status).toBe(401);
+    // 403, no 401: el alumno está autenticado, sólo que el informe es de
+    // staff. 401 significaría "vuelve a identificarte", que no es el caso.
+    expect(forbidden.status).toBe(403);
 
     // 5. Antes de reconciliar, el click cuenta — pero declarado como PROXY.
     const beforeRes = await fetch(

--- a/apps/e2e/tests/clase-inscripcion.spec.ts
+++ b/apps/e2e/tests/clase-inscripcion.spec.ts
@@ -107,7 +107,8 @@ test.describe('mod.zoom-live · inscripción a clases en directo (ADR-017)', () 
       `${API_URL}/api/v1/modules/zoom-live/sessions/${session.id}/registrations`,
       { headers: alumnoHeaders },
     );
-    expect(rosterForbidden.status).toBe(401);
+    // 403, no 401: el alumno está autenticado, el roster es de staff.
+    expect(rosterForbidden.status).toBe(403);
 
     // 6. Baja: el joinUrl vuelve a estar gateado.
     const unreg = await fetch(

--- a/apps/e2e/tests/digest-opt-out.spec.ts
+++ b/apps/e2e/tests/digest-opt-out.spec.ts
@@ -4,7 +4,7 @@ import { bootstrapScenario, API_URL } from '../helpers/api';
 /**
  * Spec G5.1: el toggle de "resumen semanal de comunidad" en `/cuenta`
  * debe **persistir tras reload**. Verifica el flow completo:
- *   1. GET /modules/community/preferences → digestOptOut=false (default).
+ *   1. GET /modules/community/me/preferences → digestOptOut=false (default).
  *   2. PUT con digestOptOut=true → 200.
  *   3. Re-GET → digestOptOut=true (persistió en DB, no solo en memoria).
  *   4. PUT con digestOptOut=false → 200.
@@ -16,6 +16,12 @@ import { bootstrapScenario, API_URL } from '../helpers/api';
  *
  * Si el módulo community está deshabilitado en el tenant E2E, los
  * endpoints devuelven 403 y el test queda skip-en-el-acto.
+ *
+ * OJO con la ruta: es `me/preferences`, no `preferences` (ver
+ * `@Get('me/preferences')` en apps/api/src/modules/community/community.controller.ts).
+ * Con la ruta sin `me/` el dispatcher devuelve 404 y el propio guard de arriba
+ * lo interpretaba como «módulo deshabilitado»: el test llevaba tiempo
+ * SKIPEÁNDOSE siempre y nadie ejercitaba el contrato del digest.
  */
 test.describe('Comunidad · digest opt-out persistente (G5.1)', () => {
   test('toggle del digest se persiste en DB tras reload', async () => {
@@ -26,7 +32,7 @@ test.describe('Comunidad · digest opt-out persistente (G5.1)', () => {
     };
 
     // 1. Estado inicial.
-    const initial = await fetch(`${API_URL}/api/v1/modules/community/preferences`, { headers });
+    const initial = await fetch(`${API_URL}/api/v1/modules/community/me/preferences`, { headers });
     if (initial.status === 403 || initial.status === 404) {
       test.skip(
         true,
@@ -39,7 +45,7 @@ test.describe('Comunidad · digest opt-out persistente (G5.1)', () => {
     expect(before.digestOptOut).toBe(false);
 
     // 2. PUT digestOptOut=true.
-    const enable = await fetch(`${API_URL}/api/v1/modules/community/preferences`, {
+    const enable = await fetch(`${API_URL}/api/v1/modules/community/me/preferences`, {
       method: 'PUT',
       headers,
       body: JSON.stringify({ digestOptOut: true }),
@@ -49,13 +55,15 @@ test.describe('Comunidad · digest opt-out persistente (G5.1)', () => {
     expect(enabled.digestOptOut).toBe(true);
 
     // 3. Reload (nuevo fetch, simula recargar la página).
-    const afterEnable = await fetch(`${API_URL}/api/v1/modules/community/preferences`, { headers });
+    const afterEnable = await fetch(`${API_URL}/api/v1/modules/community/me/preferences`, {
+      headers,
+    });
     expect(afterEnable.ok).toBe(true);
     const persisted = (await afterEnable.json()) as { digestOptOut: boolean };
     expect(persisted.digestOptOut).toBe(true);
 
     // 4. PUT digestOptOut=false.
-    const disable = await fetch(`${API_URL}/api/v1/modules/community/preferences`, {
+    const disable = await fetch(`${API_URL}/api/v1/modules/community/me/preferences`, {
       method: 'PUT',
       headers,
       body: JSON.stringify({ digestOptOut: false }),
@@ -63,7 +71,7 @@ test.describe('Comunidad · digest opt-out persistente (G5.1)', () => {
     expect(disable.ok).toBe(true);
 
     // 5. Reload final.
-    const afterDisable = await fetch(`${API_URL}/api/v1/modules/community/preferences`, {
+    const afterDisable = await fetch(`${API_URL}/api/v1/modules/community/me/preferences`, {
       headers,
     });
     const finalState = (await afterDisable.json()) as { digestOptOut: boolean };

--- a/apps/e2e/tests/espacios.spec.ts
+++ b/apps/e2e/tests/espacios.spec.ts
@@ -86,9 +86,15 @@ test.describe('Sidebar — sección ESPACIOS', () => {
   }) => {
     await withAdminSession(page, '/comunidad');
     const sidebar = page.locator('aside').first();
-    // Esperar a que carguen los espacios (puede haber un flash de loading)
-    await page.waitForTimeout(1500);
-    // Debe haber al menos un link dentro de la sección ESPACIOS apuntando a /espacios/
+    // La sección arranca PLEGADA y sólo enseña el contador (botón "Foros N"),
+    // así que los enlaces no están en el DOM hasta desplegarla. Antes se
+    // esperaba 1,5 s a un "flash de loading" y se afirmaba sobre enlaces que
+    // ya no se pintan de entrada: el fallo no era de datos.
+    const toggle = sidebar.getByRole('button', { name: /^Foros/ });
+    await expect(toggle).toBeVisible({ timeout: 8000 });
+    await toggle.click();
+
+    // Debe haber al menos un link dentro de la sección apuntando a /espacios/
     const espaciosLinks = sidebar.locator('a[href^="/espacios/"]');
     await expect(espaciosLinks.first()).toBeVisible({ timeout: 8000 });
     const count = await espaciosLinks.count();
@@ -241,8 +247,15 @@ test.describe('Página /espacios/[space]', () => {
   test('el compositor se abre al pulsar "Nueva publicación"', async ({ page }) => {
     await withAdminSession(page, '/espacios/general');
     await page.getByRole('button', { name: 'Nueva publicación' }).click();
-    // El modal PostComposerModal debe aparecer
-    await expect(page.locator('[role="dialog"]').first()).toBeVisible({ timeout: 5000 });
+    // El modal PostComposerModal debe aparecer. Se busca POR NOMBRE, no con
+    // `[role="dialog"]`.first(): el drawer de navegación móvil es también un
+    // `role="dialog"` (aria-label "Menú de navegación") y, aunque esté cerrado,
+    // aparece antes en el DOM — `.first()` resolvía a él y la aserción moría
+    // con "unexpected value hidden". Es el mismo patrón que ya usa el resto
+    // del fichero para el modal "Nuevo espacio".
+    await expect(page.getByRole('dialog', { name: 'Nueva publicación' })).toBeVisible({
+      timeout: 5000,
+    });
   });
 
   test('el selector de ordenación tiene las 3 opciones', async ({ page }) => {

--- a/apps/e2e/tests/inscribe-by-api.spec.ts
+++ b/apps/e2e/tests/inscribe-by-api.spec.ts
@@ -7,6 +7,7 @@ import {
   listCoursesViaApi,
   revokeViaApi,
   signup,
+  signupOnboarded,
 } from '../helpers/api';
 import { injectSession } from '../helpers/auth';
 
@@ -168,7 +169,12 @@ test.describe('Inscripción externa por API', () => {
       slug: `sin-matricula-e2e-${stamp}`,
     });
 
-    const alumno = await signup({
+    // `signupOnboarded` y no `signup` a secas: un alumno recién dado de alta
+    // nace con `onboardingCompletedAt` a null y el gate de
+    // `apps/web/src/app/(app)/layout.tsx:92` desvía TODA ruta autenticada al
+    // asistente `/onboarding`. Sin esto la ficha del curso no llega a
+    // renderizarse nunca y el fallo parece de la ficha.
+    const alumno = await signupOnboarded({
       tenantSlug,
       email: `e2e-no-matricula-${stamp}@example.test`,
       password: 'E2eNoMatricula123!',

--- a/apps/e2e/tests/mobile-nav.spec.ts
+++ b/apps/e2e/tests/mobile-nav.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { createSmokeStudent } from '../helpers/api';
 import { injectSession } from '../helpers/auth';
 
 /**
@@ -15,21 +16,16 @@ import { injectSession } from '../helpers/auth';
  * así ambos salen del árbol de accesibilidad y no hay coincidencias duplicadas.
  */
 
-// Sesión inyectada (permitido en specs por la regla #3). `onboardingCompletedAt`
-// evita el gate de onboarding de primera vez del layout.
-const SESSION = {
-  accessToken: 'fake-token-mobile-nav',
-  user: {
-    id: 'user-mobile-1',
-    email: 'lucia@acme.com',
-    name: 'Lucía Gómez',
-    tenantId: 'tenant-acme',
-    tenantSlug: 'acme',
-    roles: ['alumno'],
-    mfaEnabled: false,
-    onboardingCompletedAt: '2026-01-01T00:00:00.000Z',
-  },
-};
+// Sesión REAL de alumno (alta por `POST /auth/signup` en el tenant de smoke,
+// con el onboarding cerrado por el mismo camino que la UI). Antes aquí había
+// un `accessToken: 'fake-token-mobile-nav'` contra el tenant inexistente
+// `acme`: el shell pintaba, pero cada llamada a la API respondía 401 y el
+// drawer nunca llegaba a poblarse.
+let session: Awaited<ReturnType<typeof createSmokeStudent>>;
+
+test.beforeAll(async () => {
+  session = await createSmokeStudent('mobile-nav');
+});
 
 const MOBILE = { width: 390, height: 844 }; // iPhone 12/13/14
 const DESKTOP = { width: 1280, height: 900 };
@@ -37,7 +33,11 @@ const DESKTOP = { width: 1280, height: 900 };
 async function withSession(page: Page, url: string, viewport: { width: number; height: number }) {
   await page.setViewportSize(viewport);
   await page.goto('/signin');
-  await injectSession(page, SESSION);
+  await injectSession(page, {
+    accessToken: session.tokens.accessToken,
+    refreshToken: session.tokens.refreshToken,
+    user: session.user,
+  });
   await page.goto(url);
 }
 
@@ -55,7 +55,11 @@ test.describe('Navegación móvil — drawer + bottom nav', () => {
     await expect(hamburger).toBeVisible();
     await expect(tabBar).toBeVisible();
     await expect(tabBar.getByRole('link', { name: 'Feed' })).toBeVisible();
-    await expect(tabBar.getByRole('link', { name: 'Cursos' })).toBeVisible();
+    // `exact` obligatorio: el nombre accesible se compara por subcadena y
+    // "Cursos" también casa con "Recursos", que es un enlace real del menú
+    // (mod.resources). Con la sesión falsa anterior ese enlace no llegaba a
+    // pintarse y la ambigüedad no se veía.
+    await expect(tabBar.getByRole('link', { name: 'Cursos', exact: true })).toBeVisible();
     await expect(tabBar.getByRole('button', { name: 'Menú' })).toBeVisible();
 
     // Drawer cerrado → fuera del árbol de accesibilidad (aria-hidden).
@@ -73,7 +77,7 @@ test.describe('Navegación móvil — drawer + bottom nav', () => {
     // Reabrir por la pestaña "Menú" del bottom-nav y navegar a Cursos.
     await tabBar.getByRole('button', { name: 'Menú' }).click();
     await expect(drawer).toBeVisible();
-    await drawer.getByRole('link', { name: 'Cursos' }).click();
+    await drawer.getByRole('link', { name: 'Cursos', exact: true }).click();
     await expect(page).toHaveURL(/\/cursos/);
     // Al navegar el drawer se cierra solo.
     await expect(drawer).toBeHidden();

--- a/apps/e2e/tests/payment-connections.spec.ts
+++ b/apps/e2e/tests/payment-connections.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { adminTokenForBootstrap, API_URL } from '../helpers/api';
+import { adminSessionForBootstrap, API_URL } from '../helpers/api';
 import { injectSession } from '../helpers/auth';
 
 /**
@@ -26,7 +26,7 @@ test.describe('mod.payment-connections — contrato admin + render del panel', (
     page,
   }) => {
     const tenantSlug = process.env.E2E_TENANT_SLUG ?? 'demo';
-    const bearer = await adminTokenForBootstrap(tenantSlug);
+    const { accessToken: bearer, user: adminUser } = await adminSessionForBootstrap(tenantSlug);
     const apiHeaders = {
       Authorization: `Bearer ${bearer}`,
       'Content-Type': 'application/json',
@@ -57,35 +57,29 @@ test.describe('mod.payment-connections — contrato admin + render del panel', (
     expect([401, 403], 'sin token → 401/403').toContain(noAuthRes.status);
 
     // 4) Render del panel para super_admin.
-    const meRes = await fetch(`${API_URL}/api/v1/me`, {
+    // El perfil se lee de `/me/profile` (MeController: @Controller('me') +
+    // @Get('profile')). Antes esto pegaba a `/api/v1/me` a secas, que NUNCA ha
+    // existido: el 404 hacía caer el test aquí mismo y enmascaraba el error de
+    // la aserción de más abajo.
+    const meRes = await fetch(`${API_URL}/api/v1/me/profile`, {
       headers: { Authorization: `Bearer ${bearer}` },
     });
-    expect(meRes.ok, '/api/v1/me devuelve 200').toBe(true);
-    const me = (await meRes.json()) as {
-      id: string;
-      email: string;
-      tenantId: string;
-      roles: string[];
-    };
+    expect(meRes.ok, '/api/v1/me/profile devuelve 200').toBe(true);
+    const me = (await meRes.json()) as { id: string; email: string; roles: string[] };
+    expect(me.roles, 'el admin sembrado es super_admin').toContain('super_admin');
 
     await page.goto('/signin');
-    await injectSession(page, {
-      accessToken: bearer,
-      user: {
-        id: me.id,
-        email: me.email,
-        name: 'Admin E2E',
-        tenantId: me.tenantId,
-        tenantSlug,
-        roles: me.roles,
-        mfaEnabled: true,
-      },
-    });
+    await injectSession(page, { accessToken: bearer, user: adminUser });
 
     await page.goto('/admin/integraciones/payment-connections');
     await expect(page.getByRole('heading', { name: 'Conexiones de pago' })).toBeVisible({
       timeout: 15_000,
     });
-    await expect(page.getByText('Conectar una cuenta de Stripe')).toBeVisible({ timeout: 10_000 });
+    // El form de alta se titula "Conectar una cuenta de PAGO" — el panel sirve
+    // a stripe, paypal y woocommerce, no sólo a Stripe (ver el <select> de
+    // `provider` en la página y `adminPagos.connections.formTitle`). El texto
+    // "Conectar una cuenta de Stripe" que se afirmaba aquí no ha existido
+    // jamás en el producto: `git log -S` sólo lo encuentra en este spec.
+    await expect(page.getByText('Conectar una cuenta de pago')).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/apps/e2e/tests/redesign-smoke.spec.ts
+++ b/apps/e2e/tests/redesign-smoke.spec.ts
@@ -1,25 +1,37 @@
 import { expect, test } from '@playwright/test';
+import { createSmokeStudent } from '../helpers/api';
 import { injectSession } from '../helpers/auth';
 
-const FAKE_SESSION = {
-  accessToken: 'fake-token-smoke',
-  user: {
-    id: 'user-smoke-1',
-    email: 'lucia@acme.com',
-    name: 'Lucía Gómez',
-    tenantId: 'tenant-acme',
-    tenantSlug: 'acme',
-    roles: ['alumno'],
-    mfaEnabled: false,
-    // Sin esto el gate de onboarding secuestra la navegación y TODOS los tests
-    // del spec acaban en /signin (mismo fallo preexistente que enroll-by-code).
-    onboardingCompletedAt: '2026-01-01T00:00:00.000Z',
-  },
-};
+/**
+ * Smoke de las páginas principales con la sesión de un alumno.
+ *
+ * La sesión es REAL: alumno dado de alta por `POST /auth/signup` en el tenant
+ * de smoke, con el onboarding cerrado por el mismo camino que usa la UI.
+ *
+ * Antes se inyectaba `accessToken: 'fake-token-smoke'` con `tenantSlug:
+ * 'acme'` — un tenant que no existe. Con eso el shell pintaba, pero TODAS las
+ * llamadas a la API respondían 401 y las once aserciones caían por falta de
+ * datos. Maquillar los localizadores habría escondido el problema: lo que
+ * faltaba era el usuario.
+ *
+ * El tenant de smoke importa además por otro motivo: varias aserciones son
+ * sobre estados VACÍOS (sin grupos, sin eventos, sin conversaciones), y en el
+ * tenant principal dejan de ser ciertas en cuanto otro spec crea un grupo.
+ */
+
+let session: Awaited<ReturnType<typeof createSmokeStudent>>;
+
+test.beforeAll(async () => {
+  session = await createSmokeStudent('smoke');
+});
 
 async function withSession(page: Parameters<typeof injectSession>[0], url: string) {
   await page.goto('/signin');
-  await injectSession(page, FAKE_SESSION);
+  await injectSession(page, {
+    accessToken: session.tokens.accessToken,
+    refreshToken: session.tokens.refreshToken,
+    user: session.user,
+  });
   await page.goto(url);
 }
 
@@ -108,7 +120,16 @@ test.describe('Redesign smoke — páginas principales', () => {
   test('/mensajes muestra heading y área vacía', async ({ page }) => {
     await withSession(page, '/mensajes');
     await expect(page.getByRole('heading', { name: 'Mensajes' })).toBeVisible();
-    await expect(page.getByText('No tienes conversaciones todavía.')).toBeVisible();
-    await expect(page.getByText('Mensajes directos')).toBeVisible();
+    // El panel derecho sin conversación seleccionada. Antes se afirmaban aquí
+    // "No tienes conversaciones todavía." y "Mensajes directos", copys que
+    // desaparecieron cuando `mod.messaging` v1 (commit 64a93c62) reescribió la
+    // página entera: la lista pasó a agruparse en Salas / Profesores /
+    // Directos y el vacío pasó a ser esta nota. El spec se quedó afirmando
+    // texto de la página anterior.
+    await expect(
+      page.getByText(
+        'Selecciona una sala, tu canal de profesores o un directo — o inicia una conversación nueva.',
+      ),
+    ).toBeVisible();
   });
 });

--- a/scripts/e2e-env.sh
+++ b/scripts/e2e-env.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Didacta — entorno canónico del arnés E2E.
+# ----------------------------------------------------------------------------
+# ÚNICA fuente de verdad de las variables que necesita la suite de Playwright.
+# La consumen los dos caminos, y por eso dejaron de divergir:
+#
+#   local  →  source scripts/e2e-env.sh          (lo hace scripts/e2e-stack.sh)
+#   CI     →  bash scripts/e2e-env.sh --github-env >> "$GITHUB_ENV"
+#
+# Antes cada camino tenía su propia copia de la lista y CI se había quedado
+# sin cuatro piezas (seed.sql, onboarding del admin, secretos de Stripe y el
+# contenedor de Postgres del spec de catálogo). Con un solo fichero eso no
+# puede volver a pasar: si falta algo, falta en los dos sitios a la vez y
+# `global-setup.ts` lo grita antes de correr un solo test.
+#
+# Toda variable ya presente en el entorno GANA (patrón `: "${VAR:=...}"`), de
+# forma que un runner o un desarrollador pueden apuntar a otra base de datos
+# sin editar este fichero.
+#
+# La infraestructura por defecto es `docker-compose.test.yml` — el MISMO
+# compose en local y en CI. De ahí salen el usuario/base `didacta_test` y el
+# nombre de contenedor `didacta-postgres-test` que `catalogo-publico.spec.ts`
+# necesita para su `docker exec`.
+#
+# Los secretos de aquí son sintéticos y de un solo uso para tests: no abren
+# nada, no son rotables y no existen fuera de este arnés.
+# ============================================================================
+
+# ── Infraestructura (docker-compose.test.yml) ───────────────────────────────
+: "${E2E_PG_CONTAINER:=didacta-postgres-test}"
+: "${E2E_PG_USER:=didacta_test}"
+: "${E2E_PG_DB:=didacta_test}"
+: "${E2E_PG_PORT:=5433}"
+: "${DATABASE_URL:=postgresql://${E2E_PG_USER}:${E2E_PG_USER}@localhost:${E2E_PG_PORT}/${E2E_PG_DB}?schema=public}"
+
+# REDIS_URL NO es opcional en el arnés. Sin él `messaging-realtime.publisher`
+# degrada a no-op silencioso y los specs de realtime fallan sin decir por qué
+# (5 tests en la sesión anterior). `global-setup.ts` aborta si no está.
+: "${REDIS_URL:=redis://localhost:6380}"
+
+# ── Secretos sintéticos de la API (mínimo 32 caracteres) ────────────────────
+: "${JWT_SECRET:=e2e-test-secret-must-be-at-least-32-chars-long-aaaa}"
+: "${JWT_REFRESH_SECRET:=e2e-refresh-secret-must-be-32-chars-long-bbbb}"
+: "${AUTH_SECRET:=e2e-auth-secret-must-be-at-least-32-chars-long-cccc}"
+: "${AUTH_URL:=http://localhost:4000}"
+# Master key AES-256-GCM (64 hex) para TenantSettings cifrado. Obligatoria en
+# NODE_ENV=production; valor determinista de-prueba, nunca un secreto real.
+: "${TENANT_SETTINGS_ENC_KEY:=0000000000000000000000000000000000000000000000000000000000000000}"
+
+# ── Runtime de la API y la web ──────────────────────────────────────────────
+: "${NODE_ENV:=production}"
+# El registro público está cerrado por defecto (auth.service). Los specs lo
+# usan para fabricar alumnos de prueba → se reabre solo aquí.
+: "${AUTH_SIGNUP_ENABLED:=true}"
+: "${PORT:=4000}"
+: "${API_PORT:=4000}"
+: "${API_INTERNAL_URL:=http://localhost:4000}"
+
+# ── Rate limit: ver comentario largo abajo ──────────────────────────────────
+# Con REDIS_URL activo el rate limiter global DEJA de fallar abierto y entra en
+# vigor el cupo por defecto del plan community: 100 req/min autenticadas y
+# 30 req/min públicas, ESTAS ÚLTIMAS COMPARTIDAS por todo el tráfico anónimo
+# (bucket 'anonymous' en rate-limit.interceptor.ts). Una suite serie de 270
+# tests hace muchísimo más que eso en un minuto: cada `signin()` es pública.
+#
+# La API ya expone el cupo como configuración de primera clase
+# (`resolveRateLimitConfig()` en apps/api/src/rate-limit/rate-limit.types.ts),
+# así que el arnés sube el cupo por env en vez de parchear el producto o
+# dormir 65 s entre tandas. No se desactiva el limiter: sigue contando,
+# sigue devolviendo los headers X-RateLimit-* y sigue siendo el mismo código
+# que en producción — sólo con un techo que no estrangula al arnés.
+: "${RATE_LIMIT_COMMUNITY_AUTH_PER_MIN:=100000}"
+: "${RATE_LIMIT_COMMUNITY_PUBLIC_PER_MIN:=100000}"
+
+# ── Bootstrap del tenant principal ──────────────────────────────────────────
+: "${BOOTSTRAP_TENANT_SLUG:=demo}"
+: "${BOOTSTRAP_EMAIL:=e2e-admin@example.test}"
+: "${BOOTSTRAP_PASSWORD:=E2eAdminPassword123!}"
+
+# ── Tenant limpio para los specs de smoke ───────────────────────────────────
+# `redesign-smoke` y `mobile-nav` afirman estados vacíos ("No hay grupos
+# disponibles", "No tienes conversaciones todavía"). En `demo` eso es falso a
+# mitad de suite porque otros specs crean grupos, clases y mensajes. Se siembra
+# un segundo tenant real con el mismo `seed.ts` (idempotente y env-driven) y
+# ahí sí los estados vacíos son ciertos de verdad.
+#
+# Cada tenant necesita su PROPIO hostname, y no es un capricho: el alta y el
+# login resuelven el tenant por el Host header ANTES de mirar el `tenantSlug`
+# del body (`resolveTenantIdFromHost` en apps/api/src/auth/auth.controller.ts
+# gana sobre `explicitSlug` en auth.service.ts). Con los dos tenants apuntando
+# a `localhost` sería imposible autenticarse contra el segundo.
+#
+#   demo  → localhost   (E2E_BASE_URL / E2E_API_URL, todo lo demás)
+#   smoke → 127.0.0.1   (E2E_SMOKE_API_URL, sólo el alta del alumno de smoke)
+#
+# 127.0.0.1 se elige a propósito por encima de un `*.localhost`: resuelve en
+# cualquier sistema operativo sin tocar el fichero hosts.
+: "${E2E_SMOKE_TENANT_SLUG:=e2e-smoke}"
+: "${E2E_SMOKE_TENANT_DOMAIN:=127.0.0.1}"
+: "${E2E_SMOKE_ADMIN_EMAIL:=e2e-smoke-admin@example.test}"
+# Contra la API DIRECTA: a través del rewrite de Next el Host que llega es
+# siempre `localhost:4000` (Next reescribe `host` y mueve el original a
+# `x-forwarded-host`, que este resolver no mira), así que por ahí nunca se
+# podría alcanzar al segundo tenant.
+: "${E2E_SMOKE_API_URL:=http://127.0.0.1:${API_PORT}}"
+
+# ── Lo que lee la suite de Playwright ───────────────────────────────────────
+# `next start` tiene el puerto fijo en el script (`-p 3010`, apps/web/package.json).
+: "${E2E_BASE_URL:=http://localhost:3010}"
+: "${E2E_API_URL:=http://localhost:3010}"
+: "${E2E_API_DIRECT_URL:=http://localhost:4000}"
+: "${E2E_TENANT_SLUG:=demo}"
+: "${E2E_ADMIN_EMAIL:=${BOOTSTRAP_EMAIL}}"
+: "${E2E_ADMIN_PASSWORD:=${BOOTSTRAP_PASSWORD}}"
+
+# ── Webhooks de pago (firmados en local, sin tocar Stripe) ──────────────────
+# Sin estos, `membership-trial`, `referrals-flow` y `catalogo-publico` reciben
+# 400/401 al entregar el webhook que ellos mismos firman. No son claves reales:
+# la `sk_test_` lleva guiones a propósito para no parecerse a una de Stripe.
+#
+# UN solo valor y cuatro nombres derivados. Son los nombres que ya leen, por un
+# lado la API (STRIPE_/SUBSCRIPTIONS_) y por otro cada spec, que tiene el suyo
+# (E2E_STRIPE_ en membership-trial y referrals-flow, E2E_BILLING_ en
+# catalogo-publico). Derivarlos es lo que impide que vuelvan a divergir: en la
+# tanda anterior sólo estaba puesto E2E_BILLING_ y los tres specs de webhook
+# firmaban con un secreto distinto del que validaba la API.
+: "${E2E_WEBHOOK_SECRET:=whsec_e2e_de_prueba}"
+: "${STRIPE_SECRET_KEY:=sk_test_de-prueba-no-es-una-clave-real}"
+: "${STRIPE_WEBHOOK_SECRET:=${E2E_WEBHOOK_SECRET}}"
+: "${SUBSCRIPTIONS_WEBHOOK_SECRET:=${E2E_WEBHOOK_SECRET}}"
+: "${E2E_STRIPE_WEBHOOK_SECRET:=${E2E_WEBHOOK_SECRET}}"
+: "${E2E_BILLING_WEBHOOK_SECRET:=${E2E_WEBHOOK_SECRET}}"
+
+E2E_ENV_VARS="
+DATABASE_URL REDIS_URL
+E2E_PG_CONTAINER E2E_PG_USER E2E_PG_DB E2E_PG_PORT
+JWT_SECRET JWT_REFRESH_SECRET AUTH_SECRET AUTH_URL TENANT_SETTINGS_ENC_KEY
+NODE_ENV AUTH_SIGNUP_ENABLED PORT API_PORT API_INTERNAL_URL
+RATE_LIMIT_COMMUNITY_AUTH_PER_MIN RATE_LIMIT_COMMUNITY_PUBLIC_PER_MIN
+BOOTSTRAP_TENANT_SLUG BOOTSTRAP_EMAIL BOOTSTRAP_PASSWORD
+E2E_SMOKE_TENANT_SLUG E2E_SMOKE_TENANT_DOMAIN E2E_SMOKE_ADMIN_EMAIL E2E_SMOKE_API_URL
+E2E_BASE_URL E2E_API_URL E2E_API_DIRECT_URL
+E2E_TENANT_SLUG E2E_ADMIN_EMAIL E2E_ADMIN_PASSWORD
+E2E_WEBHOOK_SECRET STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET
+SUBSCRIPTIONS_WEBHOOK_SECRET E2E_STRIPE_WEBHOOK_SECRET E2E_BILLING_WEBHOOK_SECRET
+"
+
+# shellcheck disable=SC2086
+export $(echo "$E2E_ENV_VARS" | tr -s '[:space:]' ' ')
+
+# `--github-env` vuelca `KEY=value` para redirigirlo a $GITHUB_ENV. Se ejecuta,
+# no se sourcea, así que aquí sí conviene escribir por stdout.
+if [ "${1:-}" = "--github-env" ]; then
+  for _v in $E2E_ENV_VARS; do
+    eval "printf '%s=%s\n' \"$_v\" \"\${$_v}\""
+  done
+fi

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Didacta — arnés E2E: levanta el producto ENTERO y lo deja reproducible.
+# ----------------------------------------------------------------------------
+# Antes de este script la receta de arranque vivía repartida entre el workflow
+# de CI y un documento, y ninguno de los dos levantaba el producto completo:
+# faltaban los espacios de sistema (`prisma/seed.sql`), el onboarding del admin
+# sembrado, Redis (realtime) y los secretos de webhooks de pago. El resultado
+# eran 25 tests en rojo que parecían fallos de producto y no lo eran.
+#
+# Uso (siempre desde la raíz del repo):
+#
+#   bash scripts/e2e-stack.sh up        # infra docker (postgres + redis)
+#   bash scripts/e2e-stack.sh schema    # migraciones + RLS + grants, SIN sembrar
+#   bash scripts/e2e-stack.sh db        # schema + seeds (tenants y espacios)
+#   bash scripts/e2e-stack.sh build     # packages + modules + api + web
+#   bash scripts/e2e-stack.sh start     # arranca api y web y espera healthz
+#   bash scripts/e2e-stack.sh stop      # para SOLO los procesos que arrancó
+#   bash scripts/e2e-stack.sh reset     # BD limpia + REINICIO de la api
+#   bash scripts/e2e-stack.sh check     # diagnóstico del stack
+#   bash scripts/e2e-stack.sh all       # up + db + build + start
+#   bash scripts/e2e-stack.sh test [args…]   # reset + playwright
+#
+# `reset` existe porque la suite NO es idempotente: los specs de Fundae usan
+# NIFs fijos y en la segunda pasada devuelven 409. Y reinicia la API a
+# propósito: el registro de módulos y el token de setup se emiten en el
+# bootstrap de NestJS, así que una BD nueva bajo una API viva deja
+# `module-toggle` fallando con un 500 que no tiene nada que ver.
+#
+# Nunca mata procesos que no haya arrancado él (esta máquina tiene huérfanos de
+# otros proyectos): guarda los PID en .e2e-stack/ y sólo toca esos.
+# ============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=scripts/e2e-env.sh
+. "$REPO_ROOT/scripts/e2e-env.sh"
+
+RUN_DIR="$REPO_ROOT/.e2e-stack"
+API_PID_FILE="$RUN_DIR/api.pid"
+WEB_PID_FILE="$RUN_DIR/web.pid"
+API_LOG="$RUN_DIR/api.log"
+WEB_LOG="$RUN_DIR/web.log"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.test.yml"
+
+# Segundos que esperamos a que api+web respondan. La primera arrancada de Next
+# en Windows tarda bastante más que en un runner Linux.
+readonly HEALTH_TIMEOUT_SECONDS=180
+
+NODE_BIN="node"
+PRISMA_CLI="$REPO_ROOT/node_modules/prisma/build/index.js"
+TSX_CLI="$REPO_ROOT/node_modules/tsx/dist/cli.mjs"
+TSC_BIN="$REPO_ROOT/node_modules/typescript/bin/tsc"
+NEST_CLI="$REPO_ROOT/node_modules/@nestjs/cli/bin/nest.js"
+NEXT_CLI="$REPO_ROOT/node_modules/next/dist/bin/next"
+PLAYWRIGHT_CLI="$REPO_ROOT/node_modules/@playwright/test/cli.js"
+
+log() { printf '\033[36m[e2e-stack]\033[0m %s\n' "$*"; }
+die() { printf '\033[31m[e2e-stack] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+mkdir -p "$RUN_DIR"
+
+# ── infra ───────────────────────────────────────────────────────────────────
+cmd_up() {
+  log "Levantando docker-compose.test.yml (postgres $E2E_PG_PORT, redis 6380)…"
+  docker compose -f "$COMPOSE_FILE" up -d --wait
+  log "Infra lista."
+}
+
+cmd_down() {
+  log "Bajando la infra y BORRANDO sus datos…"
+  docker compose -f "$COMPOSE_FILE" down -v
+}
+
+# psql contra el Postgres del compose. Se hace por `docker exec` a propósito:
+# es el único camino que funciona igual en este Windows (sin cliente psql
+# instalado) y en el runner de CI, porque el compose es el mismo en los dos.
+psql_file() {
+  docker exec -i "$E2E_PG_CONTAINER" psql -U "$E2E_PG_USER" -d "$E2E_PG_DB" -v ON_ERROR_STOP=1 -f - < "$1"
+}
+
+psql_query() {
+  docker exec -i "$E2E_PG_CONTAINER" psql -U "$E2E_PG_USER" -d "$E2E_PG_DB" -t -A -c "$1"
+}
+
+# ── base de datos ───────────────────────────────────────────────────────────
+# Sólo el esquema: migraciones + RLS + grants, SIN sembrar. Lo necesita el
+# wizard de `/setup`, que sólo se puede completar una vez por instancia y por
+# tanto exige una base donde todavía no exista ningún tenant.
+cmd_schema() {
+  assert_prisma_client
+  log "Aplicando migraciones…"
+  "$NODE_BIN" "$PRISMA_CLI" migrate deploy --schema packages/database/prisma/schema.prisma
+
+  # grants.sql no es opcional: desde RLS F3 el arranque hace
+  # `SET LOCAL ROLE didacta_super` y sin el rol la API no llega a levantar.
+  log "Aplicando rls.sql y grants.sql…"
+  psql_file packages/database/prisma/rls.sql >/dev/null
+  psql_file packages/database/prisma/grants.sql >/dev/null
+}
+
+assert_prisma_client() {
+  [ -d "$REPO_ROOT/node_modules/.prisma/client" ] || \
+    [ -n "$(find "$REPO_ROOT/node_modules/.pnpm" -maxdepth 6 -type d -name '.prisma' -print -quit 2>/dev/null)" ] || \
+    die "Falta el cliente Prisma. Corre primero: bash scripts/e2e-stack.sh build"
+}
+
+cmd_db() {
+  # `prisma generate` vive en `build`, no aquí: en Windows el motor de consultas
+  # (`query_engine-windows.dll.node`) queda abierto por la API viva y el rename
+  # revienta con EPERM. `reset` corre `db` con la API parada, pero `db` suelto
+  # se usa muchas veces con el stack arriba.
+  cmd_schema
+
+  log "Sembrando tenant principal ($BOOTSTRAP_TENANT_SLUG)…"
+  ( cd packages/database && \
+    BOOTSTRAP_TENANT_SLUG="$BOOTSTRAP_TENANT_SLUG" \
+    BOOTSTRAP_EMAIL="$BOOTSTRAP_EMAIL" \
+    BOOTSTRAP_PASSWORD="$BOOTSTRAP_PASSWORD" \
+    BOOTSTRAP_DOMAINS="localhost" \
+    "$NODE_BIN" "$TSX_CLI" src/seed.ts >/dev/null )
+
+  # Segundo tenant, con el MISMO seed del producto (es idempotente y va por
+  # env). Sirve a los specs que afirman estados vacíos: en `demo` dejan de ser
+  # ciertos a mitad de suite. BOOTSTRAP_DOMAINS propio y obligatorio — con el
+  # default le robaría `localhost` al tenant principal.
+  log "Sembrando tenant de smoke ($E2E_SMOKE_TENANT_SLUG)…"
+  ( cd packages/database && \
+    BOOTSTRAP_TENANT_SLUG="$E2E_SMOKE_TENANT_SLUG" \
+    BOOTSTRAP_TENANT_NAME="E2E Smoke" \
+    BOOTSTRAP_EMAIL="$E2E_SMOKE_ADMIN_EMAIL" \
+    BOOTSTRAP_PASSWORD="$BOOTSTRAP_PASSWORD" \
+    BOOTSTRAP_DOMAINS="$E2E_SMOKE_TENANT_DOMAIN" \
+    "$NODE_BIN" "$TSX_CLI" src/seed.ts >/dev/null )
+
+  # seed.sql crea los 4 espacios de sistema (general/anuncios/preguntas/recursos)
+  # para TODOS los tenants. Lo aplica infra/docker/entrypoint.sh en el contenedor
+  # de producto, pero ni `db:seed` ni el arnés lo hacían: `mod_community_space`
+  # se quedaba a 0 filas y todo lo de comunidad/espacios fallaba por datos que
+  # no existían. Va DESPUÉS de los seeds porque necesita los tenants creados.
+  log "Aplicando seed.sql (espacios de sistema)…"
+  psql_file packages/database/prisma/seed.sql >/dev/null
+
+  local spaces
+  spaces="$(psql_query 'SELECT count(*) FROM mod_community_space;')"
+  log "Base lista. Espacios de sistema sembrados: $spaces"
+}
+
+# ── compilación ─────────────────────────────────────────────────────────────
+cmd_build() {
+  # Requiere la API PARADA: en Windows el rename del motor de consultas de
+  # Prisma da EPERM si algún proceso lo tiene abierto.
+  log "Generando cliente Prisma…"
+  "$NODE_BIN" "$PRISMA_CLI" generate --schema packages/database/prisma/schema.prisma >/dev/null
+
+  log "Compilando los 5 packages…"
+  for p in packages/database packages/core-kernel packages/core-registry \
+           packages/license-sdk packages/module-package-spec; do
+    ( cd "$p" && "$NODE_BIN" "$TSC_BIN" -p tsconfig.json )
+  done
+
+  # Los 24 modules NO son opcionales: sin dist/ la API falla en *collect*.
+  log "Compilando los modules…"
+  for p in modules/*/; do
+    ( cd "$p" && "$NODE_BIN" "$TSC_BIN" -p tsconfig.json )
+  done
+
+  log "Compilando la API…"
+  ( cd apps/api && "$NODE_BIN" "$NEST_CLI" build )
+
+  # API_INTERNAL_URL se CONGELA en el build: los rewrites de next.config.mjs se
+  # hornean en routes-manifest.json. Mover la API de puerto obliga a reconstruir.
+  log "Compilando la web…"
+  ( cd apps/web && API_INTERNAL_URL="$API_INTERNAL_URL" NODE_ENV=production \
+      "$NODE_BIN" "$NEXT_CLI" build )
+}
+
+# ── procesos ────────────────────────────────────────────────────────────────
+is_alive() {
+  local pid_file="$1"
+  [ -f "$pid_file" ] || return 1
+  local pid
+  pid="$(cat "$pid_file")"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+start_api() {
+  if is_alive "$API_PID_FILE"; then
+    log "API ya viva (pid $(cat "$API_PID_FILE"))."
+    return
+  fi
+  log "Arrancando la API en :$PORT…"
+  ( cd apps/api && "$NODE_BIN" dist/main.js > "$API_LOG" 2>&1 & echo $! > "$API_PID_FILE" )
+}
+
+start_web() {
+  if is_alive "$WEB_PID_FILE"; then
+    log "Web ya viva (pid $(cat "$WEB_PID_FILE"))."
+    return
+  fi
+  # PORT=4000 es de la API y `next start` lo respeta por encima del -p del
+  # script; hay que quitarlo del entorno del proceso web.
+  log "Arrancando la web en :3010…"
+  ( cd apps/web && unset PORT && "$NODE_BIN" "$NEXT_CLI" start -p 3010 > "$WEB_LOG" 2>&1 & echo $! > "$WEB_PID_FILE" )
+}
+
+stop_pid_file() {
+  local pid_file="$1" name="$2"
+  if is_alive "$pid_file"; then
+    local pid
+    pid="$(cat "$pid_file")"
+    log "Parando $name (pid $pid)…"
+    kill "$pid" 2>/dev/null || true
+    # En Windows `next start` deja un hijo; el group kill lo recoge.
+    kill -- "-$pid" 2>/dev/null || true
+  fi
+  rm -f "$pid_file"
+}
+
+wait_healthy() {
+  local i=0
+  log "Esperando a api :$PORT y web :3010 (máx ${HEALTH_TIMEOUT_SECONDS}s)…"
+  while [ "$i" -lt "$HEALTH_TIMEOUT_SECONDS" ]; do
+    if curl -sf "http://localhost:${PORT}/healthz" >/dev/null 2>&1 \
+       && curl -sf -o /dev/null "http://localhost:3010/signin" 2>/dev/null; then
+      log "api + web arriba."
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  log "----- últimas líneas de api.log -----"; tail -n 30 "$API_LOG" 2>/dev/null || true
+  log "----- últimas líneas de web.log -----"; tail -n 30 "$WEB_LOG" 2>/dev/null || true
+  die "api/web no respondieron en ${HEALTH_TIMEOUT_SECONDS}s."
+}
+
+cmd_start() { start_api; start_web; wait_healthy; }
+
+cmd_stop() {
+  stop_pid_file "$API_PID_FILE" "la API"
+  stop_pid_file "$WEB_PID_FILE" "la web"
+}
+
+# ── reset entre tandas ──────────────────────────────────────────────────────
+cmd_reset() {
+  log "Reset completo: infra nueva + BD nueva + API reiniciada."
+  stop_pid_file "$API_PID_FILE" "la API"
+  cmd_down
+  cmd_up
+  cmd_db
+  start_api
+  start_web
+  wait_healthy
+}
+
+# ── diagnóstico ─────────────────────────────────────────────────────────────
+cmd_check() {
+  printf 'DATABASE_URL   %s\n' "$DATABASE_URL"
+  printf 'REDIS_URL      %s\n' "$REDIS_URL"
+  printf 'postgres       %s\n' "$(docker inspect -f '{{.State.Status}}' "$E2E_PG_CONTAINER" 2>/dev/null || echo ausente)"
+  printf 'redis          %s\n' "$(docker inspect -f '{{.State.Status}}' didacta-redis-test 2>/dev/null || echo ausente)"
+  printf 'api :%s        %s\n' "$PORT" "$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/healthz" || echo sin-respuesta)"
+  printf 'web :3010      %s\n' "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3010/signin || echo sin-respuesta)"
+  printf 'tenants        %s\n' "$(psql_query 'SELECT string_agg(slug, ", " ORDER BY slug) FROM tenant;' 2>/dev/null || echo n/d)"
+  printf 'espacios       %s\n' "$(psql_query 'SELECT count(*) FROM mod_community_space;' 2>/dev/null || echo n/d)"
+}
+
+cmd_all() { cmd_up; cmd_db; cmd_build; cmd_start; }
+
+cmd_test() {
+  cmd_reset
+  ( cd apps/e2e && "$NODE_BIN" "$PLAYWRIGHT_CLI" test "$@" )
+}
+
+case "${1:-}" in
+  up)     cmd_up ;;
+  down)   cmd_down ;;
+  schema) cmd_schema ;;
+  db)    cmd_db ;;
+  build) cmd_build ;;
+  start) cmd_start ;;
+  stop)  cmd_stop ;;
+  reset) cmd_reset ;;
+  check) cmd_check ;;
+  all)   cmd_all ;;
+  test)  shift; cmd_test "$@" ;;
+  *)     die "uso: e2e-stack.sh {up|down|schema|db|build|start|stop|reset|check|all|test}" ;;
+esac


### PR DESCRIPTION
El arnés E2E de este repo nunca había levantado el producto entero. Las piezas
que faltaban no fallaban: **degradaban en silencio**, y el síntoma aparecía a
treinta ficheros de distancia como si fuera un bug de producto. De ahí salían
los 25 rojos que arrastrábamos.

## Qué faltaba y qué se ha puesto

| Faltaba | Efecto real | Ahora |
| --- | --- | --- |
| `packages/database/prisma/seed.sql` no se aplicaba nunca | `mod_community_space` a 0 filas → todo comunidad/espacios fallaba por datos inexistentes | Lo aplica `scripts/e2e-stack.sh db`, **después** de los seeds (necesita los tenants creados) |
| `onboarding_completed_at` a NULL en el admin sembrado | El gate de `apps/web/src/app/(app)/layout.tsx:92` secuestra **toda** ruta autenticada al asistente | `apps/e2e/global-setup.ts` lo cierra por el MISMO camino que la UI: `PATCH /me/profile` + `POST /me/onboarding/complete`. Sin SQL a mano |
| Secretos de Stripe | Los specs firman sus propios webhooks; sin el secreto la API responde 400/401 y parece fallo de negocio | Un único `E2E_WEBHOOK_SECRET` del que derivan los cuatro nombres que leen la API y cada spec |
| `catalogo-publico` hace `docker exec` a `didacta-postgres-test`, que no existía | 2 tests muertos | La infra pasa a ser `docker-compose.test.yml`, **el mismo compose en local y en CI**: mismos puertos, mismo usuario/base y mismos nombres de contenedor |
| `REDIS_URL` ausente | `messaging-realtime.publisher` es un **no-op silencioso** | Redis dedicado del compose de test, con el cupo de rate limit subido por env (ver abajo) |

Tres piezas nuevas, todas dentro de `apps/e2e/**`, `scripts/` y el workflow:

- **`scripts/e2e-env.sh`** — única fuente de verdad del entorno. Lo `source`a el
  arranque local y lo vuelca a `$GITHUB_ENV` el workflow
  (`bash scripts/e2e-env.sh --github-env >> "$GITHUB_ENV"`). Antes había dos
  copias de la lista y **a las dos les faltaba lo mismo**; por eso las cuatro
  piezas de arriba faltaban a la vez en local y en CI.
- **`scripts/e2e-stack.sh`** — `up | schema | db | build | start | stop | reset |
  check | all | test`. `reset` existe porque **la suite no es idempotente** (los
  NIF fijos de Fundae dan 409 en la segunda pasada) y reinicia la API a
  propósito: el registro de módulos se siembra en el bootstrap de NestJS, así
  que una base nueva bajo una API viva deja `module-toggle` con un 500 que no
  tiene nada que ver. `bash scripts/e2e-stack.sh test` = base limpia + tanda.
- **`apps/e2e/global-setup.ts`** — convierte cada degradación silenciosa en un
  fallo ruidoso ANTES de correr un solo test, y deja el entorno en el estado que
  los specs dan por supuesto.

Además se siembra un **segundo tenant** con el mismo `seed.ts` del producto
(idempotente y env-driven), para los specs que afirman estados vacíos: en el
tenant principal «No hay grupos disponibles» deja de ser cierto en cuanto otro
spec crea un grupo.

> Gotcha que costó encontrar: el alta y el login resuelven el tenant por el
> **Host header** y esa resolución **gana** sobre el `tenantSlug` del body
> (`resolveTenantIdFromHost`, `apps/api/src/auth/auth.controller.ts:165` →
> `resolveTenantForRequest`, `auth.service.ts:509-522`). Con los dos tenants
> apuntando a `localhost` el segundo era inalcanzable. Cada tenant tiene ahora
> su hostname: `demo → localhost`, smoke → `127.0.0.1`, y el alta del alumno de
> smoke va a la API directa (`E2E_SMOKE_API_URL`) porque a través del rewrite de
> Next el Host que llega es siempre `localhost:4000`.

## Recuento antes/después

| Tanda | Total | Pasan | Fallan | Skipped |
| --- | --- | --- | --- | --- |
| **Partida** (Sesión H, arnés anterior) | 270 | 233 | **25** | 12 |
| Sólo con el arnés arreglado, **sin tocar una sola aserción** | 270 | 242 | 17 | 11 |
| Árbol final, muestra A | 277 | 260 | 7 | 10 |
| Árbol final, muestra B | 277 | 259 | 8 | 10 |

Las dos muestras finales salen de `bash scripts/e2e-stack.sh test --grep-invert
"Auth · MFA"`, o sea con base recreada desde cero y API reiniciada. Tardan ~7,3
minutos cada una.

El total sube de 270 a 277 porque entran los 7 tests de
`apps/e2e/tests/arnes-contrato.spec.ts`. Y los skipped bajan porque
`digest-opt-out.spec.ts` **ya no se auto-skipea**: pegaba a
`/modules/community/preferences` cuando la ruta es `me/preferences`
(`community.controller.ts:238`), y su propio guard interpretaba el 404 como
«módulo deshabilitado». Llevaba tiempo sin ejercitar nada.

## La decisión sobre Redis ↔ rate-limit

**Redis ENCENDIDO, y el cupo del rate limiter subido con las variables que la
propia API ya expone.** En `scripts/e2e-env.sh`:

```
RATE_LIMIT_COMMUNITY_AUTH_PER_MIN=100000
RATE_LIMIT_COMMUNITY_PUBLIC_PER_MIN=100000
```

Lo primero que hay que entender es que **el 429 no lo causa Redis**: lo causa
que Redis hace que el limiter sea real. Sin Redis, `RateLimitService.recordRequest`
cae en `buildAllowAllDecision` (`apps/api/src/rate-limit/rate-limit.service.ts:130-135`),
o sea que **la suite corría sin rate limit ninguno**. Lo que ahoga la tanda es
que el cupo público de Community son **30 req/min COMPARTIDAS por todo el
tráfico anónimo** — un único bucket `'anonymous'`
(`rate-limit.interceptor.ts:80-82`) — y cada `signin()` de cada spec cae ahí.

Subirlo no es un parche: `resolveRateLimitConfig()`
(`apps/api/src/rate-limit/rate-limit.types.ts:119-146`) declara ese cupo como
configuración de primera clase. El limiter **sigue encendido**: sigue contando en
Redis, sigue escribiendo las cabeceras `X-RateLimit-*` y sigue siendo el mismo
código que en producción. Sólo cambia el techo. `arnes-contrato.spec.ts` afirma
además que `remaining < limit`, que es la prueba de que Redis está contando de
verdad y no estamos en el camino failsafe.

**Alternativas descartadas:**

1. **Dejar Redis apagado (statu quo).** Cuesta 5 tests de realtime y, peor, deja
   el producto sin ninguna cobertura del camino realtime *y* sin cobertura del
   interceptor de rate limit, que nunca llegaba a contar. En producción
   `REDIS_URL` siempre está: la configuración honesta es con Redis.
2. **Los 65 s de espera entre tandas** que se midieron en la sesión anterior.
   Convierte 7 minutos en horas y no arregla nada: es dormir sobre el síntoma.
3. **Serializar los specs afectados.** No sirve: el bucket público es global
   (`'anonymous'`), no por spec ni por tenant, y `workers` ya es 1. Serializar
   no baja el ritmo de peticiones por minuto.
4. **Aislar por worker o por tenant.** Mismo motivo: todo el tráfico anónimo cae
   en el mismo bucket independientemente del tenant.
5. **Desactivar el interceptor en test** (flag de env o quitar el
   `APP_INTERCEPTOR`). Exige tocar código de producto y saca del camino bajo
   prueba justo la pieza que queremos ejercitar.

**Acoplamiento que aparece al encender Redis, y que declaro explícitamente:**
`REDIS_URL` también cambia el despachador del outbox. Sin Redis despacha
in-process y **síncrono**; con Redis encola en BullMQ y lo resuelve un worker
(`apps/api/src/modules/outbox-queue.service.ts:56-62`). Es paridad con
producción, pero hace que los *bridges* de eventos de dominio pasen a ser
realmente asíncronos. Por eso `catalogo-publico.spec.ts:243` pasa de esperar
30 s a 90 s, con el mismo criterio que `drip-tier-grupo.spec.ts`, que ya
esperaba 110 s por esta misma razón. Y es también el origen de lo que queda
rojo, más abajo.

## Aserciones desincronizadas del producto (ninguna era un bug real)

- **`payment-connections.spec.ts`** — las **dos** líneas, porque arreglar una
  sola no cambiaba nada: `:60` pegaba a `/api/v1/me`, que **nunca ha existido**
  (el perfil es `/me/profile`, `MeController` con `@Controller('me')` +
  `@Get('profile')`), y ese 404 mataba el test **antes** de llegar a `:89`, que
  afirmaba `'Conectar una cuenta de Stripe'` — texto que `git log -S` sólo
  encuentra dentro del propio spec. El form real se titula **«Conectar una
  cuenta de pago»**: el panel sirve a stripe, paypal y woocommerce.
- **`redesign-smoke.spec.ts` (11 tests) y `mobile-nav.spec.ts` (2)** —
  inyectaban `accessToken: 'fake-token-*'` con `tenantSlug: 'acme'`, un tenant
  que no existe. El shell pintaba pero toda llamada a la API era 401. Ahora la
  sesión es real (alta por `POST /auth/signup` + onboarding cerrado) en el
  tenant de smoke. Con la sesión real salieron dos cosas más: `'Cursos'` era
  ambiguo por subcadena contra `'Recursos'` (enlace real de mod.resources que
  antes no llegaba a pintarse), y `/mensajes` afirmaba dos copys que
  desaparecieron cuando `mod.messaging` v1 (`64a93c62`) reescribió la página.
- **`admin-tenants.spec.ts:50`** — afirmaba el alta de un segundo tenant, que es
  capacidad de pago (`feat:multi_tenant.real`; `COMMUNITY_TENANT_LIMIT = 1` en
  `admin-tenants.service.ts:55`). Con licencia Community era **imposible** que
  pasara. Ahora consulta `/admin/tenants/capacity` y, sin la capacidad, ejercita
  el gate: 402 con la capability y ningún tenant creado.
- **`admin-tutor-revision.spec.ts:91`, `clase-asistencia.spec.ts:112`,
  `clase-inscripcion.spec.ts:110`** — esperaban 401 donde el producto responde
  **403**. El alumno sí está autenticado; lo que le falta es el rol, y el
  backend lo dice con código propio (`AI_TUTOR_REVIEW_ADMIN_REQUIRED`). Un 401
  le diría al cliente que reintente el login.
- **`branding-logo.spec.ts:60`** — esperaba `image/webp`. El logo se guarda en
  **PNG a propósito** desde `d01a5dc4` («el logo del tenant se guarda en PNG, no
  en WebP»): acaba en la cabecera de todos los emails y los clientes de correo
  ignoran el canal alfa del WebP. Se afirma PNG **y** que sale recomprimido, que
  es lo que de verdad prueba que el optimizador corrió.
- **`espacios.spec.ts:93`** — la sección de foros arranca **plegada**, así que
  los enlaces no están en el DOM hasta desplegarla; el badge «5» ya demostraba
  que los datos estaban. **`espacios.spec.ts:245`** — `[role="dialog"]`.first()
  resolvía al drawer de navegación móvil (cerrado, `aria-hidden`) en vez de al
  compositor.
- **`inscribe-by-api.spec.ts:177`** — daba de alta al alumno con `signup` a
  secas, sin cerrar el onboarding, y el gate del layout se llevaba la navegación
  al asistente antes de llegar a la ficha.

## Lo que queda rojo, con causa

No hay ningún test excluido ni skipeado por conveniencia. Lo que queda son tests
que **fallan de forma intermitente dentro de la tanda completa y pasan siempre
en aislado o en grupos pequeños**. Se dejan corriendo y en rojo a propósito,
porque apuntan a un defecto real del producto que no me corresponde arreglar en
un PR de arnés. Unión de las dos muestras finales (A: 7 rojos, B: 8; el conjunto
varía entre tandas):

| Test | Qué espera | A | B |
| --- | --- | --- | --- |
| `catalogo-publico.spec.ts:243` | matrícula `ACTIVE\|PURCHASE` tras el webhook de compra | ✗ | ok |
| `clase-en-comunidad.spec.ts:86` | el feed muestra la clase anunciada | ✗ | ok |
| `clase-en-comunidad.spec.ts:266` | reeditar la clase sincroniza el post | ✗ | ✗ |
| `drip-tier-grupo.spec.ts:465` | asignar el tier reconcilia la membresía | ok | ✗ |
| `drip-tier-grupo.spec.ts:576` | borrar el tier revoca la membresía TIER | ✗ | ✗ |
| `membership-trial.spec.ts:370` | tras `invoice.paid`, la matrícula vuelve a `ACTIVE` | ✗ | ✗ |
| `notifications-bell.spec.ts:13` | completar un curso genera avisos in-app | ok | ✗ |
| `quiz-flow.spec.ts:96` | «¡Curso completado!» tras aprobar el quiz | ✗ | ✗ |
| `referrals-flow.spec.ts:176` | comisión tras el cobro | ok | ✗ |
| `referrals-flow.spec.ts:386` | la comisión pendiente se crea tras el cobro | ✗ | ✗ |

**Todos dependen de que un evento de dominio llegue a su *bridge*, y el hallazgo
está trazado hasta el final en uno de ellos** (`catalogo-publico`): el evento
`billing.order.completed` queda en `outbox_event` con `processed_at` puesto,
`processing_attempts = 0` y `last_error` NULL, y `BillingLearningBridge`
(`apps/api/src/modules/billing/billing-learning.bridge.ts:53-86`) **no loguea
nada**, ni el éxito ni el error — o sea que su handler nunca llegó a ejecutarse.
La causa mecánica está en `apps/api/src/modules/persistent-event-bus.ts:228-233`:

```ts
const set = this.handlers.get(event.name);
if (!set || set.size === 0) {
  // Sin subscribers locales aún -> marcamos procesado igualmente.
  await this.markProcessed(outboxId);
  return true;
}
```

Marcar procesado cuando no hay handlers hace que **la pérdida de un evento sea
indistinguible del éxito y además irrecuperable**: `recoverPending()` sólo
recoge filas con `processedAt IS NULL`, así que ese evento no se reintenta
nunca. Con el despachador in-process la ventana es minúscula; con BullMQ y carga,
se abre. Merece su propia sesión: decidir qué hacer cuando no hay subscribers
tiene radio de acción sobre todo el bus, y por eso **no lo he tocado**.

**Skipped (10), todos condicionales y con su motivo declarado en el propio spec:**
3 de `setup-wizard.spec.ts` (necesitan `E2E_SETUP_TOKEN`; tienen su propio job),
5 de `member-registration.spec.ts` (necesitan `TELEGRAM_BOT_TOKEN`), y 2 de smoke
contra producción (`cursos-mis-cursos-prod`, `ficha-venta-prod`, necesitan
`PROD_*`). Los de MFA siguen fuera por `--grep-invert "Auth · MFA"`, igual que
antes y por el mismo motivo: necesitan `DIDACTA_REQUIRE_MFA_ADMIN=true`, que
rompería el `signin()` de admin del resto.

## Caminos degradados que dejo abiertos (con su test)

Patrón obligatorio: constante nombrada, enumerados aquí, y con un test que los
cubre.

1. **`apps/e2e/global-setup.ts` — instancia sin inicializar.**
   `isInstanceInitialized()` pregunta a `GET /setup/status`; si no hay tenants,
   sólo se hacen las comprobaciones de entorno y no se busca admin sembrado. Es
   el estado que necesita el job `setup-wizard`. Se detecta por **estado real
   del producto**, no por un interruptor de «sáltate el arranque» que alguien
   acabaría dejando puesto. Cubierto por `arnes-contrato.spec.ts` (test 1), que
   afirma `initialized === true` en el golden path.
2. **`apps/e2e/global-setup.ts` — `DIDACTA_REQUIRE_MFA_ADMIN === 'true'`.** No se
   prepara al admin: completar el ciclo setup→enable dejaría a
   `mfa-setup.spec.ts` sin el estado inicial que ejercita. Cubierto por el mismo
   test 1, que afirma que la variable **no** está activa en el golden path.
3. **`apps/e2e/global-setup.ts` — `assertRateLimitHeadroom()` sin cabecera
   `X-RateLimit-Limit`.** No aborta la tanda (dejaría la suite rehén de que
   `/auth/signin` siga siendo la sonda buena) pero **avisa por consola**, y
   `arnes-contrato.spec.ts` (test 2) sí exige la cabecera: la degradación sale
   como UN test rojo con nombre, no como un arranque abortado.

Constantes nombradas, sin defaults implícitos: `MIN_RATE_LIMIT_PER_MIN`,
`SYSTEM_SPACE_SLUGS`, `READINESS_TIMEOUT_MS`, `READINESS_POLL_MS`,
`REQUIRED_PAYMENT_SECRETS` (global-setup), `HEALTH_TIMEOUT_SECONDS`
(e2e-stack.sh), `ONBOARDING_AVATAR_URL`, `ONBOARDING_FALLBACK_NAME`,
`E2E_USER_PASSWORD`, `SMOKE_TENANT_SLUG`, `SMOKE_API_URL` (helpers/api.ts).

## Fuera de frontera

- **No se ha tocado ni un fichero de `apps/api/**` ni de `apps/web/**`.** Los dos
  hallazgos de producto (el bus de eventos de arriba, y el 500 de Prisma
  «Error creating UUID» al pedir `/grupos/<no-uuid>`, que el test tolera porque
  la UI sí pinta «Grupo no encontrado») quedan documentados aquí, no parcheados.
- No se ha tocado ningún fichero de la lista del otro worker.
- `apps/e2e/shots/**` y `apps/e2e/playwright.shots.config.ts` (PR #33) **no se
  han tocado**: `playwright.shots.config.ts` tiene su propio `testDir`, así que
  el `globalSetup` nuevo no le afecta.
- `apps/e2e/shots-output/` ya estaba en `.gitignore:72`. Se añade
  `.e2e-stack/` (logs y PIDs del arnés).

## Verificación

```
bash scripts/dev-check.sh --format-fix && bash scripts/dev-check.sh --quick   # OK
pnpm tsx scripts/ee-fence.ts                                                  # 1387 ficheros, 0 violaciones
node node_modules/typescript/bin/tsc -p apps/e2e/tsconfig.json --noEmit       # OK
bash scripts/e2e-stack.sh test --grep-invert "Auth · MFA"                     # ver tabla de recuento
```
