### PR TITLE
fix: el bus deja de tragarse eventos en silencio + retirada de pt-BR

### DIFF
--- a/apps/api/src/auth/me.controller.ts
+++ b/apps/api/src/auth/me.controller.ts
@@ -35,9 +35,23 @@ import { PasswordService } from './password.service';
 import type { SessionClaims } from './token.service';
 import { ZodValidationPipe } from './zod-validation.pipe';
 
-const ALLOWED_LOCALES = ['es-ES', 'es-AR', 'en-US', 'pt-BR'] as const;
+/**
+ * Idiomas que el perfil puede GUARDAR. Refleja `SUPPORTED_LOCALES`
+ * (apps/web/src/i18n/config.ts): si la API acepta un tag que la web no sabe
+ * pintar, el usuario acaba con un perfil que la UI no puede representar.
+ *
+ * `pt-BR` estuvo aquí sin tener catálogo de mensajes: se elegía portugués,
+ * esto lo persistía, `/cuenta` confirmaba «Português (Brasil)» y la interfaz
+ * seguía en español. Retirado — se responde 400.
+ *
+ * Los perfiles que YA lo tienen guardado no se tocan: el degradado a español
+ * de `toSupportedLocale()` (web) y de `resolveRecipientLocale()`
+ * (apps/api/src/modules/notifications/email-template-catalog.ts) sigue
+ * cubriéndolos, y siguen pudiendo cambiar de idioma a cualquiera de éstos.
+ */
+export const ALLOWED_LOCALES = ['es-ES', 'es-AR', 'en-US'] as const;
 
