### PR TITLE
fix(outbox): la identidad del job de BullMQ deja de venir del BIGSERIAL y el failsafe deja de mentir

### DIFF
--- a/apps/api/src/modules/module-registry.service.ts
+++ b/apps/api/src/modules/module-registry.service.ts
@@ -1100,7 +1100,12 @@ export class ModuleRegistryService implements OnModuleInit {
     return this.messaging;
   }
 
-  async recoverOutbox(): Promise<{ processed: number; failed: number; undelivered: number }> {
+  async recoverOutbox(): Promise<{
+    processed: number;
+    failed: number;
+    undelivered: number;
+    deduplicated: number;
+  }> {
     return this.factory.getEventBus().recoverPending();
   }
 

--- a/apps/api/src/modules/outbox-enqueue.ts
+++ b/apps/api/src/modules/outbox-enqueue.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+import type { EnqueueOutcome, OutboxJobRef } from './persistent-event-bus';
+
+/**
+ * Estados de BullMQ desde los que un job **ya no va a ejecutarse nunca**.
+ *
+ * `completed` y `failed` son terminales por definición; `unknown` es lo que
+ * devuelve `getState()` cuando el hash del job no existe (lo purgó
+ * `removeOnComplete`/`removeOnFail` entre el `add` y la consulta), y desde ahí
+ * tampoco va a correr nada.
+ *
+ * El resto (`waiting`, `active`, `delayed`, `prioritized`,
+ * `waiting-children`) significa «hay un job que acabará llamando a
+ * `processOutboxId`», que es justo lo que necesitamos saber.
+ */
+const TERMINAL_JOB_STATES: ReadonlySet<string> = new Set(['completed', 'failed', 'unknown']);
+
+/**
+ * Identidad del job de despacho de una fila del outbox.
+ *
+ * ── Por qué NO basta el id ───────────────────────────────────────────────────
+ * `outbox_event.id` es un BIGSERIAL. BullMQ deduplica **en silencio** un `add`
+ * cuyo `jobId` ya existe como clave en Redis — y las claves sobreviven al
+ * final del job (`removeOnComplete` 24 h, `removeOnFail` 7 d). Con el id
+ * pelado, recrear la base sin vaciar Redis reinicia la secuencia en 1, los
+ * eventos nuevos chocan con jobs viejos ya terminados y **no se despachan
+ * jamás**. Reproducido: job `outbox-1` en Redis con `finishedOn`, 53 filas
+ * clavadas en pendiente con `attempts=0`.
+ *
+ * ── Por qué `createdAt` y no un uuid ─────────────────────────────────────────
+ * La deduplicación tiene que seguir funcionando: el mismo evento lo encolan el
+ * `publish()` y el barrido de recuperación, y desde procesos distintos (varias
+ * réplicas de la API). Un uuid aleatorio por llamada haría que cada intento
+ * fuese un job nuevo → despacho duplicado. La identidad debe ser **derivable
+ * de la fila**, igual para todo el que la lea, y no reiniciable: `(id,
+ * createdAt)` cumple las tres. Dos filas distintas no pueden compartir el par,
+ * y una base recreada no puede reproducirlo salvo restaurando un backup — en
+ * cuyo caso son literalmente el mismo evento y deduplicar es lo correcto.
+ *
+ * El prefijo `outbox-` no es decorativo: BullMQ rechaza custom ids que sean
+ * enteros puros («Custom Ids cannot be integers»).
+ */
+export function buildOutboxJobId(ref: OutboxJobRef): string {
+  return `outbox-${ref.id.toString()}-${ref.createdAt.getTime()}`;
+}
+
+/** Job de BullMQ, reducido a lo único que el encolado necesita consultar. */
+export interface OutboxJobHandle {
+  getState(): Promise<string>;
+}
+
+/**
+ * Superficie mínima de la `Queue` de BullMQ que usa el encolado. Existe para
+ * que el camino degradado (colisión con un job terminal) sea probable sin
+ * Redis: la implementación real es una lambda sobre `Queue` en
+ * `OutboxQueueService`.
+ */
+export interface OutboxJobQueuePort {
+  /**
+   * Añade el job de despacho bajo ese `jobId`. Ojo: si el id ya existe BullMQ
+   * **no añade nada** y devuelve el job existente, sin señalarlo de ninguna
+   * forma al llamante (el script Lua `addStandardJob` hace
+   * `if EXISTS(jobIdKey) then handleDuplicatedJob(...)` y devuelve el mismo id).
+   * De ahí que haya que preguntar por el estado en vez de fiarse del retorno.
+   */
+  add(jobId: string): Promise<OutboxJobHandle>;
+  /** Retira el job. Devuelve cuántos se retiraron (0 = no se pudo). */
+  remove(jobId: string): Promise<number>;
+}
+
+/** Avisos del camino degradado. Los cablea el servicio a logs y métricas. */
+export interface EnqueueCollisionReport {
+  /** Había un job terminal ocupando el id: se retiró y se reencoló. Entregable. */
+  onReplaced?(jobId: string): void;
+  /** El id sigue ocupado por un job terminal. El evento NO se despachará. */
+  onSwallowed?(jobId: string): void;
+}
+
+/**
+ * Encola el despacho de una fila del outbox y **confirma que el job resultante
+ * va a ejecutarse**.
+ *
+ * La confirmación no es paranoia: `queue.add()` con un `jobId` ya usado
+ * devuelve un job de aspecto idéntico al recién creado, así que sin preguntar
+ * por el estado no hay manera de distinguir «encolado» de «tragado». Y tragado
+ * pasa de verdad en dos escenarios, no sólo en el de la base recreada que
+ * `buildOutboxJobId` cierra:
+ *
+ *  - un job que agotó sus 5 intentos queda en el set de fallidos **7 días**:
+ *    cualquier reintento del failsafe sobre esa misma fila se descartaba en
+ *    silencio durante toda la retención, justo cuando más falta hacía;
+ *  - un job completado cuya fila quedó pendiente (proceso muerto entre el
+ *    despacho y el `UPDATE`) bloquea el reintento 24 h.
+ *
+ * Por eso, ante un id ocupado por un job terminal, se **retira y se reencola**:
+ * el failsafe vuelve a poder entregar, no sólo informar. Si ni así se consigue,
+ * se devuelve `deduplicated` — que es lo que impide que el llamante lo cuente
+ * como entregado.
+ */
+export async function enqueueOutboxJob(
+  queue: OutboxJobQueuePort,
+  ref: OutboxJobRef,
+  report: EnqueueCollisionReport = {},
+): Promise<EnqueueOutcome> {
+  const jobId = buildOutboxJobId(ref);
+
+  if (await addAndConfirm(queue, jobId)) return 'queued';
+
+  // El id lo ocupa un job terminal. Retirarlo libera la clave para que el
+  // segundo `add` cree un job de verdad. `remove()` no puede llevarse por
+  // delante un job en vuelo: sólo llegamos aquí si el estado ES terminal.
+  try {
+    await queue.remove(jobId);
+  } catch {
+    // Da igual por qué falló: el `add` siguiente lo dirá mejor que el error.
+  }
+
+  if (await addAndConfirm(queue, jobId)) {
+    report.onReplaced?.(jobId);
+    return 'queued';
+  }
+
+  report.onSwallowed?.(jobId);
+  return 'deduplicated';
+}
+
+/** Añade el job y responde si quedó en un estado desde el que llegará a correr. */
+async function addAndConfirm(queue: OutboxJobQueuePort, jobId: string): Promise<boolean> {
+  const job = await queue.add(jobId);
+  return !TERMINAL_JOB_STATES.has(await job.getState());
+}

--- a/apps/api/src/modules/outbox-queue.service.ts
+++ b/apps/api/src/modules/outbox-queue.service.ts
@@ -14,7 +14,9 @@ import { Queue, Worker, type ConnectionOptions } from 'bullmq';
 import IORedis, { type Redis } from 'ioredis';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { ModuleContextFactory } from './module-context.factory';
+import { enqueueOutboxJob, type OutboxJobQueuePort } from './outbox-enqueue';
 import { OutboxMetrics } from './outbox.metrics';
+import type { EnqueueOutcome, OutboxJobRef } from './persistent-event-bus';
 
 const QUEUE_NAME = 'didacta.outbox';
 
@@ -134,21 +136,41 @@ export class OutboxQueueService implements OnApplicationBootstrap, OnModuleDestr
   /**
    * Encola el despacho de un evento ya persistido en outbox_event.
    *
-   * El `jobId` deriva del `outboxId` para que BullMQ deduplique si el mismo
-   * evento se reencola (ej. reintento + recovery worker). Con prefijo: BullMQ
-   * rechaza custom ids enteros («Custom Id cannot be integers») — con el id
-   * numérico pelado TODOS los enqueue fallaban en silencio y el bus caía
-   * siempre al fallback in-process, dejando la cola sin uso real.
+   * El `jobId` sigue derivándose de la fila para que BullMQ deduplique cuando
+   * el mismo evento se reencola (publish + failsafe, o varias réplicas de la
+   * API a la vez), pero ya no del BIGSERIAL a secas: ver `buildOutboxJobId`.
+   *
+   * Devuelve el desenlace en vez de `void` porque un `add` puede quedar
+   * absorbido por un job terminal homónimo sin que BullMQ lo diga. El llamante
+   * NECESITA distinguirlo: `recoverPending()` lo contaba como procesado y el
+   * failsafe reportaba éxito sin haber entregado nada.
    */
-  async enqueue(outboxId: bigint): Promise<void> {
-    if (!this.queue) {
+  async enqueue(ref: OutboxJobRef): Promise<EnqueueOutcome> {
+    const queue = this.queue;
+    if (!queue) {
       throw new Error('OutboxQueueService no inicializada (REDIS_URL ausente)');
     }
-    await this.queue.add(
-      'dispatch',
-      { outboxId: outboxId.toString() },
-      { jobId: `outbox-${outboxId.toString()}` },
-    );
+    const outboxId = ref.id.toString();
+    const port: OutboxJobQueuePort = {
+      add: (jobId) => queue.add('dispatch', { outboxId }, { jobId }),
+      remove: (jobId) => queue.remove(jobId),
+    };
+    return enqueueOutboxJob(port, ref, {
+      onReplaced: (jobId) => {
+        this.metrics.recordEnqueueCollision('replaced');
+        this.logger.warn(
+          { jobId, outboxId },
+          'outbox enqueue chocó con un job ya terminado: retirado y reencolado',
+        );
+      },
+      onSwallowed: (jobId) => {
+        this.metrics.recordEnqueueCollision('swallowed');
+        this.logger.error(
+          { jobId, outboxId },
+          'outbox enqueue absorbido por un job terminal irreemplazable: el evento NO se despachará por la cola',
+        );
+      },
+    });
   }
 
   /** Health check de Redis. Devuelve true si PING contesta PONG. */

--- a/apps/api/src/modules/outbox-recovery.worker.ts
+++ b/apps/api/src/modules/outbox-recovery.worker.ts
@@ -82,8 +82,13 @@ export class OutboxRecoveryWorker implements OnApplicationBootstrap, OnModuleDes
     try {
       const result = await this.registry.recoverOutbox();
       this.metrics.recordSweep('success');
-      this.metrics.recordRecoveryEvents(result.processed, result.failed);
-      if (result.processed > 0 || result.failed > 0 || result.undelivered > 0) {
+      this.metrics.recordRecoveryEvents(result.processed, result.failed, result.deduplicated);
+      if (
+        result.processed > 0 ||
+        result.failed > 0 ||
+        result.undelivered > 0 ||
+        result.deduplicated > 0
+      ) {
         this.logger.log(result, 'outbox recovery sweep');
       }
     } catch (error) {

--- a/apps/api/src/modules/outbox.metrics.ts
+++ b/apps/api/src/modules/outbox.metrics.ts
@@ -23,7 +23,15 @@ import { Counter, Gauge, Histogram } from 'prom-client';
  * - `outbox_recovery_sweeps_total{result}` (counter): cada barrido
  *   del recovery worker (`success` | `error`).
  * - `outbox_recovery_events_total{result}` (counter): eventos recuperados
- *   por los sweeps (`processed` | `failed`).
+ *   por los sweeps (`processed` | `failed` | `deduplicated`).
+ *   `deduplicated` es la etiqueta que hace visible el failsafe que no
+ *   entrega: un re-enqueue que BullMQ descartó contra un job terminal. Antes
+ *   iba sumado a `processed` y era indistinguible de una recuperación real.
+ * - `outbox_enqueue_collisions_total{result}` (counter): encolados que
+ *   chocaron con un job terminal ocupando el mismo `jobId` (`replaced` = se
+ *   retiró el viejo y se reencoló; `swallowed` = no se pudo, el evento NO se
+ *   despacha por la cola). Cualquier valor > 0 sostenido en `swallowed` es
+ *   pérdida de despacho y merece alerta.
  * - `outbox_pending_oldest_age_seconds` (gauge): edad en segundos del
  *   evento `processedAt IS NULL` más viejo. 0 si no hay pendientes.
  *   Lo refresca el recovery worker en cada sweep — refleja un valor
@@ -65,7 +73,18 @@ export class OutboxMetrics {
     private readonly undeliveredCounter: Counter<string>,
     @InjectMetric('outbox_replayed_total')
     private readonly replayedCounter: Counter<string>,
+    @InjectMetric('outbox_enqueue_collisions_total')
+    private readonly enqueueCollisionsCounter: Counter<'result'>,
   ) {}
+
+  /**
+   * Un encolado chocó con un job terminal que ocupaba el mismo `jobId`.
+   * `replaced` = se retiró y se reencoló (el evento sí se despachará);
+   * `swallowed` = BullMQ se lo tragó y no se pudo reemplazar.
+   */
+  recordEnqueueCollision(result: 'replaced' | 'swallowed'): void {
+    this.enqueueCollisionsCounter.inc({ result });
+  }
 
   /** Un evento se despachó y no había ningún handler suscrito. */
   recordUndelivered(): void {
@@ -93,9 +112,10 @@ export class OutboxMetrics {
     this.sweepsCounter.inc({ result });
   }
 
-  recordRecoveryEvents(processed: number, failed: number): void {
+  recordRecoveryEvents(processed: number, failed: number, deduplicated = 0): void {
     if (processed > 0) this.recoveryEventsCounter.inc({ result: 'processed' }, processed);
     if (failed > 0) this.recoveryEventsCounter.inc({ result: 'failed' }, failed);
+    if (deduplicated > 0) this.recoveryEventsCounter.inc({ result: 'deduplicated' }, deduplicated);
   }
 
   /**
@@ -148,5 +168,10 @@ export const outboxMetricsProviders = [
   makeCounterProvider({
     name: 'outbox_replayed_total',
     help: 'Total de eventos re-entregados tras aparecer un subscriber que antes faltaba.',
+  }),
+  makeCounterProvider({
+    name: 'outbox_enqueue_collisions_total',
+    help: 'Encolados que chocaron con un job terminal bajo el mismo jobId (replaced = reencolado; swallowed = no despachado).',
+    labelNames: ['result'],
   }),
 ];

--- a/apps/api/src/modules/persistent-event-bus.ts
+++ b/apps/api/src/modules/persistent-event-bus.ts
@@ -65,13 +65,42 @@ function rowToEvent(row: OutboxRowLike): DomainEvent<unknown> {
 }
 
 /**
+ * Referencia a la fila de `outbox_event` cuyo despacho se va a encolar.
+ *
+ * NO es sólo el `id` a propósito. El `id` es un BIGSERIAL: si la base se
+ * recrea, la secuencia vuelve a empezar en 1 y un evento NUEVO hereda la
+ * identidad de uno viejo. `createdAt` es lo que rompe esa herencia sin dejar
+ * de ser determinista — cualquier proceso que lea la misma fila deriva la
+ * misma identidad, que es lo que sostiene la deduplicación. Ver
+ * `buildOutboxJobId` en `outbox-enqueue.ts`.
+ */
+export interface OutboxJobRef {
+  id: bigint;
+  createdAt: Date;
+}
+
+/**
+ * Desenlace de un intento de encolado. Es lo que devuelve `enqueue()` en lugar
+ * del `void` anterior, que no tenía forma de representar el único fallo que de
+ * verdad importa aquí: que el `add` a BullMQ se lo trague un job homónimo que
+ * ya nunca se va a ejecutar.
+ *
+ *   queued       → existe un job que despachará este evento (recién añadido,
+ *                  o uno anterior que sigue pendiente de ejecutarse).
+ *   deduplicated → el `add` fue absorbido por un job TERMINAL (completado o
+ *                  fallido) que no se pudo reemplazar. El evento NO se va a
+ *                  despachar por la cola.
+ */
+export type EnqueueOutcome = 'queued' | 'deduplicated';
+
+/**
  * Adaptador opcional de despacho asíncrono. Si está presente y `isEnabled()`
  * devuelve true, `publish()` encola en lugar de despachar in-process. La
  * implementación real es `OutboxQueueService` con BullMQ + Redis.
  */
 export interface OutboxDispatcher {
   isEnabled(): boolean;
-  enqueue(outboxId: bigint): Promise<void>;
+  enqueue(ref: OutboxJobRef): Promise<EnqueueOutcome>;
 }
 
 /**
@@ -163,8 +192,17 @@ export class PersistentEventBus implements EventBus {
 
     if (this.dispatcher?.isEnabled()) {
       try {
-        await this.dispatcher.enqueue(persisted.id);
-        return;
+        const outcome = await this.dispatcher.enqueue(persisted);
+        if (outcome === 'queued') return;
+        // `deduplicated`: el add se lo tragó un job terminal homónimo que ya
+        // no va a correr. Cae al despacho in-process por el mismo motivo que
+        // el catch de abajo — el evento existe, está sin procesar y nadie más
+        // lo va a recoger. No hay riesgo de doble entrega: sólo se llega aquí
+        // con un job en estado terminal.
+        this.logger.error('enqueue absorbido por un job ya terminado, fallback in-process', {
+          outboxId: persisted.id.toString(),
+          event: event.name,
+        });
       } catch (err) {
         // Si Redis falló al encolar, no perdemos el evento: la tabla outbox
         // tiene la fila con processedAt=null. El recovery worker lo reencola
@@ -236,10 +274,22 @@ export class PersistentEventBus implements EventBus {
    * Si hay dispatcher async habilitado, reencola los pendientes a la cola
    * (failsafe para casos de Redis caído al momento del publish original).
    * Sin dispatcher, los procesa in-process.
+   *
+   * `deduplicated` es un desenlace propio y NO se suma a `processed`: un
+   * re-enqueue que BullMQ descarta contra un job terminal no entrega nada.
+   * Contarlo como procesado —lo que hacía antes— convertía al failsafe en un
+   * mentiroso: reportaba éxito mientras la fila seguía pendiente y el gauge de
+   * lag subía. Tampoco es `failed`: no ha fallado nada, es que la entrega
+   * simplemente no ha ocurrido y hay que poder alertar sobre ese caso concreto.
+   *
+   * A diferencia de `publish()`, aquí NO se cae a despacho in-process: el
+   * barrido toca hasta 50 filas cada 5 min y despacharlas dentro del timer
+   * cambiaría el perfil de carga del proceso. El evento se reintenta en el
+   * siguiente barrido, donde `enqueue()` vuelve a intentar el reemplazo.
    */
   async recoverPending(
     limit = 50,
-  ): Promise<{ processed: number; failed: number; undelivered: number }> {
+  ): Promise<{ processed: number; failed: number; undelivered: number; deduplicated: number }> {
     // Barrido cross-tenant de pendientes: acceso global sancionado.
     const pending = await runSanctionedGlobalAccess(() =>
       this.prisma.outboxEvent.findMany({
@@ -252,12 +302,21 @@ export class PersistentEventBus implements EventBus {
     let processed = 0;
     let failed = 0;
     let undelivered = 0;
+    let deduplicated = 0;
 
     for (const row of pending) {
       if (this.dispatcher?.isEnabled()) {
         try {
-          await this.dispatcher.enqueue(row.id);
-          processed++;
+          const outcome = await this.dispatcher.enqueue(row);
+          if (outcome === 'queued') {
+            processed++;
+          } else {
+            deduplicated++;
+            this.logger.error(
+              'recovery: re-enqueue absorbido por un job terminal — el evento sigue SIN entregar',
+              { outboxId: row.id.toString(), event: row.eventName },
+            );
+          }
         } catch (err) {
           failed++;
           this.logger.error('recovery: falló re-enqueue', {
@@ -279,10 +338,11 @@ export class PersistentEventBus implements EventBus {
         processed,
         failed,
         undelivered,
+        deduplicated,
         viaQueue: this.dispatcher?.isEnabled() ?? false,
       });
     }
-    return { processed, failed, undelivered };
+    return { processed, failed, undelivered, deduplicated };
   }
 
   /**

--- a/apps/api/tests/outbox-enqueue.test.ts
+++ b/apps/api/tests/outbox-enqueue.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildOutboxJobId,
+  enqueueOutboxJob,
+  type OutboxJobHandle,
+  type OutboxJobQueuePort,
+} from '../src/modules/outbox-enqueue';
+
+/**
+ * Fake de la `Queue` de BullMQ que reproduce **la** conducta que causa el bug:
+ * `add()` con un `jobId` que ya existe NO añade nada, devuelve el job
+ * existente y no lo señala de ninguna forma.
+ */
+function makeFakeQueue(seed: Record<string, string> = {}): OutboxJobQueuePort & {
+  jobs: Map<string, string>;
+  adds: string[];
+  removes: string[];
+  removable: boolean;
+} {
+  const jobs = new Map<string, string>(Object.entries(seed));
+  const fake = {
+    jobs,
+    adds: [] as string[],
+    removes: [] as string[],
+    /** false = el `remove` no consigue liberar el id (job bloqueado, etc.). */
+    removable: true,
+    async add(jobId: string): Promise<OutboxJobHandle> {
+      fake.adds.push(jobId);
+      if (!jobs.has(jobId)) jobs.set(jobId, 'waiting');
+      return { getState: async () => jobs.get(jobId) ?? 'unknown' };
+    },
+    async remove(jobId: string): Promise<number> {
+      fake.removes.push(jobId);
+      if (!fake.removable) return 0;
+      return jobs.delete(jobId) ? 1 : 0;
+    },
+  };
+  return fake;
+}
+
+const ref = (id: bigint, createdAtMs: number) => ({ id, createdAt: new Date(createdAtMs) });
+
+describe('buildOutboxJobId', () => {
+  it('es determinista: la misma fila siempre produce el mismo jobId', () => {
+    // Es lo que sostiene la deduplicación. Sin esto, publish() y el barrido de
+    // recuperación encolarían dos jobs para el mismo evento.
+    expect(buildOutboxJobId(ref(42n, 1_700_000_000_000))).toBe(
+      buildOutboxJobId(ref(42n, 1_700_000_000_000)),
+    );
+  });
+
+  it('base recreada: el mismo BIGSERIAL con otro createdAt NO reusa el jobId', () => {
+    // El defecto entero. La secuencia vuelve a empezar en 1 y, con el id
+    // pelado, el evento nuevo heredaba la identidad de un job ya completado en
+    // Redis y BullMQ lo descartaba en silencio.
+    const viejo = buildOutboxJobId(ref(1n, 1_700_000_000_000));
+    const nuevo = buildOutboxJobId(ref(1n, 1_800_000_000_000));
+    expect(nuevo).not.toBe(viejo);
+  });
+
+  it('no es un entero pelado (BullMQ rechaza custom ids enteros)', () => {
+    const jobId = buildOutboxJobId(ref(7n, 1_700_000_000_000));
+    expect(Number.isNaN(Number(jobId))).toBe(true);
+    expect(jobId).toContain('7');
+  });
+});
+
+describe('enqueueOutboxJob', () => {
+  it('id libre: encola y devuelve queued', async () => {
+    const queue = makeFakeQueue();
+    const report = { onReplaced: vi.fn(), onSwallowed: vi.fn() };
+
+    const outcome = await enqueueOutboxJob(queue, ref(1n, 1_700_000_000_000), report);
+
+    expect(outcome).toBe('queued');
+    expect(queue.adds).toHaveLength(1);
+    expect(queue.removes).toHaveLength(0);
+    expect(report.onReplaced).not.toHaveBeenCalled();
+    expect(report.onSwallowed).not.toHaveBeenCalled();
+  });
+
+  it('dedup contra un job que TODAVÍA va a correr cuenta como queued', async () => {
+    // Este dedup es el bueno: el evento se entregará por el job que ya estaba.
+    // Reencolar aquí sería duplicar el despacho.
+    const jobId = buildOutboxJobId(ref(1n, 1_700_000_000_000));
+    const queue = makeFakeQueue({ [jobId]: 'active' });
+
+    const outcome = await enqueueOutboxJob(queue, ref(1n, 1_700_000_000_000));
+
+    expect(outcome).toBe('queued');
+    expect(queue.removes).toHaveLength(0); // no se toca un job en vuelo
+  });
+
+  it.each(['completed', 'failed', 'unknown'])(
+    'job terminal en estado %s: lo retira, reencola y avisa (replaced)',
+    async (estado) => {
+      // El caso que deja al failsafe inútil: un job que agotó sus 5 intentos
+      // sigue 7 días en el set de fallidos y se traga todo reintento.
+      const jobId = buildOutboxJobId(ref(9n, 1_700_000_000_000));
+      const queue = makeFakeQueue({ [jobId]: estado });
+      const report = { onReplaced: vi.fn(), onSwallowed: vi.fn() };
+
+      const outcome = await enqueueOutboxJob(queue, ref(9n, 1_700_000_000_000), report);
+
+      expect(outcome).toBe('queued');
+      expect(queue.removes).toEqual([jobId]);
+      expect(queue.adds).toEqual([jobId, jobId]);
+      expect(queue.jobs.get(jobId)).toBe('waiting'); // hay job de verdad
+      expect(report.onReplaced).toHaveBeenCalledWith(jobId);
+      expect(report.onSwallowed).not.toHaveBeenCalled();
+    },
+  );
+
+  it('si el id sigue ocupado tras el remove devuelve deduplicated (swallowed)', async () => {
+    const jobId = buildOutboxJobId(ref(3n, 1_700_000_000_000));
+    const queue = makeFakeQueue({ [jobId]: 'failed' });
+    queue.removable = false; // el remove no libera la clave
+    const report = { onReplaced: vi.fn(), onSwallowed: vi.fn() };
+
+    const outcome = await enqueueOutboxJob(queue, ref(3n, 1_700_000_000_000), report);
+
+    expect(outcome).toBe('deduplicated');
+    expect(report.onSwallowed).toHaveBeenCalledWith(jobId);
+    expect(report.onReplaced).not.toHaveBeenCalled();
+  });
+
+  it('un remove que lanza no rompe el encolado: se intenta el add igualmente', async () => {
+    const jobId = buildOutboxJobId(ref(4n, 1_700_000_000_000));
+    const queue = makeFakeQueue({ [jobId]: 'completed' });
+    const boom = vi.fn(async () => {
+      throw new Error('job locked');
+    });
+    const report = { onReplaced: vi.fn(), onSwallowed: vi.fn() };
+
+    const outcome = await enqueueOutboxJob(
+      { add: queue.add, remove: boom },
+      ref(4n, 1_700_000_000_000),
+      report,
+    );
+
+    expect(boom).toHaveBeenCalledOnce();
+    // El id sigue ocupado por el job completado -> no se despachará.
+    expect(outcome).toBe('deduplicated');
+    expect(report.onSwallowed).toHaveBeenCalledWith(jobId);
+  });
+});

--- a/apps/api/tests/outbox.metrics.test.ts
+++ b/apps/api/tests/outbox.metrics.test.ts
@@ -11,6 +11,7 @@ function makeMetrics(): {
   events: Counter<'result'>;
   oldestAge: Gauge<string>;
   pending: Gauge<string>;
+  collisions: Counter<'result'>;
 } {
   const registry = new Registry();
   const dispatch = new Counter({
@@ -47,8 +48,34 @@ function makeMetrics(): {
     help: 't',
     registers: [registry],
   });
-  const metrics = new OutboxMetrics(dispatch, duration, sweeps, events, oldestAge, pending);
-  return { metrics, registry, dispatch, duration, sweeps, events, oldestAge, pending };
+  const undelivered = new Counter({
+    name: 'outbox_undelivered_total',
+    help: 't',
+    registers: [registry],
+  });
+  const replayed = new Counter({
+    name: 'outbox_replayed_total',
+    help: 't',
+    registers: [registry],
+  });
+  const collisions = new Counter({
+    name: 'outbox_enqueue_collisions_total',
+    help: 't',
+    labelNames: ['result'],
+    registers: [registry],
+  });
+  const metrics = new OutboxMetrics(
+    dispatch,
+    duration,
+    sweeps,
+    events,
+    oldestAge,
+    pending,
+    undelivered,
+    replayed,
+    collisions,
+  );
+  return { metrics, registry, dispatch, duration, sweeps, events, oldestAge, pending, collisions };
 }
 
 describe('OutboxMetrics', () => {
@@ -97,6 +124,26 @@ describe('OutboxMetrics', () => {
     expect(byLabel['failed']).toBe(1);
   });
 
+  it('recordRecoveryEvents saca los deduplicados a su propia label', async () => {
+    // Si se sumaran a `processed` la métrica volvería a decir que el failsafe
+    // recuperó eventos que en realidad no se entregaron.
+    setup.metrics.recordRecoveryEvents(1, 0, 4);
+    const value = await setup.events.get();
+    const byLabel = Object.fromEntries(value.values.map((v) => [v.labels.result, v.value]));
+    expect(byLabel['deduplicated']).toBe(4);
+    expect(byLabel['processed']).toBe(1);
+  });
+
+  it('recordEnqueueCollision distingue replaced/swallowed', async () => {
+    setup.metrics.recordEnqueueCollision('replaced');
+    setup.metrics.recordEnqueueCollision('swallowed');
+    setup.metrics.recordEnqueueCollision('swallowed');
+    const value = await setup.collisions.get();
+    const byLabel = Object.fromEntries(value.values.map((v) => [v.labels.result, v.value]));
+    expect(byLabel['replaced']).toBe(1);
+    expect(byLabel['swallowed']).toBe(2);
+  });
+
   it('setOldestPendingAgeSeconds expone el último valor', async () => {
     setup.metrics.setOldestPendingAgeSeconds(42);
     const v1 = await setup.oldestAge.get();
@@ -117,9 +164,11 @@ describe('OutboxMetrics', () => {
     setup.metrics.recordSweep('success');
     setup.metrics.recordRecoveryEvents(1, 0);
     setup.metrics.recordDispatchDuration(0.02);
+    setup.metrics.recordEnqueueCollision('swallowed');
     setup.metrics.setOldestPendingAgeSeconds(123);
     setup.metrics.setPendingEventsCount(4);
     const text = await setup.registry.metrics();
+    expect(text).toContain('outbox_enqueue_collisions_total');
     expect(text).toContain('outbox_dispatch_total');
     expect(text).toContain('outbox_dispatch_duration_seconds');
     expect(text).toContain('outbox_recovery_sweeps_total');

--- a/apps/api/tests/persistent-event-bus.test.ts
+++ b/apps/api/tests/persistent-event-bus.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   NO_HANDLER_REPLAY_WINDOW_MS,
   PersistentEventBus,
+  type EnqueueOutcome,
   type OutboxDispatcher,
+  type OutboxJobRef,
 } from '../src/modules/persistent-event-bus';
 import { tenantContextStorage, type TenantContext } from '../src/tenancy/tenant-context.storage';
 
@@ -108,15 +110,22 @@ function makeFakePrisma() {
   return prisma;
 }
 
-function makeFakeDispatcher(): OutboxDispatcher & { enqueued: bigint[]; enabled: boolean } {
+function makeFakeDispatcher(): OutboxDispatcher & {
+  enqueued: bigint[];
+  enabled: boolean;
+  /** Qué contesta el encolado. `deduplicated` = BullMQ se lo tragó. */
+  outcome: EnqueueOutcome;
+} {
   const state = {
     enqueued: [] as bigint[],
     enabled: true,
+    outcome: 'queued' as EnqueueOutcome,
     isEnabled() {
       return state.enabled;
     },
-    async enqueue(id: bigint) {
-      state.enqueued.push(id);
+    async enqueue(ref: OutboxJobRef) {
+      state.enqueued.push(ref.id);
+      return state.outcome;
     },
   };
   return state;
@@ -512,7 +521,75 @@ describe('PersistentEventBus', () => {
       dispatcher.enabled = true;
       const result = await bus.recoverPending();
       expect(result.processed).toBe(1);
+      expect(result.deduplicated).toBe(0);
       expect(dispatcher.enqueued).toEqual([row.id]);
+    });
+
+    it('recoverPending NO cuenta como procesado un re-enqueue deduplicado', async () => {
+      // El failsafe reportando éxito sin entregar nada: `processed++` sobre un
+      // `add` que BullMQ descartó contra un job terminal. La fila sigue
+      // pendiente, el handler no corrió, y el sweep decía que todo bien.
+      const dispatcher = makeFakeDispatcher();
+      const bus = new PersistentEventBus(prisma as never, silentLogger, dispatcher);
+      const handler = vi.fn(async () => {});
+      bus.subscribe('learning.course.completed', handler);
+
+      dispatcher.enabled = false;
+      await bus.publish(makeEvent('learning.course.completed', {}, 'idem-dedup'));
+      const [row] = [...prisma._rows.values()];
+      row.processedAt = null; // pendiente, como si el despacho original no hubiera ido
+
+      dispatcher.enabled = true;
+      dispatcher.outcome = 'deduplicated';
+      const result = await bus.recoverPending();
+
+      expect(result.deduplicated).toBe(1);
+      expect(result.processed).toBe(0);
+      expect(result.failed).toBe(0);
+      // Y sigue pendiente: el próximo barrido lo vuelve a intentar.
+      expect(row.processedAt).toBeNull();
+    });
+
+    it('publish cae a in-process si el enqueue quedó deduplicado', async () => {
+      // `deduplicated` no es una excepción, así que sin desenlace explícito
+      // publish() se daba por satisfecho y volvía. El evento no lo despachaba
+      // nadie: ni la cola (job terminal) ni el proceso.
+      const dispatcher = makeFakeDispatcher();
+      dispatcher.outcome = 'deduplicated';
+      const bus = new PersistentEventBus(prisma as never, silentLogger, dispatcher);
+      const handler = vi.fn(async () => {});
+      bus.subscribe('learning.course.completed', handler);
+
+      await bus.publish(makeEvent('learning.course.completed', {}, 'idem-dedup-pub'));
+
+      expect(dispatcher.enqueued).toHaveLength(1);
+      expect(handler).toHaveBeenCalledOnce();
+      const row = [...prisma._rows.values()][0];
+      expect(row!.processedAt).toBeInstanceOf(Date);
+    });
+
+    it('el dispatcher recibe la fila entera, no sólo el id (createdAt es identidad)', async () => {
+      // Si el bus siguiera pasando `row.id`, `buildOutboxJobId` no tendría de
+      // dónde sacar el discriminante que sobrevive a recrear la base.
+      const seen: OutboxJobRef[] = [];
+      const dispatcher: OutboxDispatcher = {
+        isEnabled: () => true,
+        enqueue: async (ref) => {
+          seen.push(ref);
+          return 'queued';
+        },
+      };
+      const bus = new PersistentEventBus(prisma as never, silentLogger, dispatcher);
+      bus.subscribe(
+        'learning.course.completed',
+        vi.fn(async () => {}),
+      );
+
+      await bus.publish(makeEvent('learning.course.completed', {}, 'idem-ref'));
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.createdAt).toBeInstanceOf(Date);
+      expect(seen[0]!.id).toBe([...prisma._rows.values()][0]!.id);
     });
   });
 });


### PR DESCRIPTION
Cierra el hallazgo que dejó abierto el PR #43. **Sin migración de esquema**:
`created_at` ya está en `outbox_event`, no hace falta columna nueva.

Reproducido contra Redis real (contenedor propio en `127.0.0.1:6399`, `netstat`
antes; no se tocó ninguno de los stacks vivos de otros workers) y verificado por
mutación.

---

## El defecto

`OutboxQueueService.enqueue()` derivaba el `jobId` del BIGSERIAL:
`outbox-${outboxId}`. El script Lua `addStandardJob` de BullMQ hace

```lua
jobId = args[2]
jobIdKey = args[1] .. jobId
if rcall("EXISTS", jobIdKey) == 1 then
    return handleDuplicatedJob(...)   -- devuelve el mismo id, no añade nada
end
```

y la clave del job **sobrevive al final del job**: `removeOnComplete` 24 h,
`removeOnFail` 7 d. El `Job` que devuelve `queue.add()` en ese caso se
construye en local con los datos que le pasaste, así que **es indistinguible de
uno recién creado**: `finishedOn` no viene, no hay flag, no hay excepción.

Recrear la base sin vaciar Redis reinicia la secuencia en 1 → los eventos
nuevos heredan la identidad de jobs viejos ya completados → **no se despachan
jamás**.

### Y hay un segundo caso de la misma familia, no reportado

Un job que agota sus 5 intentos queda en el set de **fallidos 7 días**. Durante
esa ventana, **todo re-enqueue del failsafe sobre esa fila se descartaba en
silencio** — justo el escenario para el que existe el failsafe. Este no
necesita ninguna base recreada: pasa en producción con el ciclo normal de
reintentos.

### Reproducción (Redis real, ambos casos)

| | |
|---|---|
| A1 primer evento con `jobId=outbox-1` | se despacha |
| **A2 evento nuevo tras recrear la base, mismo `outbox-1`** | **nunca se despacha** |
| C1 job que agota intentos | queda en el set de fallidos |
| **C2 re-enqueue del failsafe sobre esa fila** | **descartado en silencio** |

---

## 1 · Identidad que aguanta que la base se recree

`buildOutboxJobId(ref)` → `outbox-<id>-<createdAt.getTime()>`
(`apps/api/src/modules/outbox-enqueue.ts`).

### Por qué `(id, createdAt)` y no un uuid

**La deduplicación no se pierde, y ese era el requisito duro.** El `jobId`
estaba ahí porque el mismo evento lo encolan dos caminos distintos —
`publish()` y el barrido de recuperación — y desde procesos distintos (varias
réplicas de la API). Un uuid aleatorio por llamada haría de cada intento un job
nuevo: **despacho duplicado**, que es peor que el bug que se arregla.

La identidad tiene que ser **derivable de la fila** (igual para todo el que la
lea, sin coordinación) y **no reiniciable**. `(id, createdAt)` cumple las dos:
dos filas distintas no pueden compartir el par, y una base recreada no puede
reproducirlo salvo restaurando un backup — en cuyo caso son literalmente el
mismo evento y deduplicar es lo correcto.

### Qué garantiza ahora que un evento no se procesa dos veces

Tres capas, y sólo la tercera cambia de clave:

| capa | garantía | ¿cambia? |
|---|---|---|
| `@@unique([tenantId, idempotencyKey])` + `upsert` en `publish()` | un evento lógico = una fila | no |
| `processOutboxId()` sale temprano si `row.processedAt` | un job que llega tarde no re-ejecuta handlers | no |
| `jobId` determinista por fila | dos encolados de la misma fila colapsan en un job | **misma propiedad, clave con un componente que no se reinicia** |

Verificado contra Redis real: `B4 reencolar la misma fila no la despacha dos
veces`.

El prefijo `outbox-` se mantiene: BullMQ rechaza custom ids que sean enteros
puros.

---

## 2 · `enqueue()` devuelve un desenlace, no `void`

Misma familia que el bug del PR #43: **un desenlace que no puede representar el
fallo, colapsado sobre el éxito.** `void` no tenía forma de decir «esto no se
va a despachar».

```ts
export type EnqueueOutcome = 'queued' | 'deduplicated';
```

Como BullMQ no señala el descarte, hay que **confirmar el estado del job
resultante**:

- `waiting` / `active` / `delayed` / `prioritized` / `waiting-children` → hay un
  job que acabará llamando a `processOutboxId`. `queued`. Ojo: aquí entra el
  dedup **bueno** (chocar con un job que sigue pendiente); reencolar ahí sería
  duplicar el despacho.
- `completed` / `failed` / `unknown` → ya no corre nada. Se **retira y se
  reencola**: así el failsafe vuelve a poder *entregar*, no sólo informar (es lo
  que desbloquea el caso C de arriba). `remove()` no puede llevarse por delante
  un job en vuelo porque sólo se llega ahí con el estado ya terminal.
- Si ni así se libera el id → `deduplicated`.

**Coste:** un RTT extra a Redis por encolado (`getState`), al lado de un upsert
a Postgres que ya estaba. Se paga en los dos caminos y no sólo en el failsafe a
propósito: el caso del set de fallidos afecta también a `publish()`.

`publish()` cae a despacho in-process ante `deduplicated`, por el mismo motivo
que ya lo hacía cuando el `enqueue` lanzaba. Sin riesgo de doble entrega: el
job que ocupaba el id está terminal.

---

## 3 · `recoverPending()` deja de contar como procesado lo no entregado

`recoverPending()` hacía `processed++` justo después del `enqueue()`. Con el
`add` descartado, eso es **el failsafe reportando éxito sin haber entregado
nada**: la fila seguía pendiente, el handler no corría, y `outbox_pending_events`
subía mientras el sweep decía que todo bien.

Ahora devuelve `{ processed, failed, undelivered, deduplicated }`.

`deduplicated` es campo propio y **no** se suma a `processed` ni a `failed`: no
ha fallado nada — es que la entrega no ha ocurrido, y hay que poder alertar
sobre ese caso concreto.

**Asimetría deliberada con `publish()`:** el barrido NO cae a despacho
in-process. Toca hasta 50 filas cada 5 min y despacharlas dentro del timer
cambia el perfil de carga del proceso. El evento se reintenta en el barrido
siguiente, donde `enqueue()` vuelve a intentar el reemplazo.

---

## Camino degradado

| caso | dónde | qué pasa |
|---|---|---|
| id ocupado por job terminal, se libera | `outbox-enqueue.ts` `enqueueOutboxJob` | retira + reencola, WARN, `outbox_enqueue_collisions_total{result="replaced"}` |
| id ocupado y no se libera | ídem | `deduplicated`, ERROR, `…{result="swallowed"}` |
| `remove()` lanza (job bloqueado) | ídem | se traga el error y deja que lo diga el `add` siguiente |
| `publish` con `deduplicated` | `persistent-event-bus.ts` | ERROR + fallback in-process |
| `recoverPending` con `deduplicated` | ídem | `deduplicated++`, ERROR con `outboxId` y nombre de evento |

### Observabilidad

- `outbox_enqueue_collisions_total{result}` — `swallowed > 0` sostenido es
  pérdida de despacho y merece alerta; `replaced > 0` dice que Redis lleva jobs
  terminales que estorban.
- `outbox_recovery_events_total{result="deduplicated"}` — la label que hace
  visible el failsafe que no entrega.

---

## Verificación por mutación

Baseline de los 3 specs tocados: 44 tests, 0 rojos. Cada mutación restaura
desde una **copia en disco**, nunca `git checkout --`.

| mutación | rojos |
|---|---|
| M1 `buildOutboxJobId` vuelve a depender sólo del BIGSERIAL | 1 |
| M2 el `add` no confirma el estado (se fía del retorno de BullMQ) | 5 |
| M3 sin retirar/reencolar el job terminal (sólo informa) | 3 |
| M4 `recoverPending` vuelve a contar el deduplicado como procesado | 1 |
| M5 `publish` se da por satisfecho con cualquier desenlace | 1 |
| M6 la métrica de recovery suma los deduplicados a `processed` | 1 |

Los tests que caen son en cada caso exactamente los que nombran ese
comportamiento — ninguna mutación se lleva por delante tests ajenos.

## Verificación

| | resultado |
|---|---|
| vitest api | **2214/2214** (baseline 2185) |
| vitest web | **356/356** (baseline 352) |
| ee-fence | **0 violaciones** (1402 ficheros) |
| dev-check --quick | typecheck api+web, eslint, prettier — OK |
| probe contra Redis real | **10/10**, incluidos los 2 defectos reproducidos |

`apps/api/tests/outbox.metrics.test.ts` construía `OutboxMetrics` con 6 de los 8
argumentos que ya pedía tras el PR #43 (pasaba en runtime porque no ejercitaba
los dos contadores nuevos; `apps/api/tsconfig.json` sólo incluye `src/**/*`, así
que el typecheck no lo veía). Queda con la aridad correcta.

## Frontera

Sólo `apps/api/src/modules/{outbox-enqueue,outbox-queue.service,outbox-recovery.worker,outbox.metrics,persistent-event-bus,module-registry.service}.ts`
y `apps/api/tests/**`. **Sin migración de Prisma.** No se ha tocado
`modules/notifications/**`, `prisma-notification-hub.service.ts`,
`modules/member-registration/**` ni ningún composer de plantillas de email.

`outbox-enqueue.ts` es fichero nuevo para que el camino degradado sea probable
sin Redis: el algoritmo depende de un puerto de dos métodos (`add`/`remove`) en
vez de la `Queue` de BullMQ, y `OutboxQueueService` sólo lo cablea.
