### PR TITLE
fix(e2e): un no-2xx deja de traducirse a «instancia virgen» en el arranque del arnés

### DIFF
--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -11,7 +11,9 @@
  * fallo ruidoso ANTES de correr un solo test, y deja el entorno en el estado
  * que la suite da por supuesto:
  *
- *   1. api y web responden.
+ *   1. api, web Y la api a través del rewrite de Next responden — las tres,
+ *      porque la suite entera habla por el rewrite y ese camino puede estar
+ *      caído con la api directa perfectamente sana.
  *   2. Redis configurado — sin él la mensajería realtime es un no-op silencioso.
  *   3. Cupo de rate limit con margen — con Redis activo el limiter deja de
  *      fallar abierto y el cupo público por defecto (30 req/min COMPARTIDOS
@@ -19,6 +21,11 @@
  *   4. Secretos de webhooks de pago presentes.
  *   5. Espacios de sistema sembrados (`prisma/seed.sql`).
  *   6. Onboarding cerrado para los admins sembrados.
+ *
+ * Regla que rige todo el fichero: «no he podido comprobarlo» NUNCA se traduce
+ * a un estado. Un no-2xx inesperado es un fallo con mensaje, no un estado
+ * inferido — que es exactamente el agujero que tuvo `readInstanceState` y que
+ * dejaba saltarse ENTERA la preparación del entorno sin que nada fallara.
  *
  * La receta completa para dejar el stack en pie está en `scripts/e2e-stack.sh`.
  */
@@ -54,23 +61,41 @@ function fail(what: string, why: string): never {
   );
 }
 
-async function waitForService(url: string, label: string): Promise<void> {
+/**
+ * Qué cuenta como «este servicio ya sirve». Se enumeran a propósito en vez de
+ * aceptar cualquier respuesta: un 502 del proxy de Next TAMBIÉN es una
+ * respuesta, y darlo por bueno era justo lo que dejaba pasar un rewrite que
+ * todavía no proxyaba.
+ */
+type SondaAceptable = (status: number) => boolean;
+
+/** Para endpoints de API: sólo 2xx. Un 5xx del proxy no es «arriba». */
+const SOLO_2XX: SondaAceptable = (s) => s >= 200 && s < 300;
+
+/** Para páginas de Next: 2xx o la redirección del gate de sesión (307/308). */
+const PAGINA_SERVIDA: SondaAceptable = (s) => s >= 200 && s < 400;
+
+async function waitForService(
+  url: string,
+  label: string,
+  aceptable: SondaAceptable,
+  pista: string,
+): Promise<void> {
   const deadline = Date.now() + READINESS_TIMEOUT_MS;
-  let last = '';
+  let ultimo = 'sin intentos';
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url);
-      // Cualquier respuesta HTTP vale: lo que comprobamos es que hay alguien
-      // escuchando y sirviendo, no que la ruta concreta devuelva 200.
-      if (res.status > 0) return;
+      if (aceptable(res.status)) return;
+      ultimo = `HTTP ${res.status}`;
     } catch (err) {
-      last = (err as Error).message;
+      ultimo = (err as Error).message;
     }
     await new Promise((r) => setTimeout(r, READINESS_POLL_MS));
   }
   fail(
-    `${label} no responde en ${url}.`,
-    `Tras ${READINESS_TIMEOUT_MS / 1000}s sigue sin contestar (último error: ${last || 'timeout'}).`,
+    `${label} no responde como debe en ${url}.`,
+    `Tras ${READINESS_TIMEOUT_MS / 1000}s el último resultado fue: ${ultimo}.\n\n${pista}`,
   );
 }
 
@@ -116,8 +141,9 @@ async function assertRateLimitHeadroom(): Promise<void> {
     // sale como UN test rojo con nombre, no como un arranque abortado.
     // eslint-disable-next-line no-console
     console.warn(
-      '[arnés E2E] Sin cabecera X-RateLimit-Limit en /auth/signin: no se pudo comprobar\n' +
-        '            el cupo. Lo verifica igualmente "Contrato del arnés E2E".',
+      `[arnés E2E] Sin cabecera X-RateLimit-Limit en /auth/signin (respondió HTTP ${res.status}):\n` +
+        '            no se pudo comprobar el cupo. Lo verifica igualmente el test\n' +
+        '            "Contrato del arnés E2E", que sí exige la cabecera.',
     );
     return;
   }
@@ -169,9 +195,18 @@ async function assertSystemSpacesSeeded(bearer: string): Promise<void> {
       'Sin este endpoint no se puede verificar el sembrado de espacios.',
     );
   }