-const updateProfileSchema = z.object({
+export const updateProfileSchema = z.object({
   name: z.string().min(1).max(120).optional(),
   /**
    * Biografía corta opcional (máx 280). `''` o `null` la borran; omitir la

--- a/apps/api/src/modules/module-context.factory.ts
+++ b/apps/api/src/modules/module-context.factory.ts
@@ -19,6 +19,7 @@ import type { StorageService } from '@didacta/core-kernel';
 import { LocalDiskStorageService } from './local-disk-storage.service';
 import { S3StorageService, buildS3StorageFromEnv } from './s3-storage.service';
 import { withImageOptimization } from './image-optimizing-storage';
+import { OutboxMetrics } from './outbox.metrics';
 import { OutboxQueueService } from './outbox-queue.service';
 import { PersistentEventBus } from './persistent-event-bus';
 import { PrismaAuditLogService } from './prisma-audit-log.service';
@@ -119,6 +120,7 @@ export class ModuleContextFactory implements OnApplicationShutdown {
     private readonly pino: PinoLogger,
     @Inject(forwardRef(() => OutboxQueueService))
     private readonly outboxQueue: OutboxQueueService,
+    private readonly outboxMetrics: OutboxMetrics,
   ) {}
 
   build(): ModuleContext {
@@ -127,7 +129,12 @@ export class ModuleContextFactory implements OnApplicationShutdown {
     // bridges se suscriben en onModuleInit (que en Nest 11 puede correr ANTES
     // de que el registry construya el contexto) — todos deben compartir la
     // misma instancia o las suscripciones se pierden.
-    this.eventBus ??= new PersistentEventBus(this.prisma, adaptedLogger, this.outboxQueue);
+    this.eventBus ??= new PersistentEventBus(
+      this.prisma,
+      adaptedLogger,
+      this.outboxQueue,
+      this.outboxMetrics,
+    );
     const auditLog = new PrismaAuditLogService(this.prisma);
     const evidenceVault = new PrismaEvidenceVaultService(this.prisma, this.storage);
     this.tenantConfig = new PrismaTenantConfigService(this.prisma, this.cipher, auditLog);
@@ -312,6 +319,7 @@ export class ModuleContextFactory implements OnApplicationShutdown {
       this.prisma,
       this.adaptLogger(this.pino),
       this.outboxQueue,
+      this.outboxMetrics,
     );
     return this.eventBus;
   }

--- a/apps/api/src/modules/module-registry.service.ts
+++ b/apps/api/src/modules/module-registry.service.ts
@@ -1100,8 +1100,16 @@ export class ModuleRegistryService implements OnModuleInit {
     return this.messaging;
   }
 
-  async recoverOutbox(): Promise<{ processed: number; failed: number }> {
+  async recoverOutbox(): Promise<{ processed: number; failed: number; undelivered: number }> {
     return this.factory.getEventBus().recoverPending();
+  }
+
+  /**
+   * Re-entrega los eventos que no llegaron a ningún handler y que ahora sí
+   * tienen subscriber. Lo llama el OutboxRecoveryWorker en cada barrido.
+   */
+  async replayUndeliveredOutbox(): Promise<{ replayed: number; failed: number }> {
+    return this.factory.getEventBus().replayUndelivered();
   }
 }
 

--- a/apps/api/src/modules/outbox-recovery.worker.ts
+++ b/apps/api/src/modules/outbox-recovery.worker.ts
@@ -83,12 +83,27 @@ export class OutboxRecoveryWorker implements OnApplicationBootstrap, OnModuleDes
       const result = await this.registry.recoverOutbox();
       this.metrics.recordSweep('success');
       this.metrics.recordRecoveryEvents(result.processed, result.failed);
-      if (result.processed > 0 || result.failed > 0) {
+      if (result.processed > 0 || result.failed > 0 || result.undelivered > 0) {
         this.logger.log(result, 'outbox recovery sweep');
       }
     } catch (error) {
       this.metrics.recordSweep('error');
       this.logger.error({ err: error }, 'outbox recovery sweep falló');
+    }
+
+    // Re-entrega de los eventos que no llegaron a ningún handler y cuyo
+    // subscriber ya existe. El barrido de ARRANQUE es el que importa: cubre la
+    // carrera en que un evento se despachó antes de que su bridge llegara a
+    // `onModuleInit`, que es justo el caso que dejaba el evento perdido para
+    // siempre (`recoverPending` sólo mira `processed_at IS NULL`).
+    try {
+      const replay = await this.registry.replayUndeliveredOutbox();
+      this.metrics.recordReplayed(replay.replayed);
+      if (replay.replayed > 0 || replay.failed > 0) {
+        this.logger.log(replay, 'outbox replay de eventos sin handler');
+      }
+    } catch (error) {
+      this.logger.error({ err: error }, 'outbox replay falló');
     }
 
     // Siempre actualizamos los gauges, incluso si el sweep falló: nos interesa

--- a/apps/api/src/modules/outbox.metrics.ts
+++ b/apps/api/src/modules/outbox.metrics.ts
@@ -30,6 +30,17 @@ import { Counter, Gauge, Histogram } from 'prom-client';
  *   con staleness máxima de 5min en prod (intervalo del worker).
  * - `outbox_pending_events` (gauge): número de eventos pendientes en
  *   la última muestra del worker. 0 si no hay.
+ * - `outbox_undelivered_total` (counter): eventos despachados que NO
+ *   llegaron a ningún handler. Sin label de evento a propósito
+ *   (cardinalidad): el nombre va en el WARN del bus y en `last_error`.
+ *   Lo incrementa el propio bus, no el sweep, para que cuente también el
+ *   camino BullMQ — que en producción es el 99% del tráfico.
+ * - `outbox_replayed_total` (counter): eventos re-entregados por
+ *   `replayUndelivered` cuando apareció un subscriber que antes faltaba.
+ *
+ * `outbox_undelivered_total` es lo que hace observable el fan-out a cero.
+ * Antes un evento sin subscribers se marcaba procesado y no dejaba ni métrica
+ * ni traza: era indistinguible de una entrega correcta.
  *
  * El dispatch counter cuenta TODOS los jobs (incluidos los que tienen
  * varios attempts), no solo los fallos terminales — útil para detectar
@@ -50,7 +61,21 @@ export class OutboxMetrics {
     private readonly oldestPendingAge: Gauge<string>,
     @InjectMetric('outbox_pending_events')
     private readonly pendingEvents: Gauge<string>,
+    @InjectMetric('outbox_undelivered_total')
+    private readonly undeliveredCounter: Counter<string>,
+    @InjectMetric('outbox_replayed_total')
+    private readonly replayedCounter: Counter<string>,
   ) {}
+
+  /** Un evento se despachó y no había ningún handler suscrito. */
+  recordUndelivered(): void {
+    this.undeliveredCounter.inc();
+  }
+
+  /** Eventos re-entregados tras aparecer el subscriber que faltaba. */
+  recordReplayed(count: number): void {
+    if (count > 0) this.replayedCounter.inc(count);
+  }
 
   recordDispatchCompleted(): void {
     this.dispatchCounter.inc({ result: 'completed' });
@@ -115,5 +140,13 @@ export const outboxMetricsProviders = [
   makeGaugeProvider({
     name: 'outbox_pending_events',
     help: 'Número de eventos `processed_at IS NULL` en la última muestra del recovery worker.',
+  }),
+  makeCounterProvider({
+    name: 'outbox_undelivered_total',
+    help: 'Total de eventos despachados que no encontraron ningún handler suscrito.',
+  }),
+  makeCounterProvider({
+    name: 'outbox_replayed_total',
+    help: 'Total de eventos re-entregados tras aparecer un subscriber que antes faltaba.',
   }),
 ];

--- a/apps/api/src/modules/persistent-event-bus.ts
+++ b/apps/api/src/modules/persistent-event-bus.ts
@@ -10,6 +10,61 @@ import { runSanctionedGlobalAccess, tenantContextStorage } from '../tenancy/tena
 type AnyEventHandler = (event: DomainEvent<unknown>) => Promise<void> | void;
 
 /**
+ * Marca que el despacho de un evento NO llegó a ningún handler.
+ *
+ * Va en `outbox_event.last_error` porque es la única columna que distingue
+ * un desenlace de otro sin migrar el esquema. Antes de esto un evento sin
+ * subscribers se marcaba `processed_at` a secas: `processing_attempts=0`,
+ * `last_error` NULL — es decir, EXACTAMENTE la misma fila que un evento
+ * entregado con éxito. Perder un evento era indistinguible de procesarlo y,
+ * como `recoverPending()` sólo mira `processed_at IS NULL`, irrecuperable.
+ *
+ * El prefijo (no el mensaje entero) es lo que se consulta: detrás va el
+ * nombre del evento para poder agrupar en SQL sin joins.
+ */
+export const NO_HANDLER_ERROR_PREFIX = 'NO_HANDLER: ';
+
+/**
+ * Ventana en la que un evento no entregado sigue siendo elegible para
+ * re-entrega automática (`replayUndelivered`). Acota el efecto de registrar
+ * un bridge nuevo: se recuperan los eventos que ese bridge se perdió por una
+ * carrera de arranque o un despliegue a medias, no la historia entera del
+ * tenant desde el día uno.
+ */
+export const NO_HANDLER_REPLAY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Desenlace de un intento de despacho. Es lo que devuelve `runHandlers` en
+ * lugar del `boolean` anterior, que colapsaba «entregado» y «no había a quién
+ * entregar» en el mismo `true`.
+ *
+ *   delivered   → ≥1 handler y todos terminaron OK.
+ *   failed      → ≥1 handler y alguno lanzó. Reintentable.
+ *   undelivered → 0 handlers. NO es un fallo (fan-out a cero es legítimo en un
+ *                 bus), pero tampoco es un éxito: queda etiquetado y se
+ *                 re-entrega solo si algún día aparece un subscriber.
+ */
+export type DispatchOutcome = 'delivered' | 'failed' | 'undelivered';
+
+/** Forma mínima de una fila de `outbox_event` que el bus necesita rehidratar. */
+interface OutboxRowLike {
+  eventName: string;
+  payloadVersion: number;
+  payload: unknown;
+  metadata: unknown;
+}
+
+/** Rehidrata el DomainEvent desde la fila persistida. */
+function rowToEvent(row: OutboxRowLike): DomainEvent<unknown> {
+  return {
+    name: row.eventName,
+    version: row.payloadVersion,
+    data: row.payload,
+    metadata: row.metadata as DomainEvent['metadata'],
+  };
+}
+
+/**
  * Adaptador opcional de despacho asíncrono. Si está presente y `isEnabled()`
  * devuelve true, `publish()` encola en lugar de despachar in-process. La
  * implementación real es `OutboxQueueService` con BullMQ + Redis.
@@ -17,6 +72,19 @@ type AnyEventHandler = (event: DomainEvent<unknown>) => Promise<void> | void;
 export interface OutboxDispatcher {
   isEnabled(): boolean;
   enqueue(outboxId: bigint): Promise<void>;
+}
+
+/**
+ * Observador opcional de despachos que no llegaron a nadie. Tipado
+ * estructural (no la clase `OutboxMetrics`) para que el bus siga siendo
+ * construible en tests con `new PersistentEventBus(prisma, logger)`.
+ *
+ * Va aquí y no en el sweep de recovery a propósito: en producción el 99% del
+ * despacho pasa por el worker BullMQ (`processOutboxId`), así que contar sólo
+ * desde el sweep dejaría la métrica casi siempre a cero.
+ */
+export interface UndeliveredObserver {
+  recordUndelivered(): void;
 }
 
 /**
@@ -32,10 +100,26 @@ export interface OutboxDispatcher {
  *      - Si todos los handlers OK → marca processed_at.
  *      - Si alguno falla → deja processed_at = null + incrementa attempts.
  *  3. OutboxRecoveryWorker (failsafe) reencola cada N min outbox rows que
- *     siguen pendientes (cobertura para Redis caído al momento de publish).
+ *     siguen pendientes (cobertura para Redis caído al momento de publish) y
+ *     re-entrega los que no llegaron a ningún handler y ahora sí tienen uno.
  *
  * La tabla outbox sigue siendo la única fuente de verdad — no se pierden
  * eventos ni con BullMQ ni sin él.
+ *
+ * ── Los cuatro estados de una fila de `outbox_event` ────────────────────────
+ *
+ *  processed_at | last_error          | significado
+ *  -------------|---------------------|--------------------------------------
+ *  NOT NULL     | NULL                | entregado a ≥1 handler, todos OK
+ *  NOT NULL     | 'NO_HANDLER: <ev>'  | NO llegó a nadie. Terminal pero
+ *                                     | etiquetado y re-entregable en cuanto
+ *                                     | exista un subscriber (replayUndelivered)
+ *  NULL         | NULL                | pendiente: encolado, aún sin despachar
+ *  NULL         | '<error>'           | falló el despacho. Reintentable
+ *
+ * El único estado ambiguo posible sería «processed_at puesto y last_error
+ * viejo pegado» de un reintento que acabó bien: por eso `markProcessed()`
+ * LIMPIA `last_error`. Sin esa limpieza la tabla de arriba no cerraría.
  */
 export class PersistentEventBus implements EventBus {
   private readonly handlers = new Map<string, Set<AnyEventHandler>>();
@@ -44,6 +128,7 @@ export class PersistentEventBus implements EventBus {
     private readonly prisma: PrismaService,
     private readonly logger: Logger,
     private readonly dispatcher?: OutboxDispatcher,
+    private readonly undeliveredObserver?: UndeliveredObserver,
   ) {}
 
   async publish<TPayload>(event: DomainEvent<TPayload>): Promise<void> {
@@ -135,14 +220,11 @@ export class PersistentEventBus implements EventBus {
       // Idempotencia: ya procesado.
       return;
     }
-    const event: DomainEvent<unknown> = {
-      name: row.eventName,
-      version: row.payloadVersion,
-      data: row.payload as unknown,
-      metadata: row.metadata as unknown as DomainEvent['metadata'],
-    };
-    const ok = await this.runHandlers(row.id, event);
-    if (!ok) {
+    const outcome = await this.runHandlers(row.id, rowToEvent(row));
+    // Sólo `failed` propaga: es el único desenlace que un reintento puede
+    // arreglar. `undelivered` ya quedó etiquetado en la fila y se recupera por
+    // `replayUndelivered()`, no reintentando contra un set de handlers vacío.
+    if (outcome === 'failed') {
       throw new Error(`outbox dispatch falló (id=${outboxId.toString()})`);
     }
   }
@@ -155,7 +237,9 @@ export class PersistentEventBus implements EventBus {
    * (failsafe para casos de Redis caído al momento del publish original).
    * Sin dispatcher, los procesa in-process.
    */
-  async recoverPending(limit = 50): Promise<{ processed: number; failed: number }> {
+  async recoverPending(
+    limit = 50,
+  ): Promise<{ processed: number; failed: number; undelivered: number }> {
     // Barrido cross-tenant de pendientes: acceso global sancionado.
     const pending = await runSanctionedGlobalAccess(() =>
       this.prisma.outboxEvent.findMany({
@@ -167,6 +251,7 @@ export class PersistentEventBus implements EventBus {
 
     let processed = 0;
     let failed = 0;
+    let undelivered = 0;
 
     for (const row of pending) {
       if (this.dispatcher?.isEnabled()) {
@@ -181,14 +266,9 @@ export class PersistentEventBus implements EventBus {
           });
         }
       } else {
-        const event: DomainEvent<unknown> = {
-          name: row.eventName,
-          version: row.payloadVersion,
-          data: row.payload as unknown,
-          metadata: row.metadata as unknown as DomainEvent['metadata'],
-        };
-        const ok = await this.runHandlers(row.id, event);
-        if (ok) processed++;
+        const outcome = await this.runHandlers(row.id, rowToEvent(row));
+        if (outcome === 'delivered') processed++;
+        else if (outcome === 'undelivered') undelivered++;
         else failed++;
       }
     }
@@ -198,10 +278,73 @@ export class PersistentEventBus implements EventBus {
         size: pending.length,
         processed,
         failed,
+        undelivered,
         viaQueue: this.dispatcher?.isEnabled() ?? false,
       });
     }
-    return { processed, failed };
+    return { processed, failed, undelivered };
+  }
+
+  /**
+   * Re-entrega los eventos que en su día NO llegaron a ningún handler y cuyo
+   * nombre SÍ tiene subscribers ahora.
+   *
+   * Es la mitad «recuperable» del arreglo: sin esto, marcar el evento como no
+   * entregado sólo dejaría una lápida legible. Los casos que recupera de
+   * verdad son los que dejaban el evento perdido para siempre:
+   *   - carrera de arranque (el evento se despachó antes de que el bridge
+   *     llegara a `onModuleInit`);
+   *   - despliegue a medias en el que el módulo consumidor subió después;
+   *   - un bridge que se registró más tarde en la vida del proceso.
+   *
+   * Acotado por `NO_HANDLER_REPLAY_WINDOW_MS` y por `limit`: registrar un
+   * bridge nuevo no puede desencadenar una re-entrega masiva de historia.
+   */
+  async replayUndelivered(limit = 50): Promise<{ replayed: number; failed: number }> {
+    const subscribed = [...this.handlers.entries()]
+      .filter(([, set]) => set.size > 0)
+      .map(([name]) => name);
+    if (subscribed.length === 0) return { replayed: 0, failed: 0 };
+
+    const since = new Date(Date.now() - NO_HANDLER_REPLAY_WINDOW_MS);
+    // Barrido cross-tenant: acceso global sancionado, igual que recoverPending.
+    const rows = await runSanctionedGlobalAccess(() =>
+      this.prisma.outboxEvent.findMany({
+        where: {
+          processedAt: { not: null },
+          eventName: { in: subscribed },
+          lastError: { startsWith: NO_HANDLER_ERROR_PREFIX },
+          createdAt: { gte: since },
+        },
+        orderBy: { createdAt: 'asc' },
+        take: limit,
+      }),
+    );
+
+    let replayed = 0;
+    let failed = 0;
+
+    for (const row of rows) {
+      // Reabrir ANTES de despachar: si el proceso muere a mitad, la fila queda
+      // pendiente (recuperable por recoverPending), nunca marcada como
+      // entregada sin haberlo estado.
+      await this.prisma.outboxEvent.update({
+        where: { id: row.id },
+        data: { processedAt: null, lastError: null },
+      });
+      const outcome = await this.runHandlers(row.id, rowToEvent(row));
+      if (outcome === 'delivered') replayed++;
+      else failed++;
+    }
+
+    if (rows.length > 0) {
+      this.logger.info('outbox replay de eventos sin handler', {
+        size: rows.length,
+        replayed,
+        failed,
+      });
+    }
+    return { replayed, failed };
   }
 
   private async dispatchLocal<TPayload>(
@@ -211,7 +354,10 @@ export class PersistentEventBus implements EventBus {
     await this.runHandlers(outboxId, event as DomainEvent<unknown>);
   }
 
-  private async runHandlers(outboxId: bigint, event: DomainEvent<unknown>): Promise<boolean> {
+  private async runHandlers(
+    outboxId: bigint,
+    event: DomainEvent<unknown>,
+  ): Promise<DispatchOutcome> {
     // Contexto de tenant del EVENTO para todo el despacho: los handlers (y los
     // 17 bridges suscritos) ejecutan sus queries con la extensión RLS
     // escopando al tenant correcto, sin tocar cada bridge.
@@ -224,12 +370,30 @@ export class PersistentEventBus implements EventBus {
     return this.runHandlersInner(outboxId, event);
   }
 
-  private async runHandlersInner(outboxId: bigint, event: DomainEvent<unknown>): Promise<boolean> {
+  private async runHandlersInner(
+    outboxId: bigint,
+    event: DomainEvent<unknown>,
+  ): Promise<DispatchOutcome> {
     const set = this.handlers.get(event.name);
+
+    // RECUENTO DE HANDLERS EN EL DESPACHO. Cero subscribers no es un fallo
+    // (un bus admite fan-out a cero por diseño) pero tampoco es una entrega:
+    // se marca como tal para que quede rastro y para que `replayUndelivered`
+    // pueda re-entregarlo si más adelante aparece quien lo escuche.
+    //
+    // No se lanza excepción a propósito: haría que BullMQ reintentara 5 veces
+    // CADA evento sin consumidor — y hoy hay ~30 nombres de evento publicados
+    // que legítimamente no tiene nadie suscrito (fundae.*, messaging.*,
+    // courses.course.created…). Serían miles de reintentos inútiles por tanda.
     if (!set || set.size === 0) {
-      // Sin subscribers locales aún -> marcamos procesado igualmente.
-      await this.markProcessed(outboxId);
-      return true;
+      await this.markUndelivered(outboxId, event.name);
+      this.undeliveredObserver?.recordUndelivered();
+      this.logger.warn('evento sin handlers: no se entregó a nadie', {
+        event: event.name,
+        outboxId: outboxId.toString(),
+        tenantId: event.metadata?.tenantId,
+      });
+      return 'undelivered';
     }
 
     const errors: string[] = [];
@@ -249,17 +413,40 @@ export class PersistentEventBus implements EventBus {
 
     if (errors.length === 0) {
       await this.markProcessed(outboxId);
-      return true;
+      return 'delivered';
     }
 
     await this.markFailed(outboxId, errors.join(' | '));
-    return false;
+    return 'failed';
   }
 
   private async markProcessed(outboxId: bigint): Promise<void> {
     await this.prisma.outboxEvent.update({
       where: { id: outboxId },
-      data: { processedAt: new Date() },
+      data: {
+        processedAt: new Date(),
+        // Limpiar el error es lo que hace que «processed_at puesto» + «sin
+        // last_error» signifique EXACTAMENTE «entregado bien»: si un reintento
+        // acaba en éxito, el error del intento anterior no puede quedarse
+        // pegado o el estado NO_HANDLER dejaría de ser distinguible.
+        lastError: null,
+      },
+    });
+  }
+
+  /**
+   * Marca la fila como «no llegó a ningún handler». Terminal para el barrido
+   * de pendientes (`processed_at` puesto: no se re-encola en bucle ni infla el
+   * gauge de lag) pero explícitamente distinta de un éxito, y recuperable vía
+   * `replayUndelivered()`.
+   */
+  private async markUndelivered(outboxId: bigint, eventName: string): Promise<void> {
+    await this.prisma.outboxEvent.update({
+      where: { id: outboxId },
+      data: {
+        processedAt: new Date(),
+        lastError: `${NO_HANDLER_ERROR_PREFIX}${eventName}`.slice(0, 2000),
+      },
     });
   }
 

--- a/apps/api/tests/me-profile-locale.test.ts
+++ b/apps/api/tests/me-profile-locale.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { ALLOWED_LOCALES, updateProfileSchema } from '../src/auth/me.controller';
+
+/**
+ * Contrato de idioma de `PATCH /api/v1/me/profile`.
+ *
+ * `pt-BR` estuvo en `ALLOWED_LOCALES` sin tener catálogo de mensajes en la web.
+ * La consecuencia no era cosmética: el endpoint PERSISTÍA el valor, así que un
+ * usuario acababa con un perfil en un idioma que la interfaz no sabe pintar y
+ * `/cuenta` se lo confirmaba («Português (Brasil)») mientras la UI seguía en
+ * español. Quitarlo del selector sin quitarlo de aquí habría dejado la API
+ * guardando lo mismo por SCIM, por curl o por un cliente viejo.
+ */
+describe('PATCH /me/profile · locale', () => {
+  it('rechaza pt-BR: el producto no lo tiene traducido', () => {
+    const parsed = updateProfileSchema.safeParse({ locale: 'pt-BR' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('acepta los tres idiomas que la UI sabe pintar', () => {
+    for (const locale of ['es-ES', 'es-AR', 'en-US']) {
+      expect(updateProfileSchema.safeParse({ locale }).success, locale).toBe(true);
+    }
+  });
+
+  it('la lista permitida es exactamente esa (guarda contra reintroducirlo)', () => {
+    expect([...ALLOWED_LOCALES]).toEqual(['es-ES', 'es-AR', 'en-US']);
+  });
+
+  it('sigue rechazando cualquier otro tag', () => {
+    for (const locale of ['fr-FR', 'es', 'en', 'zz', '']) {
+      expect(updateProfileSchema.safeParse({ locale }).success, locale).toBe(false);
+    }
+  });
+
+  it('omitir el locale sigue siendo válido (no toca el guardado)', () => {
+    // Es lo que protege a quien ya tiene `pt-BR`: puede editar su nombre sin
+    // que la API le exija cambiar de idioma primero.
+    expect(updateProfileSchema.safeParse({ name: 'Ana' }).success).toBe(true);
+  });
+});

--- a/apps/api/tests/persistent-event-bus.test.ts
+++ b/apps/api/tests/persistent-event-bus.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PersistentEventBus, type OutboxDispatcher } from '../src/modules/persistent-event-bus';
+import {
+  NO_HANDLER_REPLAY_WINDOW_MS,
+  PersistentEventBus,
+  type OutboxDispatcher,
+} from '../src/modules/persistent-event-bus';
 import { tenantContextStorage, type TenantContext } from '../src/tenancy/tenant-context.storage';
 
 interface OutboxRow {
@@ -55,28 +59,45 @@ function makeFakePrisma() {
       async update(args: {
         where: { id: bigint };
         data: {
-          processedAt?: Date;
+          processedAt?: Date | null;
           processingAttempts?: { increment: number };
-          lastError?: string;
+          lastError?: string | null;
         };
       }): Promise<OutboxRow> {
         const row = rows.get(args.where.id);
         if (!row) throw new Error('not found');
-        if (args.data.processedAt) row.processedAt = args.data.processedAt;
+        // `!== undefined` y no truthiness: el bus escribe `null` a propósito
+        // (limpiar el error al procesar, reabrir la fila al re-entregar) y con
+        // un `if (args.data.x)` esos writes se perderían y el fake mentiría.
+        if (args.data.processedAt !== undefined) row.processedAt = args.data.processedAt;
         if (args.data.processingAttempts)
           row.processingAttempts += args.data.processingAttempts.increment;
-        if (typeof args.data.lastError === 'string') row.lastError = args.data.lastError;
+        if (args.data.lastError !== undefined) row.lastError = args.data.lastError;
         return row;
       },
       async findMany(args: {
-        where: { processedAt: null };
+        where: {
+          processedAt?: null | { not: null };
+          eventName?: { in: string[] };
+          lastError?: { startsWith: string };
+          createdAt?: { gte: Date };
+        };
         orderBy: { createdAt: 'asc' };
         take: number;
       }): Promise<OutboxRow[]> {
-        const _ = args;
+        const w = args.where;
         return [...rows.values()]
-          .filter((r) => r.processedAt === null)
-          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+          .filter((r) => {
+            if (w.processedAt === null && r.processedAt !== null) return false;
+            if (w.processedAt && 'not' in w.processedAt && r.processedAt === null) return false;
+            if (w.eventName && !w.eventName.in.includes(r.eventName)) return false;
+            if (w.lastError && !(r.lastError ?? '').startsWith(w.lastError.startsWith))
+              return false;
+            if (w.createdAt && r.createdAt.getTime() < w.createdAt.gte.getTime()) return false;
+            return true;
+          })
+          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+          .slice(0, args.take);
       },
       async findUnique(args: { where: { id: bigint } }): Promise<OutboxRow | null> {
         return rows.get(args.where.id) ?? null;
@@ -158,11 +179,158 @@ describe('PersistentEventBus', () => {
     expect(seen?.traceId).toMatch(/^outbox-/);
   });
 
-  it('marca processedAt aunque no haya subscribers (no se pierde el evento)', async () => {
+  it('un evento sin subscribers NO queda igual que uno entregado con éxito', async () => {
     const bus = new PersistentEventBus(prisma as never, silentLogger);
-    await bus.publish(makeEvent('algo.suelto'));
-    const row = [...prisma._rows.values()][0];
+    const handler = vi.fn(async () => {});
+    bus.subscribe('con.handler', handler);
+
+    await bus.publish(makeEvent('con.handler', {}, 'idem-ok'));
+    await bus.publish(makeEvent('algo.suelto', {}, 'idem-huerfano'));
+
+    const [entregado, huerfano] = [...prisma._rows.values()];
+
+    // Ésta es LA aserción del arreglo: antes las dos filas eran idénticas
+    // (processedAt puesto, attempts 0, lastError null) y perder un evento era
+    // indistinguible de procesarlo.
+    expect(entregado!.lastError).toBeNull();
+    expect(huerfano!.lastError).toBe('NO_HANDLER: algo.suelto');
+    expect(entregado!.lastError).not.toEqual(huerfano!.lastError);
+  });
+
+  it('el éxito limpia el lastError de un intento anterior (o el estado sería ambiguo)', async () => {
+    const bus = new PersistentEventBus(prisma as never, silentLogger);
+    const off = bus.subscribe('reintento', async () => {
+      throw new Error('boom');
+    });
+    await bus.publish(makeEvent('reintento', {}, 'idem-limpia'));
+    const row = [...prisma._rows.values()][0]!;
+    expect(row.lastError).toContain('boom');
+
+    off();
+    bus.subscribe('reintento', async () => {});
+    await bus.recoverPending();
+
     expect(row.processedAt).toBeInstanceOf(Date);
+    // Sin esta limpieza, «processedAt puesto + lastError no nulo» significaría
+    // a la vez «reintento que acabó bien» y «no llegó a nadie».
+    expect(row.lastError).toBeNull();
+  });
+
+  it('avisa por log y por el observador cuando un evento no llega a nadie', async () => {
+    const warn = vi.fn();
+    const observer = { recordUndelivered: vi.fn() };
+    const bus = new PersistentEventBus(
+      prisma as never,
+      { ...silentLogger, warn },
+      undefined,
+      observer,
+    );
+
+    await bus.publish(makeEvent('nadie.escucha', {}, 'idem-warn'));
+
+    expect(observer.recordUndelivered).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('sin handlers'),
+      expect.objectContaining({ event: 'nadie.escucha' }),
+    );
+  });
+
+  it('el evento sin handler NO se re-encola en bucle en el barrido de pendientes', async () => {
+    // Marcarlo como pendiente habría sido la otra opción de diseño, y rompía el
+    // recovery: hay ~30 nombres de evento publicados sin ningún consumidor
+    // (fundae.*, messaging.*, courses.course.created…). Con `take: 50` ordenado
+    // por antigüedad, el barrido se quedaría atascado en ellos para siempre.
+    const bus = new PersistentEventBus(prisma as never, silentLogger);
+    await bus.publish(makeEvent('nadie.escucha', {}, 'idem-nobucle'));
+
+    const result = await bus.recoverPending();
+    expect(result.processed).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  describe('replayUndelivered — la parte recuperable', () => {
+    it('re-entrega el evento en cuanto aparece el subscriber que faltaba', async () => {
+      const bus = new PersistentEventBus(prisma as never, silentLogger);
+
+      // Carrera de arranque: el evento se despacha ANTES de que el bridge se
+      // suscriba. Con el comportamiento anterior esto se perdía para siempre.
+      await bus.publish(makeEvent('billing.order.completed', { orderId: 'o1' }, 'idem-replay'));
+      const row = [...prisma._rows.values()][0]!;
+      expect(row.lastError).toBe('NO_HANDLER: billing.order.completed');
+
+      const bridge = vi.fn(async () => {});
+      bus.subscribe('billing.order.completed', bridge);
+
+      const result = await bus.replayUndelivered();
+
+      expect(result.replayed).toBe(1);
+      expect(bridge).toHaveBeenCalledOnce();
+      expect(bridge.mock.calls[0]![0]).toMatchObject({
+        name: 'billing.order.completed',
+        data: { orderId: 'o1' },
+      });
+      expect(row.processedAt).toBeInstanceOf(Date);
+      expect(row.lastError).toBeNull();
+    });
+
+    it('no re-entrega dos veces: tras el replay la fila ya no es elegible', async () => {
+      const bus = new PersistentEventBus(prisma as never, silentLogger);
+      await bus.publish(makeEvent('billing.order.completed', {}, 'idem-once'));
+      const bridge = vi.fn(async () => {});
+      bus.subscribe('billing.order.completed', bridge);
+
+      await bus.replayUndelivered();
+      const second = await bus.replayUndelivered();
+
+      expect(second.replayed).toBe(0);
+      expect(bridge).toHaveBeenCalledOnce();
+    });
+
+    it('deja en paz los eventos que siguen sin tener a nadie suscrito', async () => {
+      const bus = new PersistentEventBus(prisma as never, silentLogger);
+      bus.subscribe('otro.evento', async () => {});
+      await bus.publish(makeEvent('nadie.escucha', {}, 'idem-sigue-solo'));
+
+      const result = await bus.replayUndelivered();
+
+      expect(result.replayed).toBe(0);
+      const row = [...prisma._rows.values()][0]!;
+      expect(row.lastError).toBe('NO_HANDLER: nadie.escucha');
+    });
+
+    it('no re-entrega historia más vieja que la ventana', async () => {
+      const bus = new PersistentEventBus(prisma as never, silentLogger);
+      await bus.publish(makeEvent('billing.order.completed', {}, 'idem-viejo'));
+      const row = [...prisma._rows.values()][0]!;
+      // Envejecemos la fila más allá de la ventana: registrar un bridge nuevo
+      // no puede desencadenar una re-entrega masiva de historia.
+      row.createdAt = new Date(Date.now() - NO_HANDLER_REPLAY_WINDOW_MS - 60_000);
+
+      const bridge = vi.fn(async () => {});
+      bus.subscribe('billing.order.completed', bridge);
+
+      const result = await bus.replayUndelivered();
+      expect(result.replayed).toBe(0);
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('si el handler del replay falla, la fila queda pendiente y reintentable', async () => {
+      const bus = new PersistentEventBus(prisma as never, silentLogger);
+      await bus.publish(makeEvent('billing.order.completed', {}, 'idem-replay-falla'));
+      bus.subscribe('billing.order.completed', async () => {
+        throw new Error('el bridge revienta');
+      });
+
+      const result = await bus.replayUndelivered();
+
+      expect(result.failed).toBe(1);
+      const row = [...prisma._rows.values()][0]!;
+      // NO vuelve al estado NO_HANDLER: ahora es un fallo de despacho normal,
+      // que `recoverPending` sí reintenta.
+      expect(row.processedAt).toBeNull();
+      expect(row.lastError).toContain('el bridge revienta');
+      expect(row.processingAttempts).toBe(1);
+    });
   });
 
   it('incrementa attempts y guarda lastError si el handler falla', async () => {
@@ -307,6 +475,22 @@ describe('PersistentEventBus', () => {
       await expect(bus.processOutboxId(row.id)).rejects.toThrow(/outbox dispatch falló/);
       expect(row.processedAt).toBeNull();
       expect(row.processingAttempts).toBe(1);
+    });
+
+    it('processOutboxId NO lanza si no hay handlers, pero deja la fila etiquetada', async () => {
+      const dispatcher = makeFakeDispatcher();
+      const bus = new PersistentEventBus(prisma as never, silentLogger, dispatcher);
+
+      await bus.publish(makeEvent('nadie.escucha', {}, 'idem-nohandler-q'));
+      const [row] = [...prisma._rows.values()];
+
+      // Lanzar haría que BullMQ reintentara 5 veces con backoff CADA evento sin
+      // consumidor. Reintentar contra un set de handlers vacío no arregla nada:
+      // lo que lo arregla es que aparezca un subscriber, y de eso se ocupa
+      // replayUndelivered.
+      await expect(bus.processOutboxId(row!.id)).resolves.toBeUndefined();
+      expect(row!.lastError).toBe('NO_HANDLER: nadie.escucha');
+      expect(row!.processingAttempts).toBe(0);
     });
 
     it('recoverPending reencola pendientes a la queue (no despacha local)', async () => {

--- a/apps/web/src/app/(app)/cuenta/page.tsx
+++ b/apps/web/src/app/(app)/cuenta/page.tsx
@@ -67,8 +67,14 @@ function getInitials(name: string | null, email: string): string {
   return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
 }
 
+/**
+ * Etiqueta del idioma para la ficha de solo lectura. Normaliza antes de buscar:
+ * un perfil guardado con un tag que ya no se ofrece (`pt-BR`) mostraría si no
+ * el tag crudo, y encima anunciaría un idioma que la UI no está sirviendo.
+ */
 function localeLabel(value: string): string {
-  return LOCALE_OPTIONS.find((o) => o.value === value)?.label ?? value;
+  const normalized = toSupportedLocale(value);
+  return LOCALE_OPTIONS.find((o) => o.value === normalized)?.label ?? normalized;
 }
 
 function monthYear(iso: string): string {
@@ -112,7 +118,12 @@ export default function CuentaPage() {
     setDepartment(p.department ?? '');
     setLocation(p.location ?? '');
     setBio(p.bio ?? '');
-    setLocale(p.locale);
+    // Normalizado, no crudo: en base de datos hay perfiles con locales que el
+    // selector ya no ofrece (`pt-BR` de antes de su retirada, o cualquier tag
+    // que entre por SCIM). Con el valor crudo el `<select>` no casaría con
+    // ninguna opción y quedaría en blanco. Degradado al mismo idioma que la UI
+    // está sirviendo de verdad.
+    setLocale(toSupportedLocale(p.locale));
     setTimezone(p.timezone);
     setAvatarUrl(p.avatarUrl ?? '');
     setDocumentId(p.documentId ?? '');

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -20,6 +20,7 @@ import { ApiHttpError } from '@/lib/api-client';
 import { authStorage } from '@/lib/auth-storage';
 import { consumeIntendedPath } from '@/lib/post-login-redirect';
 import { apiErrorMessage } from '@/lib/i18n/api-error';
+import { toSupportedLocale } from '@/i18n/config';
 import { LOCALE_OPTIONS, meApi, TIMEZONE_OPTIONS, type NotificationPreference } from '@/lib/me';
 import { useTenantContext } from '@/lib/tenant-context';
 import { communityApi } from '@/modules/community';
@@ -77,7 +78,10 @@ export default function OnboardingPage() {
         setEmail(p.email);
         setName(p.name ?? '');
         setBio(p.bio ?? '');
-        setLocale(p.locale);
+        // Normalizado: ver el mismo comentario en `/cuenta`. Un locale
+        // guardado que el selector ya no ofrece dejaría el `<select>` sin
+        // opción que casar.
+        setLocale(toSupportedLocale(p.locale));
         setTimezone(p.timezone);
         setDocumentId(p.documentId ?? '');
         setAvatarUrl(p.avatarUrl);

--- a/apps/web/src/i18n/config.test.ts
+++ b/apps/web/src/i18n/config.test.ts
@@ -20,7 +20,12 @@ describe('toSupportedLocale', () => {
     expect(toSupportedLocale('EN-gb')).toBe('en-US');
   });
 
-  it('pt-BR (válido en el backend, sin catálogo) → es-ES', () => {
+  it('CAMINO DEGRADADO: pt-BR (retirado, pero guardado en perfiles viejos) → es-ES', () => {
+    // Ya no se puede elegir ni guardar (fuera de LOCALE_OPTIONS y de
+    // ALLOWED_LOCALES), pero sigue existiendo en base de datos: perfiles
+    // anteriores a la retirada y altas por SCIM, que copia el locale del IdP
+    // sin validar (apps/api/src/scim/scim.mapper.ts). Sin este degradado esos
+    // usuarios quedarían con un valor que la UI no sabe pintar.
     expect(toSupportedLocale('pt-BR')).toBe('es-ES');
   });
 

--- a/apps/web/src/i18n/config.ts
+++ b/apps/web/src/i18n/config.ts
@@ -12,9 +12,19 @@
  *
  * `SUPPORTED_LOCALES` son los tags que la UI puede ACTIVAR; los catálogos de
  * mensajes son solo dos (`es`, `en`): es-AR comparte el catálogo español y
- * únicamente cambia el formato de fechas/números. `pt-BR` sigue siendo válido
- * en el backend (ALLOWED_LOCALES de me.controller) pero cae al catálogo `es`
- * hasta que exista traducción portuguesa.
+ * únicamente cambia el formato de fechas/números.
+ *
+ * Esta lista es la ÚNICA fuente de verdad del idioma elegible: `LOCALE_OPTIONS`
+ * (apps/web/src/lib/me.ts) se deriva de ella y `ALLOWED_LOCALES`
+ * (apps/api/src/auth/me.controller.ts) la refleja. Antes eran tres listas
+ * independientes y por eso `pt-BR` llegó a estar en el selector y en la API sin
+ * existir en los catálogos: el usuario elegía portugués, la API lo guardaba,
+ * `/cuenta` le confirmaba «Português (Brasil)» y la UI seguía en español.
+ *
+ * `toSupportedLocale()` sigue degradando cualquier tag ajeno —`pt-BR` incluido—
+ * porque en base de datos quedan valores que la UI ya no ofrece: perfiles
+ * guardados antes de esta retirada y los que entran por SCIM
+ * (apps/api/src/scim/scim.mapper.ts, que copia el locale del IdP sin validar).
  */
 
 export const LOCALE_COOKIE = 'didacta_locale';

--- a/apps/web/src/lib/locale-options.test.ts
+++ b/apps/web/src/lib/locale-options.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { SUPPORTED_LOCALES, toSupportedLocale } from '@/i18n/config';
+import { LOCALE_OPTIONS } from './me';
+
+/**
+ * El selector de idioma de `/cuenta` y `/onboarding`.
+ *
+ * El fallo que cubren estos tests: `LOCALE_OPTIONS` era una lista suelta,
+ * independiente de `SUPPORTED_LOCALES`, y ofrecía `pt-BR` — un idioma sin
+ * catálogo de mensajes. El usuario elegía portugués, la API lo guardaba,
+ * `/cuenta` le confirmaba «Português (Brasil)» y la interfaz seguía en español.
+ */
+describe('LOCALE_OPTIONS', () => {
+  it('no ofrece pt-BR: el producto no lo tiene traducido', () => {
+    expect(LOCALE_OPTIONS.map((o) => o.value)).not.toContain('pt-BR');
+    expect(LOCALE_OPTIONS.map((o) => o.label).join(' ')).not.toContain('Português');
+  });
+
+  it('ofrece exactamente los idiomas soportados, ni uno más', () => {
+    // La igualdad en los DOS sentidos es el punto: ofrecer de menos esconde un
+    // idioma que sí existe, y ofrecer de más es el bug que se está arreglando.
+    expect(LOCALE_OPTIONS.map((o) => o.value).sort()).toEqual([...SUPPORTED_LOCALES].sort());
+  });
+
+  it('toda opción tiene etiqueta no vacía', () => {
+    for (const option of LOCALE_OPTIONS) {
+      expect(option.label.trim(), `sin etiqueta: ${option.value}`).not.toBe('');
+    }
+  });
+
+  it('CAMINO DEGRADADO: un locale guardado que ya no se ofrece casa con una opción real', () => {
+    // `pt-BR` sigue en base de datos (perfiles anteriores a la retirada y altas
+    // por SCIM). `/cuenta` y `/onboarding` normalizan antes de pintar el
+    // `<select>`; sin eso el desplegable no casaría con ninguna opción y
+    // quedaría en blanco.
+    const almacenados = ['pt-BR', 'fr-FR', 'zz', ''];
+    for (const guardado of almacenados) {
+      const normalizado = toSupportedLocale(guardado);
+      expect(
+        LOCALE_OPTIONS.some((o) => o.value === normalizado),
+        `${guardado} degradó a ${normalizado}, que no está en el selector`,
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/lib/me.ts
+++ b/apps/web/src/lib/me.ts
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
  */
 
+import { SUPPORTED_LOCALES, type SupportedLocale } from '@/i18n/config';
 import { apiFetch } from './api-client';
 
 export interface UserProfile {
@@ -185,9 +186,26 @@ export const TIMEZONE_OPTIONS: Array<{ group: string; values: string[] }> = Obje
   TIMEZONE_GROUPS,
 ).map(([group, values]) => ({ group, values }));
 
-export const LOCALE_OPTIONS = [
-  { value: 'es-AR', label: 'Español (Argentina)' },
-  { value: 'es-ES', label: 'Español (España)' },
-  { value: 'en-US', label: 'English (US)' },
-  { value: 'pt-BR', label: 'Português (Brasil)' },
-];
+/**
+ * Etiqueta de cada idioma elegible. En su propio idioma a propósito: quien
+ * busca «English» no está leyendo la interfaz en español.
+ *
+ * El `Record<SupportedLocale, string>` es lo que impide que el selector y los
+ * idiomas realmente soportados vuelvan a divergir: añadir un tag a
+ * `SUPPORTED_LOCALES` sin etiqueta aquí no compila.
+ */
+const LOCALE_LABELS: Record<SupportedLocale, string> = {
+  'es-AR': 'Español (Argentina)',
+  'es-ES': 'Español (España)',
+  'en-US': 'English (US)',
+};
+
+/**
+ * Opciones del selector de idioma de `/cuenta` y `/onboarding`.
+ *
+ * DERIVADO de `SUPPORTED_LOCALES`, no una lista aparte. Cuando era una lista
+ * suelta ofrecía `pt-BR`, que no tiene catálogo: se elegía portugués, la API lo
+ * guardaba y la UI seguía en español. Retirado — el producto sirve `es` y `en`.
+ */
+export const LOCALE_OPTIONS: Array<{ value: SupportedLocale; label: string }> =
+  SUPPORTED_LOCALES.map((value) => ({ value, label: LOCALE_LABELS[value] }));


### PR DESCRIPTION
Dos encargos independientes. Verificados con la suite unitaria, con mutación de
las líneas que sostienen cada test, y con una tanda E2E completa sobre un stack
aislado (base y Redis propios, para no tocar el stack que otro worker tiene vivo
en :4000/:3010).

---

## 1 — El bus se tragaba los eventos sin handler

`persistent-event-bus.ts` marcaba `processed_at` cuando el despacho no
encontraba ningún subscriber. La fila quedaba **idéntica** a la de una entrega
correcta (`processing_attempts=0`, `last_error` NULL) y, como `recoverPending()`
sólo mira `processed_at IS NULL`, no se reintentaba jamás.

**Medido, no supuesto.** Sobre la base del arnés antes de tocar nada: 589
eventos, 0 pendientes, 0 con error — todos «bien», incluidos los ~14 nombres de
evento que no consume nadie. Con el arreglo, una tanda completa da:

| estado | filas |
|---|---|
| entregado a >=1 handler | 275 |
| **no llegó a nadie** | **367** |

El 57% del tráfico del bus no llegaba a ningún sitio y era indistinguible del
éxito.

### Diseño

Recuento de handlers en el despacho y desenlace explícito (`DispatchOutcome`:
`delivered` / `failed` / `undelivered`) en vez del `boolean` que colapsaba
«entregado» y «no había a quién entregar» en el mismo `true`. Sin migración de
esquema: los cuatro estados se leen de las columnas que ya existen.

| `processed_at` | `last_error` | significado |
|---|---|---|
| NOT NULL | NULL | entregado a >=1 handler, todos OK |
| NOT NULL | `NO_HANDLER: <ev>` | **no llegó a nadie**; terminal pero etiquetado y re-entregable |
| NULL | NULL | pendiente |
| NULL | `<error>` | falló; reintentable |

`markProcessed()` ahora **limpia `last_error`**. Sin eso un reintento que acaba
bien dejaría el error viejo pegado y la fila 2 dejaría de distinguirse.

**Recuperable** = `replayUndelivered()`: re-entrega los eventos sin handler cuyo
nombre **ya tiene subscriber**, acotado por `NO_HANDLER_REPLAY_WINDOW_MS` (24 h)
y por `limit`. Lo llama el `OutboxRecoveryWorker` en cada barrido, **incluido el
de arranque**, que es el que cubre la carrera en que un evento se despacha antes
de que su bridge llegue a `onModuleInit`.

### Por qué fan-out a cero NO se trata como fallo

Las dos alternativas se descartaron por medición, no por gusto:

- **Lanzar** → BullMQ reintentaría 5 veces con backoff cada uno de los ~14
  nombres de evento sin consumidor (`fundae.*`, `messaging.*`,
  `courses.course.created`, `gamification.points.awarded`…). Miles de reintentos
  inútiles por tanda.
- **Dejar la fila pendiente** → el barrido usa `take: 50` ordenado por
  antigüedad. Con 367 de 642 eventos permanentemente pendientes se atascaría en
  ellos para siempre y el failsafe dejaría de funcionar.

### Camino degradado

Constante nombrada: `NO_HANDLER_ERROR_PREFIX`
(`apps/api/src/modules/persistent-event-bus.ts:25`). Casos:

1. **Sin subscribers para el nombre del evento** —
   `apps/api/src/modules/persistent-event-bus.ts:398`. Fila etiquetada, WARN con
   nombre de evento + tenant, contador `outbox_undelivered_total`.
   `processOutboxId` no lanza.
2. **El replay falla al re-despachar** —
   `apps/api/src/modules/persistent-event-bus.ts:353`. La fila NO vuelve al
   estado `NO_HANDLER`: pasa a fallo normal (`processed_at` NULL, attempts+1)
   que `recoverPending` sí reintenta. Se reabre **antes** de despachar, así que
   si el proceso muere a mitad queda pendiente, nunca marcada como entregada sin
   estarlo.

### Verificación por mutación

| mutación | tests en rojo |
|---|---|
| sin handler → `markProcessed` (comportamiento viejo) | 6 |
| `markProcessed` no limpia `last_error` | 1 |
| `replayUndelivered` sin ventana temporal | 1 |

### Observabilidad

`outbox_undelivered_total` y `outbox_replayed_total`. El contador lo incrementa
el **bus**, no el sweep: en producción casi todo el despacho pasa por el worker
BullMQ, así que contarlo desde el sweep lo dejaría casi siempre a cero. Sin
label de evento (cardinalidad) — el nombre va en el WARN y en `last_error`.

---

## 2 — pt-BR retirado

El selector ofrecía «Português (Brasil)», la API lo persistía y no existe
catálogo portugués: se elegía portugués, `/cuenta` lo confirmaba y la UI seguía
en español.

Sale de las dos puntas: del selector **y** de `ALLOWED_LOCALES`
(`me.controller.ts` → 400). Quitarlo sólo del selector habría dejado la API
guardándolo por SCIM, por curl o desde un cliente viejo.

La causa de fondo eran **tres listas independientes** de idiomas. Ahora
`LOCALE_OPTIONS` se **deriva** de `SUPPORTED_LOCALES` con un
`Record<SupportedLocale, string>` de etiquetas: añadir un tag sin etiqueta no
compila y el selector no puede volver a divergir.

**Usuarios que ya lo tengan guardado.** `pt-BR` sigue en base de datos (perfiles
anteriores y altas por SCIM, que copia el locale del IdP sin validar —
`apps/api/src/scim/scim.mapper.ts`). No quedan impintables:

- `toSupportedLocale()` lo degrada a `es-ES` — ya existía, ahora con test que
  nombra el caso;
- `/cuenta` y `/onboarding` normalizan el locale guardado antes de poblar el
  `<select>`, que si no se quedaría sin opción que casar;
- `localeLabel()` normaliza antes de buscar etiqueta, para no anunciar un idioma
  que la UI no está sirviendo;
- pueden editar el resto del perfil sin cambiar de idioma primero (`locale` es
  opcional en el schema).

**Consumidores revisados.** `resolveRecipientLocale()` sigue devolviendo `pt-BR`
tal cual a propósito (un override de plantilla per-tenant en pt-BR todavía puede
ganar; el email cae al español por `toHubTemplateLang()`) — sin cambios. Los
tests de camino degradado de email y password-reset siguen verdes. No se toca
`courseLanguage` de los catálogos: es el idioma del CONTENIDO de un curso, otro
eje.

`apps/e2e/tests/i18n-language-switch.spec.ts` sólo usa `es-ES` y `en-US`: pasa.

---

## Verificación

| | resultado |
|---|---|
| vitest api | **2185/2185** (baseline 2171 + 14 nuevos) |
| vitest web | **355/355** (baseline 351 + 4 nuevos) |
| ee-fence | **0 violaciones** |
| dev-check --quick | typecheck api+web, eslint, prettier — OK |
| E2E completo | **270 pasan / 2 fallan / 10 skipped** (282) |

### Sobre los rojos de E2E

**Los 3 que traía el encargo pasan**: `membership-trial:370`, `quiz-flow:96` y
`referrals-flow:386` — verde tanto en aislado como en la tanda completa.

**Pero no salían de aquí, y conviene decirlo.** La evidencia que produce el
propio arreglo lo descarta: los eventos de los que dependen esos tres specs
(`subscriptions.membership.activated`, `subscriptions.invoice.paid`,
`subscriptions.subscription.activated`, `referrals.referral.attributed`,
`learning.course.completed`, `assessments.attempt.passed`,
`certificates.issued`) salen **todos con 0 en la columna «sin handler»**. Sus
bridges se suscriben incondicionalmente en `onModuleInit`, antes de que la API
acepte tráfico. Lo que sí aparece sin consumidor es otra cosa
(`subscriptions.invoice.payment_failed`, `referrals.commission.approved`,
`referrals.commission.revoked`, `messaging.*`, `fundae.*`). Así que su
intermitencia sigue sin causa identificada — este PR la deja
**diagnosticable**, que antes era justo lo imposible.

**Los 2 que fallan son previos.** `mfa-setup:24` y `mfa-enforcement:47`, ambos
por `session.mfaRequired === false`. Comprobado haciendo `stash` de todo el PR,
recompilando la API desde el commit base y corriéndolos: **fallan igual**. No
tocan ni el bus ni el locale.

### Hallazgo aparte (no arreglado aquí)

`OutboxQueueService.enqueue()` deriva el `jobId` del BIGSERIAL de
`outbox_event`. BullMQ **deduplica en silencio** un `add` cuyo jobId ya existe,
incluso en el set de completados (retención 24 h). Si la base se recrea sin
vaciar Redis, la secuencia reinicia en 1, los jobs nuevos chocan con los viejos
y **los eventos no se despachan nunca**. Lo pisé montando el arnés y lo
reproduje (job `outbox-1` en Redis con `finishedOn` y 53 filas clavadas en
pendiente con `attempts=0`); al vaciar Redis, el barrido de arranque las drenó
todas. Peor: `recoverPending()` cuenta ese re-enqueue deduplicado como
`processed++`, así que el failsafe **reporta éxito sin entregar nada**.
`e2e-stack.sh reset` no lo sufre porque hace `docker compose down -v`. Merece
encargo propio.

## Frontera

No se ha tocado `modules/*/`, ni `modules/*/src/errors.ts`, ni ningún
`ExceptionFilter`, ni los catálogos `errorsApi*.json`.

Fuera de la lista literal del encargo, y por qué:
`apps/web/src/app/(app)/cuenta/page.tsx` y `apps/web/src/app/onboarding/page.tsx`
— una línea cada uno, para normalizar el locale guardado antes de pintar el
`<select>`. Sin eso el criterio «no pueden quedar en un estado que la UI no sabe
pintar» no se cumplía: al salir `pt-BR` de `LOCALE_OPTIONS`, un perfil con ese
valor dejaba el desplegable en blanco.