-  const body = (await res.json()) as Array<{ slug: string }> | { spaces?: Array<{ slug: string }> };
-  const spaces = Array.isArray(body) ? body : (body.spaces ?? []);
-  const present = new Set(spaces.map((s) => s.slug));
+  const body = (await res.json()) as unknown;
+  const spaces = Array.isArray(body) ? body : (body as { spaces?: unknown }).spaces;
+  if (!Array.isArray(spaces)) {
+    // Mismo criterio que `readInstanceState`: un cuerpo con otra forma es "no
+    // he podido preguntar", no "no hay espacios". Antes esto caía a `[]` y el
+    // arranque abortaba diciendo que faltaba el seed, que es una pista falsa.
+    fail(
+      `GET /modules/community/spaces devolvió un cuerpo con forma inesperada.`,
+      `Se esperaba un array o \`{ spaces: [...] }\` y llegó: ${JSON.stringify(body).slice(0, 200)}`,
+    );
+  }
+  const present = new Set((spaces as Array<{ slug: string }>).map((s) => s.slug));
   const missing = SYSTEM_SPACE_SLUGS.filter((slug) => !present.has(slug));
   if (missing.length === 0) return;
   fail(
@@ -185,32 +220,114 @@ async function assertSystemSpacesSeeded(bearer: string): Promise<void> {
 }
 
 /**
+ * Estado de la instancia. Son DOS respuestas válidas, y no hay una tercera:
+ * «no he podido preguntar» NO es un estado, es un fallo.
+ */
+type EstadoInstancia = 'inicializada' | 'virgen';
+
+/**
  * ¿La instancia ya tiene al menos un tenant? Se lo preguntamos al producto
  * (`GET /setup/status`) en vez de deducirlo de una variable de entorno: el job
  * del wizard de `/setup` corre a propósito contra una instancia VIRGEN, y ahí
  * no hay admin sembrado que preparar. Distinguirlo por estado real evita un
  * interruptor de "sáltate el arranque" que tarde o temprano se deja puesto.
+ *
+ * OJO — aquí vivía el agujero que este fichero existe para no tener. La
+ * versión anterior devolvía `boolean` y hacía `if (!res.ok) return false`, o
+ * sea que CUALQUIER no-2xx se traducía a «instancia virgen». Y la petición va
+ * a `E2E_API_URL`, que es la web (`http://localhost:3010`), o sea a través del
+ * rewrite de Next: un 502 del proxy —el stack sano, sólo el rewrite todavía
+ * sin proxyar— se leía como «no hay tenants», el arranque se saltaba ENTERA la
+ * preparación del entorno con un `console.info`, y la tanda daba 43 rojos que
+ * parecían del producto.
+ *
+ * Por eso ahora: sólo un 200 con `initialized` booleano es una respuesta.
+ * Cualquier otra cosa —error de red, no-2xx, cuerpo con otra forma— es un
+ * fallo ruidoso, porque significa que no sabemos en qué estado está la
+ * instancia, y actuar sin saberlo es exactamente lo que rompió la tanda.
  */
-async function isInstanceInitialized(): Promise<boolean> {
-  const res = await fetch(`${API_URL}/api/v1/setup/status`);
-  if (!res.ok) return false;
-  const body = (await res.json()) as { initialized?: boolean };
-  return body.initialized === true;
+async function readInstanceState(): Promise<EstadoInstancia> {
+  const url = `${API_URL}/api/v1/setup/status`;
+  const noSePudoPreguntar = (detalle: string): never =>
+    fail(
+      `No se pudo determinar el estado de la instancia en ${url}.`,
+      `${detalle}\n\n` +
+        'Esto NO se interpreta como "instancia virgen": no saberlo es un fallo.\n' +
+        'Recuerda que E2E_API_URL apunta a la web, así que esta llamada pasa por\n' +
+        'el rewrite de Next (`next.config.mjs`), no por la API directa. Si la API\n' +
+        'directa responde y esto no, el que falla es el rewrite.\n\n' +
+        'Diagnóstico:  bash scripts/e2e-stack.sh check',
+    );
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    return noSePudoPreguntar(`La petición ni siquiera llegó: ${(err as Error).message}`);
+  }
+
+  if (res.status !== 200) {
+    const cuerpo = await res.text().catch(() => '');
+    return noSePudoPreguntar(
+      `Respondió HTTP ${res.status}. Cuerpo: ${cuerpo.slice(0, 200) || '(vacío)'}`,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return noSePudoPreguntar(`El 200 no traía JSON: ${(err as Error).message}`);
+  }
+
+  const initialized = (body as { initialized?: unknown }).initialized;
+  if (typeof initialized !== 'boolean') {
+    return noSePudoPreguntar(
+      `El cuerpo no trae \`initialized\` booleano: ${JSON.stringify(body).slice(0, 200)}`,
+    );
+  }
+
+  return initialized ? 'inicializada' : 'virgen';
 }
 
 export default async function globalSetup(): Promise<void> {
-  await waitForService(`${API_DIRECT_URL}/healthz`, 'La API');
-  await waitForService(`${BASE_URL}/signin`, 'La web');
+  await waitForService(
+    `${API_DIRECT_URL}/healthz`,
+    'La API',
+    SOLO_2XX,
+    'Arranca el stack con:  bash scripts/e2e-stack.sh start',
+  );
+  await waitForService(
+    `${BASE_URL}/signin`,
+    'La web',
+    PAGINA_SERVIDA,
+    'Arranca el stack con:  bash scripts/e2e-stack.sh start',
+  );
+  // La API A TRAVÉS DEL REWRITE de Next, que es por donde habla la suite
+  // entera (`E2E_API_URL` es la web, no la API directa). Sondearla aquí la
+  // calienta Y la verifica: antes el arranque sólo miraba `healthz` directo y
+  // `/signin`, así que este camino —del que depende cada spec— nunca se
+  // comprobaba y su primer uso real caía dentro de `readInstanceState`.
+  await waitForService(
+    `${API_URL}/api/v1/setup/status`,
+    'La API a través del rewrite de Next',
+    SOLO_2XX,
+    'La API directa puede estar perfectamente y este camino no. Comprueba el\n' +
+      'rewrite de `apps/web/next.config.mjs` y que API_INTERNAL_URL apuntaba a la\n' +
+      'API cuando se construyó la web: se congela en el build, no basta con\n' +
+      'reexportar la variable.',
+  );
 
   assertRealtimeBackendConfigured();
   assertPaymentSecretsConfigured();
   await assertRateLimitHeadroom();
 
-  if (!(await isInstanceInitialized())) {
+  if ((await readInstanceState()) === 'virgen') {
     // eslint-disable-next-line no-console
     console.info(
-      '[arnés E2E] Instancia sin inicializar (no hay tenants): sólo comprobaciones de entorno.\n' +
-        '            Es el estado que necesita el wizard de /setup — ver el job "setup-wizard".',
+      '[arnés E2E] Instancia sin inicializar (el producto dice initialized:false):\n' +
+        '            sólo comprobaciones de entorno. Es el estado que necesita el\n' +
+        '            wizard de /setup — ver el job "setup-wizard".',
     );
     return;
   }

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -223,11 +223,18 @@ stop_pid_file() {
 
 wait_healthy() {
   local i=0
-  log "Esperando a api :$PORT y web :3010 (máx ${HEALTH_TIMEOUT_SECONDS}s)…"
+  log "Esperando a api :$PORT, web y rewrite (máx ${HEALTH_TIMEOUT_SECONDS}s)…"
   while [ "$i" -lt "$HEALTH_TIMEOUT_SECONDS" ]; do
+    # Las TRES sondas, y la tercera no es redundante: la suite entera habla con
+    # la API a través del rewrite de Next (E2E_API_URL es la web), no por la
+    # API directa. Sin esta comprobación el arnés daba el stack por bueno con
+    # el rewrite todavía sin proxyar, y el primer uso real de ese camino caía
+    # dentro del arranque de Playwright.
+    # `curl -f` falla con >=400, así que un 502 del proxy NO cuenta como arriba.
     if curl -sf "http://localhost:${PORT}/healthz" >/dev/null 2>&1 \
-       && curl -sf -o /dev/null "http://localhost:3010/signin" 2>/dev/null; then
-      log "api + web arriba."
+       && curl -sf -o /dev/null "${E2E_BASE_URL}/signin" 2>/dev/null \
+       && curl -sf -o /dev/null "${E2E_API_URL}/api/v1/setup/status" 2>/dev/null; then
+      log "api + web + rewrite arriba."
       return 0
     fi
     sleep 1
@@ -235,7 +242,10 @@ wait_healthy() {
   done
   log "----- últimas líneas de api.log -----"; tail -n 30 "$API_LOG" 2>/dev/null || true
   log "----- últimas líneas de web.log -----"; tail -n 30 "$WEB_LOG" 2>/dev/null || true
-  die "api/web no respondieron en ${HEALTH_TIMEOUT_SECONDS}s."
+  log "sonda api directa:   $(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/healthz" || echo sin-respuesta)"
+  log "sonda web:           $(curl -s -o /dev/null -w '%{http_code}' "${E2E_BASE_URL}/signin" || echo sin-respuesta)"
+  log "sonda por rewrite:   $(curl -s -o /dev/null -w '%{http_code}' "${E2E_API_URL}/api/v1/setup/status" || echo sin-respuesta)"
+  die "api/web/rewrite no respondieron en ${HEALTH_TIMEOUT_SECONDS}s."
 }
 
 cmd_start() { start_api; start_web; wait_healthy; }
@@ -264,7 +274,10 @@ cmd_check() {
   printf 'postgres       %s\n' "$(docker inspect -f '{{.State.Status}}' "$E2E_PG_CONTAINER" 2>/dev/null || echo ausente)"
   printf 'redis          %s\n' "$(docker inspect -f '{{.State.Status}}' didacta-redis-test 2>/dev/null || echo ausente)"
   printf 'api :%s        %s\n' "$PORT" "$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/healthz" || echo sin-respuesta)"
-  printf 'web :3010      %s\n' "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3010/signin || echo sin-respuesta)"
+  printf 'web :3010      %s\n' "$(curl -s -o /dev/null -w '%{http_code}' "${E2E_BASE_URL}/signin" || echo sin-respuesta)"
+  # El camino por el que habla la suite. Si esta línea no es 200 y la de arriba
+  # sí, el problema es el rewrite de Next, no la API.
+  printf 'api x rewrite  %s\n' "$(curl -s -o /dev/null -w '%{http_code}' "${E2E_API_URL}/api/v1/setup/status" || echo sin-respuesta)"
   printf 'tenants        %s\n' "$(psql_query 'SELECT string_agg(slug, ", " ORDER BY slug) FROM tenant;' 2>/dev/null || echo n/d)"
   printf 'espacios       %s\n' "$(psql_query 'SELECT count(*) FROM mod_community_space;' 2>/dev/null || echo n/d)"
 }


### PR DESCRIPTION
Seguimiento del #38. El arranque del arnés podía **saltarse entera la
preparación del entorno sin fallar**, con el stack sano. Es exactamente la clase
de degradación silenciosa que ese PR vino a matar, sobreviviendo en el sitio que
decide si se ejecuta todo lo demás. Le produjo a otro worker una muestra de **43
rojos**.

Diagnóstico original suyo; verificado línea por línea al llegar (los merges de
#39 y #40 no tocaron ni `global-setup.ts` ni `e2e-env.sh` — el único cambio en
`apps/e2e/**` fue el spec nuevo, así que las líneas reportadas eran exactas).

## La cadena

1. `isInstanceInitialized()` devolvía `boolean` y hacía `if (!res.ok) return
   false`: **cualquier** no-2xx se traducía a «instancia virgen».
2. La petición va a `E2E_API_URL`, que es la **web** (`http://localhost:3010`,
   `scripts/e2e-env.sh:111`), o sea **a través del rewrite de Next**. Ese camino
   el arranque no lo comprobaba nunca: sólo sondeaba `healthz` en la API directa
   y `/signin`. Su primer uso real era precisamente esta llamada.
3. Con `false`, el `return` se saltaba cerrar el onboarding del admin, verificar
   `seed.sql` y preparar el tenant de smoke — y lo hacía con un `console.info`.

El tipo de retorno era el defecto de fondo: un `boolean` no puede distinguir
**tres** estados, y el tercero («no he podido preguntar») acababa colapsado
sobre el segundo, que además es el que apaga la preparación.

## El arreglo, por los tres lados

**1. `readInstanceState()` sustituye al booleano** y devuelve
`'inicializada' | 'virgen'`. Sólo un **200 con `initialized` booleano** cuenta
como respuesta. Error de red, no-2xx, 200 sin JSON, o cuerpo con otra forma →
`fail()` con el status y un trozo del cuerpo. «No he podido preguntar» deja de
ser un estado: es un fallo, porque actuar sin saber en qué estado está la
instancia es justo lo que rompió la tanda.

**2. El arranque sondea la API a través del rewrite.** Es por donde habla la
suite entera, así que sondearla la **calienta y la verifica**. El mensaje de
fallo distingue los dos casos, que es lo que costaba diagnosticar: «la API está
caída» vs «la API está bien y el que no proxya es el rewrite» (con el recordatorio
de que `API_INTERNAL_URL` se congela en el `next build`).

**3. `waitForService` deja de aceptar «cualquier respuesta».** Tenía
`if (res.status > 0) return`, y un 502 del proxy también es una respuesta. Ahora
recibe qué códigos cuentan como servir, con constante nombrada: `SOLO_2XX` para
endpoints de API, `PAGINA_SERVIDA` (2xx–3xx) para páginas de Next, que redirigen
por el gate de sesión. Y el error final dice el último código visto, no un
«sigue sin contestar» genérico.

## El mismo patrón en otros dos sitios (barrido pedido)

Repasé `global-setup.ts` y `e2e-stack.sh` enteros buscando «no-2xx ⇒ estado
inferido». Dos más, los dos cerrados:

- **`assertSystemSpacesSeeded`** — `body.spaces ?? []` ante un cuerpo con otra
  forma caía a lista vacía y el arranque abortaba diciendo **«faltan los espacios
  de sistema, aplica seed.sql»**, que es una pista falsa: el seed podía estar
  perfectamente. Ahora un cuerpo inesperado dice que no se ha podido comprobar,
  y enseña lo que llegó.
- **`wait_healthy` (`scripts/e2e-stack.sh`)** — daba el stack por bueno sin
  haber tocado nunca el rewrite; es el hueco gemelo del punto 2, en el script.
  Ahora son **tres** sondas y, al agotarse el plazo, imprime el código de cada
  una para saber cuál falló. `cmd_check` gana la misma línea (`api x rewrite`).

Revisados y **dejados como estaban**, con motivo:

- `assertRateLimitHeadroom` sin cabecera `X-RateLimit-Limit`: sigue siendo un
  camino degradado deliberado y documentado, porque abortar ahí dejaría la suite
  rehén de que `/auth/signin` siga siendo la sonda buena. Está cubierto por
  `arnes-contrato.spec.ts` (test 2), que **sí** exige la cabecera. Sólo se le
  añade el status al aviso, para que sea diagnosticable.
- `cmd_check` en `e2e-stack.sh` usa `|| echo sin-respuesta`, pero es una salida
  de diagnóstico que no condiciona nada.

## Verificación por mutación

Apuntando la llamada de estado a una ruta que responde 404 por el rewrite
(`/api/v1/setup/status-MUTANTE-404`):

**Con el arreglo** — la tanda aborta con exit 1 antes de correr un test:

```
Error:
[arnés E2E] No se pudo determinar el estado de la instancia en
            http://localhost:3010/api/v1/setup/status-MUTANTE-404.

Respondió HTTP 404. Cuerpo: {"message":"Cannot GET /api/v1/setup/...","statusCode":404}

Esto NO se interpreta como "instancia virgen": no saberlo es un fallo.
Recuerda que E2E_API_URL apunta a la web, así que esta llamada pasa por
el rewrite de Next (`next.config.mjs`), no por la API directa. Si la API
directa responde y esto no, el que falla es el rewrite.
```

**Con la clasificación anterior reinstalada** y la misma condición — imprime
`[arnés E2E] Instancia sin inicializar` y **sigue adelante**, saltándose la
preparación. (En esa demo los tests aún pasaban porque la base ya venía
preparada de una tanda anterior; sobre una base recién creada es donde salen los
43 rojos.)

## Recuento

| Tanda | Total | Pasan | Fallan | Skipped |
| --- | --- | --- | --- | --- |
| Referencia del árbol (coordinación) | 280 | 263 | 7 | 10 |
| Esta rama, `e2e-stack.sh test --grep-invert "Auth · MFA"` | 280 | **267** | **3** | 10 |

Los 3 rojos son el hallazgo conocido de `persistent-event-bus.ts:228-233` y **no
se han tocado**: `membership-trial.spec.ts:370`, `quiz-flow.spec.ts:96` y
`referrals-flow.spec.ts:386`. Son los mismos 7 de la referencia, que es un
conjunto intermitente — esta tanda cayeron 3. Ninguno de los arreglos de este PR
los afecta ni los enmascara.

## Frontera

- Sólo `apps/e2e/global-setup.ts` y `scripts/e2e-stack.sh`.
- **No se ha tocado nada de `apps/api/src/**` ni de `apps/web/src/**`.** El
  arreglo no lo necesitaba: el agujero era del arnés, no del producto.

## Comprobaciones

```
bash scripts/dev-check.sh --format-fix && bash scripts/dev-check.sh --quick   # OK
pnpm tsx scripts/ee-fence.ts                                                  # 1396 ficheros, 0 violaciones
bash -n scripts/e2e-stack.sh                                                  # OK
```
