### PR TITLE
fix(typecheck): los tests de todo el monorepo entran en el typecheck

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "dev": "nest start --watch",
     "start": "node dist/main.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration:license": "node scripts/run-integration-license.mjs",

--- a/apps/api/src/ai/adapters/openai.adapter.ts
+++ b/apps/api/src/ai/adapters/openai.adapter.ts
@@ -157,7 +157,10 @@ export class GroqAdapter extends OpenAiAdapter {
   protected override defaultBaseUrl = 'https://api.groq.com/openai/v1';
   protected override defaultChatModel = 'llama-3.3-70b-versatile';
 
-  override async embed(): Promise<EmbedResult> {
+  // Los parámetros se declaran aunque no se usen: sin ellos el override
+  // estrecha la firma pública del adapter a `() => …` y llamarlo como manda
+  // el contrato (`embed(input, config)`) deja de compilar en el subtipo.
+  override async embed(_input: EmbedInput, _config: ResolvedProviderConfig): Promise<EmbedResult> {
     throw new ProviderUnsupportedCapabilityError(this.id, 'embed');
   }
 }
@@ -169,7 +172,8 @@ export class OpenRouterAdapter extends OpenAiAdapter {
   protected override defaultBaseUrl = 'https://openrouter.ai/api/v1';
   protected override defaultChatModel = 'openai/gpt-4o-mini';
 
-  override async embed(): Promise<EmbedResult> {
+  // Idem GroqAdapter: la firma completa mantiene el contrato del subtipo.
+  override async embed(_input: EmbedInput, _config: ResolvedProviderConfig): Promise<EmbedResult> {
     throw new ProviderUnsupportedCapabilityError(this.id, 'embed');
   }
 }

--- a/apps/api/tests/access-groups.service.test.ts
+++ b/apps/api/tests/access-groups.service.test.ts
@@ -180,9 +180,11 @@ function makeHarness(opts: { publishedCourses?: string[] } = {}) {
         const g = groups.find((x) => x.id === where.id)!;
         for (const [k, v] of Object.entries(data)) {
           if (v && typeof v === 'object' && 'increment' in v) {
-            (g as never as Record<string, number>)[k] += (v as { increment: number }).increment;
+            (g as never as Record<string, number>)[k] =
+              (g as never as Record<string, number>)[k]! + (v as { increment: number }).increment;
           } else if (v && typeof v === 'object' && 'decrement' in v) {
-            (g as never as Record<string, number>)[k] -= (v as { decrement: number }).decrement;
+            (g as never as Record<string, number>)[k] =
+              (g as never as Record<string, number>)[k]! - (v as { decrement: number }).decrement;
           } else if (v !== undefined) {
             (g as never as Record<string, unknown>)[k] = v;
           }
@@ -235,9 +237,9 @@ function makeHarness(opts: { publishedCourses?: string[] } = {}) {
         for (let i = groupCourses.length - 1; i >= 0; i--) {
           const c = groupCourses[i];
           if (
-            c.tenantId === where.tenantId &&
-            c.groupId === where.groupId &&
-            (inList === null || inList.includes(c.courseId))
+            c!.tenantId === where.tenantId &&
+            c!.groupId === where.groupId &&
+            (inList === null || inList.includes(c!.courseId))
           ) {
             groupCourses.splice(i, 1);
             count++;
@@ -496,13 +498,13 @@ describe('AccessGroupsService.assignMembers', () => {
     expect(h.enrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
     expect(h.enrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c2');
     expect(h.grants.filter((x) => x.revokedAt === null)).toHaveLength(2);
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
 
     // Re-asignar el mismo usuario no duplica membresía ni memberCount.
     const r2 = await h.service.assignMembers(TENANT, g.id, ['u1']);
     expect(r2.added).toBe(0);
     expect(h.members.filter((m) => m.userId === 'u1')).toHaveLength(1);
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
   });
 
   it('alta MANUAL marca la membresía con source=MANUAL', async () => {
@@ -563,7 +565,7 @@ describe('AccessGroupsService.revokeMember (refcount)', () => {
     await h.service.assignMembers(TENANT, g.id, ['u1']);
     await h.service.revokeMember(TENANT, g.id, 'u1');
     expect(h.unenrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
-    expect(h.groups[0].memberCount).toBe(0);
+    expect(h.groups[0]!.memberCount).toBe(0);
   });
 
   it('NO desmatricula si otro grupo vivo otorga el mismo curso (refcount > 0)', async () => {
@@ -642,23 +644,23 @@ describe('AccessGroupsService.updateGroup (vínculo de tier)', () => {
     await h.service.reconcileTierMembership(TENANT, 'u1', 'gold');
     expect(member(h, g.id, 'u1')?.status).toBe('ACTIVE');
     expect(member(h, g.id, 'u1')?.source).toBe('TIER');
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
     h.unenrollFromGroup.mockClear();
 
     // Cambiamos el vínculo a otro tier → los TIER del vínculo anterior se retiran.
     await h.service.updateGroup(TENANT, g.id, { linkedTierName: 'silver' });
     expect(member(h, g.id, 'u1')?.status).toBe('REVOKED');
     expect(h.unenrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
-    expect(h.groups[0].memberCount).toBe(0);
+    expect(h.groups[0]!.memberCount).toBe(0);
   });
 
   it('cadena vacía en linkedTierName se normaliza a null (desvincula)', async () => {
     const h = makeHarness();
     const g = await h.service.createGroup(TENANT, { name: 'Pro', kind: 'ALL_COURSES' } as never);
     await h.service.updateGroup(TENANT, g.id, { linkedTierName: 'gold' });
-    expect(h.groups[0].linkedTierName).toBe('gold');
+    expect(h.groups[0]!.linkedTierName).toBe('gold');
     await h.service.updateGroup(TENANT, g.id, { linkedTierName: '   ' });
-    expect(h.groups[0].linkedTierName).toBeNull();
+    expect(h.groups[0]!.linkedTierName).toBeNull();
   });
 
   it('no toca a los miembros MANUAL al cambiar el vínculo de tier', async () => {
@@ -693,7 +695,7 @@ describe('AccessGroupsService.reconcileTierMembership', () => {
     expect(member(h, g.id, 'u1')?.source).toBe('TIER');
     expect(member(h, g.id, 'u1')?.status).toBe('ACTIVE');
     expect(h.enrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
   });
 
   it('cambio de tier: retira la membresía TIER stale de otro grupo y desmatricula', async () => {
@@ -765,7 +767,7 @@ describe('AccessGroupsService.reconcileTierMembership', () => {
     expect(res).toEqual({ addedToGroups: 0, removedFromGroups: 1 });
     expect(member(h, gold.id, 'u1')?.status).toBe('REVOKED');
     expect(h.unenrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
-    expect(h.groups[0].memberCount).toBe(0);
+    expect(h.groups[0]!.memberCount).toBe(0);
   });
 
   it('es idempotente: re-reconciliar el mismo tier no descuadra memberCount ni duplica', async () => {
@@ -783,7 +785,7 @@ describe('AccessGroupsService.reconcileTierMembership', () => {
 
     expect(h.members.filter((m) => m.userId === 'u1' && m.groupId === gold.id)).toHaveLength(1);
     expect(h.grants.filter((g) => g.userId === 'u1' && g.revokedAt === null)).toHaveLength(1);
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
   });
 
   it('sin grupos del tier ni membresías TIER stale → no-op', async () => {
@@ -850,7 +852,7 @@ describe('AccessGroupsService source=MEMBERSHIP (bridge de membresía, F6)', () 
     expect(r.added).toBe(1);
     expect(member(h, g.id, 'u1')?.source).toBe('MEMBERSHIP');
     expect(h.enrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
   });
 
   it('revokeMember con onlySource MEMBERSHIP revoca la MEMBERSHIP y desmatricula', async () => {
@@ -866,7 +868,7 @@ describe('AccessGroupsService source=MEMBERSHIP (bridge de membresía, F6)', () 
     expect(res).toEqual({ revoked: true });
     expect(member(h, g.id, 'u1')?.status).toBe('REVOKED');
     expect(h.unenrollFromGroup).toHaveBeenCalledWith(TENANT, 'u1', 'c1');
-    expect(h.groups[0].memberCount).toBe(0);
+    expect(h.groups[0]!.memberCount).toBe(0);
   });
 
   it('revokeMember con onlySource MEMBERSHIP NUNCA toca una membresía MANUAL (sticky)', async () => {
@@ -882,7 +884,7 @@ describe('AccessGroupsService source=MEMBERSHIP (bridge de membresía, F6)', () 
     expect(res).toEqual({ revoked: false });
     expect(member(h, g.id, 'u1')?.status).toBe('ACTIVE');
     expect(h.unenrollFromGroup).not.toHaveBeenCalled();
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
   });
 
   it('tampoco toca una membresía TIER (cada bridge revoca solo lo suyo)', async () => {
@@ -948,7 +950,7 @@ describe('AccessGroupsService source=MEMBERSHIP (bridge de membresía, F6)', () 
     await h.service.assignMembers(TENANT, g.id, ['u1'], 'MEMBERSHIP');
     expect(member(h, g.id, 'u1')?.status).toBe('ACTIVE');
     expect(member(h, g.id, 'u1')?.source).toBe('MEMBERSHIP');
-    expect(h.groups[0].memberCount).toBe(1);
+    expect(h.groups[0]!.memberCount).toBe(1);
   });
 
   it('reconcileTierMembership no retira membresías MEMBERSHIP (solo TIER stale)', async () => {

--- a/apps/api/tests/admin-stats.service.test.ts
+++ b/apps/api/tests/admin-stats.service.test.ts
@@ -24,7 +24,7 @@ function setup(
     if (where.status === 'COMPLETED') return counts.completed;
     return counts.total;
   });
-  const certCount = vi.fn(async () => counts.cert);
+  const certCount = vi.fn(async (_args: { where: Record<string, unknown> }) => counts.cert);
 
   const prisma = {
     user: { count: userCount },
@@ -50,7 +50,7 @@ describe('AdminStatsService.getStats', () => {
     await service.getStats('t1', 'all');
     const calls = enrollmentCount.mock.calls.map((c) => c[0].where);
     expect(calls.every((w: any) => !w.enrolledAt)).toBe(true);
-    expect(certCount.mock.calls[0]?.[0].where.issuedAt).toBeUndefined();
+    expect(certCount.mock.calls[0]?.[0]!.where.issuedAt).toBeUndefined();
   });
 
   it('range=30d aplica enrolledAt gte ~30 días atrás', async () => {

--- a/apps/api/tests/admin-users-pagination.test.ts
+++ b/apps/api/tests/admin-users-pagination.test.ts
@@ -81,7 +81,17 @@ function makeService(allUsers: SeedUser[]) {
   const noopLogger = { warn: vi.fn(), log: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
 
   return {
-    service: new AdminUsersService(prisma, noopAudit, noopReset, noopLogger),
+    service: new AdminUsersService(
+      prisma,
+      noopAudit,
+      noopReset,
+      noopLogger,
+      // accountState y accessGroups no participan en `list()`. Se pasan
+      // explícitamente para que la aridad del constructor quede cubierta por
+      // el typecheck (mismo criterio que admin-users-invite.test.ts).
+      undefined as never,
+      undefined as never,
+    ),
     userCount,
     userFindMany,
   };

--- a/apps/api/tests/ai-gateway.test.ts
+++ b/apps/api/tests/ai-gateway.test.ts
@@ -7,8 +7,11 @@ import {
   type AiProviderAdapter,
 } from '../src/ai/types/contracts';
 
+// Sin `as never` en el return: el doble conserva su forma real para poder
+// hacer aserciones sobre los espías. El `as never` se aplica solo donde se
+// inyecta, que es el único punto donde hace falta.
 function makeLogger() {
-  return { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() } as never;
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
 }
 
 function makeRegistry(adapter: AiProviderAdapter): ProviderRegistry {
@@ -46,7 +49,7 @@ describe('AiGatewayService', () => {
     const gw = new AiGatewayService(
       makeRegistry(fakeAdapter),
       makeResolver({ provider: 'openai', model: 'gpt-4o' }),
-      makeLogger(),
+      makeLogger() as never,
     );
     const r = await gw.chat({
       tenantId: 't1',
@@ -72,7 +75,7 @@ describe('AiGatewayService', () => {
     const gw = new AiGatewayService(
       makeRegistry(fakeAdapter),
       makeResolver({ provider: 'openai' }),
-      makeLogger(),
+      makeLogger() as never,
     );
     const r = await gw.embed({ tenantId: 't1', input: { texts: ['a'] } });
     expect(r.embeddings).toHaveLength(1);
@@ -81,7 +84,11 @@ describe('AiGatewayService', () => {
 
   it('chat() lanza AiGatewayError si el provider resuelto no está registrado', async () => {
     const r = new ProviderRegistry();
-    const gw = new AiGatewayService(r, makeResolver({ provider: 'inexistente' }), makeLogger());
+    const gw = new AiGatewayService(
+      r,
+      makeResolver({ provider: 'inexistente' }),
+      makeLogger() as never,
+    );
     await expect(
       gw.chat({ tenantId: 't', input: { system: 's', messages: [] } }),
     ).rejects.toBeInstanceOf(AiGatewayError);
@@ -97,7 +104,7 @@ describe('AiGatewayService', () => {
     const gw = new AiGatewayService(
       makeRegistry(embedOnly),
       makeResolver({ provider: 'voyage' }),
-      makeLogger(),
+      makeLogger() as never,
     );
     await expect(
       gw.chat({ tenantId: 't', input: { system: 's', messages: [] } }),
@@ -114,7 +121,7 @@ describe('AiGatewayService', () => {
     const gw = new AiGatewayService(
       makeRegistry(chatOnly),
       makeResolver({ provider: 'anthropic' }),
-      makeLogger(),
+      makeLogger() as never,
     );
     await expect(gw.embed({ tenantId: 't', input: { texts: ['x'] } })).rejects.toBeInstanceOf(
       ProviderUnsupportedCapabilityError,
@@ -134,7 +141,7 @@ describe('AiGatewayService', () => {
     const gw = new AiGatewayService(
       makeRegistry(failingAdapter),
       makeResolver({ provider: 'openai' }),
-      logger,
+      logger as never,
     );
     await expect(gw.chat({ tenantId: 't', input: { system: 's', messages: [] } })).rejects.toThrow(
       /boom/,

--- a/apps/api/tests/ai-grader.controller.test.ts
+++ b/apps/api/tests/ai-grader.controller.test.ts
@@ -20,6 +20,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['formador'],
     email: 'f@x.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/ai-providers.controller.test.ts
+++ b/apps/api/tests/ai-providers.controller.test.ts
@@ -23,12 +23,13 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'admin@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }
 
 function makeDeps(opts: { cipherReady?: boolean; capabilities?: ('chat' | 'embed')[] } = {}) {
-  const findMany = vi.fn(async () => []);
+  const findMany = vi.fn(async () => [] as Record<string, unknown>[]);
   const findFirst = vi.fn(async () => null as { id: string } | null);
   const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
     id: 'new-id',
@@ -161,7 +162,7 @@ describe('AiProvidersController · guards', () => {
     expect(row).not.toHaveProperty('apiKeyCipher');
     expect(row).not.toHaveProperty('apiKeyIv');
     expect(row).not.toHaveProperty('apiKeyTag');
-    expect(row.hasApiKey).toBe(true);
+    expect(row!.hasApiKey).toBe(true);
   });
 });
 

--- a/apps/api/tests/ai-tutor.controller.test.ts
+++ b/apps/api/tests/ai-tutor.controller.test.ts
@@ -21,6 +21,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['alumno'],
     email: 'a@x.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/audit-log.test.ts
+++ b/apps/api/tests/audit-log.test.ts
@@ -64,7 +64,7 @@ describe('PrismaAuditLogService', () => {
     });
 
     expect(prisma._rows).toHaveLength(1);
-    const [first] = prisma._rows;
+    const first = prisma._rows[0]!;
     expect(first.prevHash).toBeNull();
     expect(first.hash).toMatch(/^[a-f0-9]{64}$/);
   });
@@ -89,7 +89,7 @@ describe('PrismaAuditLogService', () => {
     });
 
     const [a, b] = prisma._rows;
-    expect(b.prevHash).toBe(a.hash);
+    expect(b!.prevHash).toBe(a!.hash);
   });
 
   it('cadenas separadas por tenant', async () => {
@@ -111,8 +111,8 @@ describe('PrismaAuditLogService', () => {
       resourceId: 'u2',
     });
 
-    expect(prisma._rows[0].prevHash).toBeNull();
-    expect(prisma._rows[1].prevHash).toBeNull();
+    expect(prisma._rows[0]!.prevHash).toBeNull();
+    expect(prisma._rows[1]!.prevHash).toBeNull();
   });
 
   it('hash refleja los datos: cambios en metadata cambian el hash', async () => {
@@ -136,7 +136,7 @@ describe('PrismaAuditLogService', () => {
       metadata: { from: 'b' },
     });
 
-    expect(prisma._rows[0].hash).not.toEqual(prisma._rows[1].hash);
+    expect(prisma._rows[0]!.hash).not.toEqual(prisma._rows[1]!.hash);
   });
 
   describe('verifyChain', () => {
@@ -234,7 +234,7 @@ describe('PrismaAuditLogService', () => {
       });
 
       // Tampering: alguien modifica metadata de la 2ª fila sin recalcular el hash
-      prisma._rows[1].metadata = { mutado: true };
+      prisma._rows[1]!.metadata = { mutado: true };
 
       const result = await svc.verifyChain('t1');
       expect(result.valid).toBe(false);
@@ -269,7 +269,7 @@ describe('PrismaAuditLogService', () => {
       });
 
       // Tampering: reescriben el hash de la 2ª fila — la propia fila ya no valida
-      prisma._rows[1].hash = 'f'.repeat(64);
+      prisma._rows[1]!.hash = 'f'.repeat(64);
 
       const result = await svc.verifyChain('t1');
       expect(result.valid).toBe(false);

--- a/apps/api/tests/audit-long-retention-gate.test.ts
+++ b/apps/api/tests/audit-long-retention-gate.test.ts
@@ -19,6 +19,7 @@ const adminUser = {
   sub: 'user-1',
   tenantId: 'tenant-1',
   roles: ['tenant_admin'],
+  mfaVerified: true,
   email: 'admin@tenant.test',
 } as Parameters<AuditController['list']>[0];
 
@@ -45,7 +46,7 @@ describe('AuditController · gate feat:audit.long_retention (B5)', () => {
     it('GET /entries sin dateFrom → aplica floor de 90d', async () => {
       await controller.list(adminUser);
       expect(listSpy).toHaveBeenCalledTimes(1);
-      const args = listSpy.mock.calls[0][1];
+      const args = listSpy.mock.calls[0]![1];
       expect(args.dateFrom).toBeInstanceOf(Date);
       const floorMs = Date.now() - COMMUNITY_AUDIT_RETENTION_DAYS * 86_400_000;
       // Tolerancia: el floor se calcula al momento exacto de la llamada.
@@ -55,7 +56,7 @@ describe('AuditController · gate feat:audit.long_retention (B5)', () => {
     it('GET /entries con dateFrom MUY antiguo → trunca al floor', async () => {
       const veryOld = new Date(Date.now() - 365 * 86_400_000).toISOString();
       await controller.list(adminUser, undefined, undefined, undefined, veryOld);
-      const args = listSpy.mock.calls[0][1];
+      const args = listSpy.mock.calls[0]![1];
       const floorMs = Date.now() - COMMUNITY_AUDIT_RETENTION_DAYS * 86_400_000;
       expect(args.dateFrom.getTime()).toBeGreaterThanOrEqual(floorMs - 1000);
       expect(args.dateFrom.getTime()).toBeLessThanOrEqual(floorMs + 1000);
@@ -64,7 +65,7 @@ describe('AuditController · gate feat:audit.long_retention (B5)', () => {
     it('GET /entries con dateFrom RECIENTE (30d) → respeta la fecha pedida', async () => {
       const recent = new Date(Date.now() - 30 * 86_400_000);
       await controller.list(adminUser, undefined, undefined, undefined, recent.toISOString());
-      const args = listSpy.mock.calls[0][1];
+      const args = listSpy.mock.calls[0]![1];
       // Tolerancia ms por el round-trip ISO string.
       expect(Math.abs(args.dateFrom.getTime() - recent.getTime())).toBeLessThan(1000);
     });
@@ -85,13 +86,13 @@ describe('AuditController · gate feat:audit.long_retention (B5)', () => {
     it('GET /entries con dateFrom MUY antiguo → no trunca', async () => {
       const veryOld = new Date(Date.now() - 365 * 86_400_000);
       await controller.list(adminUser, undefined, undefined, undefined, veryOld.toISOString());
-      const args = listSpy.mock.calls[0][1];
+      const args = listSpy.mock.calls[0]![1];
       expect(Math.abs(args.dateFrom.getTime() - veryOld.getTime())).toBeLessThan(1000);
     });
 
     it('GET /entries sin dateFrom → no aplica floor', async () => {
       await controller.list(adminUser);
-      const args = listSpy.mock.calls[0][1];
+      const args = listSpy.mock.calls[0]![1];
       expect(args.dateFrom).toBeUndefined();
     });
 

--- a/apps/api/tests/billing-learning.bridge.test.ts
+++ b/apps/api/tests/billing-learning.bridge.test.ts
@@ -36,12 +36,14 @@ const event = (
   },
 });
 
+// Sin `as never` en la declaración: hay un test que hace `{ ...noopLogger, log }`
+// y con `never` el spread no compila. El cast va en cada punto de inyección.
 const noopLogger = {
   log: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
   debug: vi.fn(),
-} as never;
+};
 
 function makeRegistry(enrollFromPurchase: ReturnType<typeof vi.fn>) {
   return {
@@ -59,7 +61,7 @@ describe('BillingLearningBridge.enroll', () => {
     const bridge = new BillingLearningBridge(
       makeRegistry(enrollFromPurchase),
       noopFactory,
-      noopLogger,
+      noopLogger as never,
     );
 
     await bridge.enroll(event());
@@ -73,7 +75,7 @@ describe('BillingLearningBridge.enroll', () => {
     const bridge = new BillingLearningBridge(
       makeRegistry(enrollFromPurchase),
       noopFactory,
-      noopLogger,
+      noopLogger as never,
     );
 
     const e = event();
@@ -88,7 +90,7 @@ describe('BillingLearningBridge.enroll', () => {
     const bridge = new BillingLearningBridge(
       makeRegistry(enrollFromPurchase),
       noopFactory,
-      noopLogger,
+      noopLogger as never,
     );
 
     await expect(bridge.enroll(event())).resolves.toBeUndefined();
@@ -100,7 +102,7 @@ describe('BillingLearningBridge.enroll', () => {
     const bridge = new BillingLearningBridge(
       makeRegistry(enrollFromPurchase),
       noopFactory,
-      noopLogger,
+      noopLogger as never,
     );
 
     await expect(bridge.enroll(event())).rejects.toThrow('db down');
@@ -130,7 +132,7 @@ describe('BillingLearningBridge.onModuleInit', () => {
   it('se suscribe a billing.order.completed exactamente una vez', () => {
     const subscribe = vi.fn().mockReturnValue(() => {});
     const factory = { getEventBus: () => ({ subscribe }) } as never;
-    const bridge = new BillingLearningBridge(makeRegistry(vi.fn()), factory, noopLogger);
+    const bridge = new BillingLearningBridge(makeRegistry(vi.fn()), factory, noopLogger as never);
 
     bridge.onModuleInit();
 

--- a/apps/api/tests/billing-provisioning.service.test.ts
+++ b/apps/api/tests/billing-provisioning.service.test.ts
@@ -107,7 +107,7 @@ describe('BillingProvisioningService.provision', () => {
     const result = await svc.provision(args);
 
     expect(result).toEqual({ userId: 'user-nuevo', created: true });
-    const data = tx.user.create.mock.calls[0][0].data;
+    const data = tx.user.create.mock.calls[0]![0].data;
     expect(data).toMatchObject({
       tenantId: TENANT,
       email: 'compradora@example.com',
@@ -127,7 +127,7 @@ describe('BillingProvisioningService.provision', () => {
       CTX,
       { ttlMinutes: 7 * 24 * 60 },
     );
-    const sent = (smtp as { send: ReturnType<typeof vi.fn> }).send.mock.calls[0][1];
+    const sent = (smtp as { send: ReturnType<typeof vi.fn> }).send.mock.calls[0]![1];
     expect(sent.to).toBe('compradora@example.com');
     expect(sent.text).toContain('reset-password?token=tok-123');
   });
@@ -171,7 +171,7 @@ describe('BillingProvisioningService · idioma del comprador', () => {
 
   /** El email que salió al MTA. */
   function sent(smtp: unknown): { subject: string; text: string; html: string } {
-    return (smtp as { send: ReturnType<typeof vi.fn> }).send.mock.calls[0][1];
+    return (smtp as { send: ReturnType<typeof vi.fn> }).send.mock.calls[0]![1];
   }
 
   it('comprador en-US: asunto, cuerpo, botón y pie en inglés', async () => {
@@ -232,8 +232,9 @@ describe('BillingProvisioningService · idioma del comprador', () => {
         notificationTemplate: { findUnique: ReturnType<typeof vi.fn> };
       }
     ).notificationTemplate.findUnique.mock.calls.map(
-      (c: [{ where: { tenantId_key_channel_locale: { locale: string } } }]) =>
-        c[0].where.tenantId_key_channel_locale.locale,
+      (c: unknown[]) =>
+        (c[0] as { where: { tenantId_key_channel_locale: { locale: string } } }).where
+          .tenantId_key_channel_locale.locale,
     );
     // Misma precedencia que `renderForTenant` del hub: no es una regla nueva.
     expect(locales).toEqual(['en-US', 'es-ES']);

--- a/apps/api/tests/billing-public.controller.test.ts
+++ b/apps/api/tests/billing-public.controller.test.ts
@@ -96,11 +96,11 @@ describe('BillingPublicController — catálogo público', () => {
     const result = await controller.catalog(req());
 
     expect(result.courses).toHaveLength(1);
-    expect(result.courses[0].slug).toBe('curso-uno');
-    expect(result.courses[0].options).toBe(options);
+    expect(result.courses[0]!.slug).toBe('curso-uno');
+    expect(result.courses[0]!.options).toBe(options);
     // La query al core filtra por tenant y estado publicado (nunca borrados).
     const where = (prisma as never as { modCoursesCourse: { findMany: ReturnType<typeof vi.fn> } })
-      .modCoursesCourse.findMany.mock.calls[0][0].where;
+      .modCoursesCourse.findMany.mock.calls[0]![0].where;
     expect(where).toMatchObject({ tenantId: TENANT, status: 'PUBLISHED', deletedAt: null });
   });
 });
@@ -162,7 +162,7 @@ describe('BillingPublicController — checkout anónimo', () => {
     // Al visitante solo se le devuelve lo que necesita para redirigir.
     expect(result).toEqual({ url: 'https://stripe/cs_1', sessionId: 'cs_1' });
     const args = (billing as { startCheckout: ReturnType<typeof vi.fn> }).startCheckout.mock
-      .calls[0][0];
+      .calls[0]![0];
     expect(args.userId).toBeNull();
     expect(args.userEmail).toBe('visitante@example.com');
     expect(args.optionId).toBe('33333333-3333-4333-8333-333333333333');

--- a/apps/api/tests/branded-email-lang.test.ts
+++ b/apps/api/tests/branded-email-lang.test.ts
@@ -119,7 +119,10 @@ async function sentHtml(locale: string): Promise<string> {
   // comprobar.
   process.env['WEB_PUBLIC_URL'] = 'https://demo.test';
   const prisma = makePrisma(locale);
-  const send = vi.fn(async () => ({ ok: true, messageId: '<id>' }));
+  const send = vi.fn(async (_config: unknown, _message: { html: string }) => ({
+    ok: true,
+    messageId: '<id>',
+  }));
   const smtp = {
     parseConfig: (raw: unknown) => raw,
     isConfigValid: () => true,

--- a/apps/api/tests/broadcast-unsubscribe.test.ts
+++ b/apps/api/tests/broadcast-unsubscribe.test.ts
@@ -24,7 +24,7 @@ describe('broadcast unsubscribe token', () => {
 
   it('rechaza un token con la firma manipulada', () => {
     const token = signUnsubscribeToken(TENANT, USER);
-    const [data] = token.split('.');
+    const data = token.split('.')[0]!;
     expect(verifyUnsubscribeToken(`${data}.firmafalsa`)).toBeNull();
   });
 

--- a/apps/api/tests/certificates-ownership.controller.test.ts
+++ b/apps/api/tests/certificates-ownership.controller.test.ts
@@ -18,6 +18,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['alumno'],
     email: 'a@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/courses.controller.roles.test.ts
+++ b/apps/api/tests/courses.controller.roles.test.ts
@@ -17,6 +17,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['alumno'],
     email: 'a@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/evidence-vault.test.ts
+++ b/apps/api/tests/evidence-vault.test.ts
@@ -53,6 +53,11 @@ function makeFakeStorage(): StorageService & { uploadCalls: number } {
       fake.uploadCalls++;
       return { key };
     },
+    // El vault nunca sube imágenes, pero `StorageService` declara el método:
+    // sin él el doble deja de cumplir el contrato que dice implementar.
+    async uploadImage(): Promise<never> {
+      throw new Error('not used');
+    },
     async download() {
       throw new Error('not used');
     },
@@ -107,8 +112,8 @@ describe('PrismaEvidenceVaultService', () => {
     await svc.store({ tenantId: 't2', resourceType: 'doc', resourceId: 'd1', data });
 
     expect(prisma._rows).toHaveLength(2);
-    expect(prisma._rows[0].tenantId).toBe('t1');
-    expect(prisma._rows[1].tenantId).toBe('t2');
+    expect(prisma._rows[0]!.tenantId).toBe('t1');
+    expect(prisma._rows[1]!.tenantId).toBe('t2');
   });
 
   it('tolera Uint8Array como entrada (no solo Buffer)', async () => {

--- a/apps/api/tests/fundae-companies.controller.test.ts
+++ b/apps/api/tests/fundae-companies.controller.test.ts
@@ -17,13 +17,14 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'admin@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }
 
 function makeRegistry() {
   const list = vi.fn(async () => []);
-  const get = vi.fn(async () => null);
+  const get = vi.fn(async () => null as { id: string; razonSocial: string } | null);
   const create = vi.fn(async (_t: string, _a: string | null, dto: { nif: string }) => ({
     id: 'created-id',
     ...dto,

--- a/apps/api/tests/fundae-group-participants.controller.test.ts
+++ b/apps/api/tests/fundae-group-participants.controller.test.ts
@@ -16,6 +16,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'admin@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/fundae-groups.controller.test.ts
+++ b/apps/api/tests/fundae-groups.controller.test.ts
@@ -17,6 +17,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'admin@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/fundae-rlpt.controller.test.ts
+++ b/apps/api/tests/fundae-rlpt.controller.test.ts
@@ -10,12 +10,16 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'admin@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }
 
 function makeRegistry() {
-  const upload = vi.fn(async () => ({ id: 'rlpt-1', tipo: 'NOTIFICACION_INICIAL' }));
+  const upload = vi.fn(async (_input: { blob: Buffer; contentType: string }) => ({
+    id: 'rlpt-1',
+    tipo: 'NOTIFICACION_INICIAL',
+  }));
   const listByCompany = vi.fn(async () => []);
   const softDelete = vi.fn(async () => ({ id: 'rlpt-1', deletedAt: new Date().toISOString() }));
   return {

--- a/apps/api/tests/groups-join-idempotente.controller.test.ts
+++ b/apps/api/tests/groups-join-idempotente.controller.test.ts
@@ -16,6 +16,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['alumno'],
     email: 'a@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/inscribe.service.test.ts
+++ b/apps/api/tests/inscribe.service.test.ts
@@ -97,7 +97,7 @@ function makeHarness(opts: {
             tenantName: 'Academia Demo',
           },
     ),
-  } as never;
+  };
   const logger = { warn: vi.fn(), log: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
 
   const accessGroupsSvc = {
@@ -122,7 +122,7 @@ function makeHarness(opts: {
     registry,
     smtpResolver,
     smtp as never,
-    passwordReset,
+    passwordReset as never,
     accessGroupsSvc as never,
     logger,
   );
@@ -153,7 +153,7 @@ describe('InscribeService.inscribe', () => {
 
     expect(result.userCreated).toBe(true);
     expect(result.userId).toBe('new-user');
-    const createArg = h.txUser.create.mock.calls[0][0].data;
+    const createArg = h.txUser.create.mock.calls[0]![0].data;
     expect(createArg.status).toBe('ACTIVE');
     // Ya NO se fuerza el cambio: el comprador elige su contraseña en el enlace,
     // así entra una sola vez y va directo al onboarding.
@@ -184,7 +184,7 @@ describe('InscribeService.inscribe', () => {
       expect.anything(),
       { ttlMinutes: SET_PASSWORD_TTL },
     );
-    const message = h.smtp.send.mock.calls[0][1] as { html: string; text: string };
+    const message = h.smtp.send.mock.calls[0]![1] as { html: string; text: string };
     expect(message.html).toContain(`${WEB_BASE_URL}/reset-password?token=tok-abc`);
     expect(message.html).toContain('Define tu contraseña');
     // No se filtra ninguna contraseña generada.
@@ -206,7 +206,7 @@ describe('InscribeService.inscribe', () => {
       WEB_BASE_URL,
     );
 
-    const message = h.smtp.send.mock.calls[0][1] as {
+    const message = h.smtp.send.mock.calls[0]![1] as {
       subject: string;
       html: string;
       text: string;
@@ -231,7 +231,7 @@ describe('InscribeService.inscribe', () => {
         { email: 'ana@x.com', name: 'Ana', courseIds: [COURSE_A], ...(locale ? { locale } : {}) },
         WEB_BASE_URL,
       );
-      const message = h.smtp.send.mock.calls[0][1] as { subject: string; text: string };
+      const message = h.smtp.send.mock.calls[0]![1] as { subject: string; text: string };
       expect(message.subject, String(locale)).toBe('Tu acceso a Academia Demo');
       expect(message.text, String(locale)).toContain('Hola Ana,');
       expect(message.text, String(locale)).toContain('Define tu contraseña:');

--- a/apps/api/tests/integration/rls-latency.integration.test.ts
+++ b/apps/api/tests/integration/rls-latency.integration.test.ts
@@ -34,7 +34,7 @@ const ITERATIONS = 200;
 
 function percentile(sortedMs: number[], p: number): number {
   const idx = Math.min(sortedMs.length - 1, Math.ceil((p / 100) * sortedMs.length) - 1);
-  return sortedMs[Math.max(0, idx)];
+  return sortedMs[Math.max(0, idx)]!;
 }
 
 async function measure(fn: () => Promise<unknown>): Promise<number[]> {

--- a/apps/api/tests/invitations-batch.test.ts
+++ b/apps/api/tests/invitations-batch.test.ts
@@ -45,7 +45,7 @@ function hacerServicio(opts: {
       return { id: 'group-1' };
     }),
     assignMembers: vi.fn(async (_tenantId: string, _groupId: string, userIds: string[]) => {
-      if (opts.assignMembersFallaPara?.has(userIds[0])) throw new Error('fallo de BD');
+      if (opts.assignMembersFallaPara?.has(userIds[0]!)) throw new Error('fallo de BD');
     }),
   };
 

--- a/apps/api/tests/learning-invitations.controller.test.ts
+++ b/apps/api/tests/learning-invitations.controller.test.ts
@@ -19,6 +19,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['alumno'],
     email: 'a@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/license-admin.service.test.ts
+++ b/apps/api/tests/license-admin.service.test.ts
@@ -133,7 +133,7 @@ describe('LicenseAdminService', () => {
           const idx = findIdx(scope, key);
           const now = new Date();
           if (idx >= 0) {
-            rows[idx] = { ...rows[idx], ...args.update, updatedAt: now };
+            rows[idx] = { ...rows[idx]!, ...args.update, updatedAt: now };
             return rows[idx];
           }
           const row: Row = {

--- a/apps/api/tests/marketplace/admin-marketplace.controller.test.ts
+++ b/apps/api/tests/marketplace/admin-marketplace.controller.test.ts
@@ -61,8 +61,8 @@ describe('AdminMarketplaceController.installPackage', () => {
     const ctrl = makeController({ install });
     await ctrl.installPackage(userWith(['super_admin']), Buffer.from('payload'));
     expect(installCalls).toHaveLength(1);
-    expect(installCalls[0].userId).toBe('u-1');
-    expect(installCalls[0].buffer.toString()).toBe('payload');
+    expect(installCalls[0]!.userId).toBe('u-1');
+    expect(installCalls[0]!.buffer.toString()).toBe('payload');
   });
 });
 
@@ -93,7 +93,7 @@ describe('AdminMarketplaceController.list', () => {
     const out = await ctrl.list(userWith(['super_admin']), 'installed', 'didacta');
     expect(installed.list).toHaveBeenCalledWith({ status: 'INSTALLED', vendor: 'DIDACTA' });
     expect(out.modules).toHaveLength(1);
-    expect(out.modules[0].name).toBe('mod.example');
+    expect(out.modules[0]!.name).toBe('mod.example');
     expect(out.modules[0]).not.toHaveProperty('manifestJson'); // no exponemos el JSON crudo
   });
 });

--- a/apps/api/tests/marketplace/installed-module.service.test.ts
+++ b/apps/api/tests/marketplace/installed-module.service.test.ts
@@ -73,6 +73,7 @@ describe('InstalledModuleService', () => {
       packageSha256: 'a'.repeat(64),
       packageSizeBytes: 1024,
       installedById: 'user-1',
+      source: 'DIRECT_UPLOAD',
     });
     expect(row.status).toBe('INSTALLING');
     expect(row.name).toBe('mod.example');
@@ -98,6 +99,7 @@ describe('InstalledModuleService', () => {
       packageSha256: 'b'.repeat(64),
       packageSizeBytes: 2048,
       installedById: 'user-2',
+      source: 'DIRECT_UPLOAD',
     });
     const updated = store.get('mod.example')!;
     expect(updated.status).toBe('INSTALLING');
@@ -126,7 +128,7 @@ describe('InstalledModuleService', () => {
 
   it('appendMigrationsApplied: array vacío solo actualiza timestamp', async () => {
     const { prisma } = makePrismaMock([
-      { id: 'r1', name: 'mod.example', migrationsApplied: [] } as InstalledModule,
+      { id: 'r1', name: 'mod.example', migrationsApplied: [] as string[] } as InstalledModule,
     ]);
     const svc = new InstalledModuleService(prisma);
     const updated = await svc.appendMigrationsApplied('r1', []);

--- a/apps/api/tests/marketplace/mod-jobs.queue.test.ts
+++ b/apps/api/tests/marketplace/mod-jobs.queue.test.ts
@@ -15,7 +15,11 @@ import {
 // Mocks de bullmq + ioredis
 // ─────────────────────────────────────────────────────────────────────────────
 
-const queueAdd = vi.fn(async () => ({ id: 'job-id' }));
+const queueAdd = vi.fn(
+  async (_name: string, _data: unknown, _opts?: { delay?: number; jobId?: string }) => ({
+    id: 'job-id',
+  }),
+);
 const queueClose = vi.fn(async () => undefined);
 
 vi.mock('bullmq', () => ({

--- a/apps/api/tests/marketplace/module-migration.service.test.ts
+++ b/apps/api/tests/marketplace/module-migration.service.test.ts
@@ -36,7 +36,7 @@ function makePrismaMock(opts: PrismaMockOptions = {}): PrismaMock {
   };
 
   const prisma = {
-    $transaction: vi.fn(async (cb: (tx: typeof tx) => Promise<void>) => {
+    $transaction: vi.fn(async (cb: (tx: unknown) => Promise<void>) => {
       const buffer = [...executed];
       try {
         await cb(tx);

--- a/apps/api/tests/marketplace/module-package.service.test.ts
+++ b/apps/api/tests/marketplace/module-package.service.test.ts
@@ -146,7 +146,7 @@ describe('ModulePackageService.validatePackage', () => {
   it('NAME_RESERVED si el nombre coincide con un built-in', async () => {
     const { pkg, sig } = makeServices();
     const reserved = Array.from(RESERVED_MODULE_NAMES)[0];
-    const slug = reserved.replace(/^mod\./, '');
+    const slug = reserved!.replace(/^mod\./, '');
     const fixture = await buildTestPackage({
       signatureService: sig,
       manifest: {

--- a/apps/api/tests/marketplace/modules-dispatcher.controller.test.ts
+++ b/apps/api/tests/marketplace/modules-dispatcher.controller.test.ts
@@ -1,6 +1,9 @@
 import { HttpException, Logger, NotFoundException } from '@nestjs/common';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ModuleRouterService } from '../../src/marketplace/module-router.service';
+import {
+  ModuleRouterService,
+  type ModuleRouteRequestContext,
+} from '../../src/marketplace/module-router.service';
 import { ModulesDispatcherController } from '../../src/marketplace/modules-dispatcher.controller';
 import { RateLimiterService } from '../../src/marketplace/rate-limiter.service';
 import { SandboxedDbService } from '../../src/marketplace/sandboxed-db.service';
@@ -130,7 +133,7 @@ afterEach(() => {
 describe('ModulesDispatcherController.dispatch', () => {
   it('despacha al handler registrado y devuelve su body', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async (ctx: any) => ({
+    const handler = vi.fn(async (ctx: ModuleRouteRequestContext) => ({
       status: 200,
       body: { from: ctx.params.id },
     }));
@@ -189,7 +192,7 @@ describe('ModulesDispatcherController.dispatch', () => {
 
   it('passes query, body y user al handler cuando el Bearer es válido', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'POST', path: '/echo', handler },
     ]);
@@ -218,15 +221,15 @@ describe('ModulesDispatcherController.dispatch', () => {
 
     await ctrl.dispatch(req, reply, { hello: 'world' });
 
-    const ctx = handler.mock.calls[0][0];
-    expect(ctx.query).toEqual({ a: '1' });
-    expect(ctx.body).toEqual({ hello: 'world' });
-    expect(ctx.user).toEqual({ sub: 'u-1', tenantId: 't-1', roles: ['formador'] });
+    const ctx = handler.mock.calls[0]![0];
+    expect(ctx!.query).toEqual({ a: '1' });
+    expect(ctx!.body).toEqual({ hello: 'world' });
+    expect(ctx!.user).toEqual({ sub: 'u-1', tenantId: 't-1', roles: ['formador'] });
   });
 
   it('user=null si no hay header Authorization', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/public', handler },
     ]);
@@ -247,12 +250,12 @@ describe('ModulesDispatcherController.dispatch', () => {
     const req = makeReq({ url: '/api/v1/modules/example/public' });
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
-    expect(handler.mock.calls[0][0].user).toBeNull();
+    expect(handler.mock.calls[0]![0]!.user).toBeNull();
   });
 
   it('user=null si el Bearer es inválido (no rompe la request)', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/public', handler },
     ]);
@@ -276,12 +279,12 @@ describe('ModulesDispatcherController.dispatch', () => {
     });
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
-    expect(handler.mock.calls[0][0].user).toBeNull();
+    expect(handler.mock.calls[0]![0]!.user).toBeNull();
   });
 
   it('user=null si el header no empieza con "Bearer "', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/public', handler },
     ]);
@@ -305,12 +308,12 @@ describe('ModulesDispatcherController.dispatch', () => {
     });
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
-    expect(handler.mock.calls[0][0].user).toBeNull();
+    expect(handler.mock.calls[0]![0]!.user).toBeNull();
   });
 
   it('user=null si "Bearer " va seguido de string vacío', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/public', handler },
     ]);
@@ -335,7 +338,7 @@ describe('ModulesDispatcherController.dispatch', () => {
     });
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
-    expect(handler.mock.calls[0][0].user).toBeNull();
+    expect(handler.mock.calls[0]![0]!.user).toBeNull();
     // Y NO debe haber intentado verificar un token vacío.
     expect(tokens.verifyAccess as any).not.toHaveBeenCalled();
   });
@@ -449,7 +452,7 @@ describe('ModulesDispatcherController.dispatch', () => {
   // la salida HTTP en el manifest antes de poder usarla.
   it('módulo sin manifest.http → ctx.http es BlockedSandboxedHttp', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/probe', handler },
     ]);
@@ -475,11 +478,11 @@ describe('ModulesDispatcherController.dispatch', () => {
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
 
-    const ctx = handler.mock.calls[0][0];
-    expect(typeof ctx.http?.get).toBe('function');
-    expect(typeof ctx.http?.post).toBe('function');
+    const ctx = handler.mock.calls[0]![0];
+    expect(typeof ctx!.http?.get).toBe('function');
+    expect(typeof ctx!.http?.post).toBe('function');
 
-    await expect(ctx.http.get('https://api.zoom.us/x')).rejects.toMatchObject({
+    await expect(ctx!.http.get('https://api.zoom.us/x')).rejects.toMatchObject({
       name: 'HttpError',
       code: 'HTTP_BLOCKED_HOST',
     });
@@ -491,7 +494,7 @@ describe('ModulesDispatcherController.dispatch', () => {
   // de la allowlist devuelve HTTP_BLOCKED_HOST (no Noop, no garbage).
   it('módulo con manifest.http restrictivo → ctx.http aplica allowlist', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule(
       'mod.zoom',
       '/modules/zoom',
@@ -526,9 +529,9 @@ describe('ModulesDispatcherController.dispatch', () => {
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
 
-    const ctx = handler.mock.calls[0][0];
+    const ctx = handler.mock.calls[0]![0];
     // Host fuera de allowlist → HTTP_BLOCKED_HOST
-    await expect(ctx.http.get('https://otro.host.com/x')).rejects.toMatchObject({
+    await expect(ctx!.http.get('https://otro.host.com/x')).rejects.toMatchObject({
       code: 'HTTP_BLOCKED_HOST',
     });
   });
@@ -540,7 +543,7 @@ describe('ModulesDispatcherController.dispatch', () => {
   // scoped al tablePrefix + tenantId del request.
   it('módulo sin requiresDb → ctx.db es BlockedSandboxedDb', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/probe', handler },
     ]);
@@ -566,12 +569,12 @@ describe('ModulesDispatcherController.dispatch', () => {
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
 
-    const ctx = handler.mock.calls[0][0];
-    expect(typeof ctx.db?.query).toBe('function');
-    expect(typeof ctx.db?.execute).toBe('function');
-    expect(typeof ctx.db?.transaction).toBe('function');
+    const ctx = handler.mock.calls[0]![0];
+    expect(typeof ctx!.db?.query).toBe('function');
+    expect(typeof ctx!.db?.execute).toBe('function');
+    expect(typeof ctx!.db?.transaction).toBe('function');
 
-    await expect(ctx.db.query('SELECT 1 FROM mod_example_jobs')).rejects.toMatchObject({
+    await expect(ctx!.db.query('SELECT 1 FROM mod_example_jobs')).rejects.toMatchObject({
       name: 'DbError',
       code: 'DB_PREFIX_VIOLATION',
       message: expect.stringContaining('requiresDb'),
@@ -580,7 +583,7 @@ describe('ModulesDispatcherController.dispatch', () => {
 
   it('módulo con requiresDb=true → ctx.db ejecuta queries scoped (con SQL guard activo)', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule(
       'mod.example',
       '/modules/example',
@@ -612,14 +615,14 @@ describe('ModulesDispatcherController.dispatch', () => {
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
 
-    const ctx = handler.mock.calls[0][0];
+    const ctx = handler.mock.calls[0]![0];
     // Query dentro del prefix → pasa el guard, llega al fakePrisma stub.
-    await expect(ctx.db.query('SELECT * FROM mod_example_jobs')).resolves.toEqual({
+    await expect(ctx!.db.query('SELECT * FROM mod_example_jobs')).resolves.toEqual({
       rows: [],
       rowCount: 0,
     });
     // Query fuera del prefix → DB_PREFIX_VIOLATION (SQL guard).
-    await expect(ctx.db.query('SELECT * FROM "user"')).rejects.toMatchObject({
+    await expect(ctx!.db.query('SELECT * FROM "user"')).rejects.toMatchObject({
       code: 'DB_PREFIX_VIOLATION',
     });
   });
@@ -630,7 +633,7 @@ describe('ModulesDispatcherController.dispatch', () => {
 
   it('módulo SIN bloque didacta → ctx.didacta rechaza con DIDACTA_PERMISSION_DENIED', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule('mod.example', '/modules/example', [
       { method: 'GET', path: '/probe', handler },
     ]);
@@ -656,11 +659,11 @@ describe('ModulesDispatcherController.dispatch', () => {
     const { reply } = makeReply();
     await ctrl.dispatch(req, reply, undefined);
 
-    const ctx = handler.mock.calls[0][0];
-    expect(typeof ctx.didacta?.users?.upsertByExternalRef).toBe('function');
+    const ctx = handler.mock.calls[0]![0];
+    expect(typeof ctx!.didacta?.users?.upsertByExternalRef).toBe('function');
 
     await expect(
-      ctx.didacta.users.upsertByExternalRef({
+      ctx!.didacta.users.upsertByExternalRef({
         externalSource: 'learndash',
         externalId: '1',
         email: 'a@b.com',
@@ -674,7 +677,7 @@ describe('ModulesDispatcherController.dispatch', () => {
 
   it('módulo CON bloque didacta → llamada llega al ScopedDidactaApiFactory.build (con permisos)', async () => {
     const router = new ModuleRouterService();
-    const handler = vi.fn(async () => ({ status: 200, body: 'ok' }));
+    const handler = vi.fn(async (_ctx: ModuleRouteRequestContext) => ({ status: 200, body: 'ok' }));
     router.registerModule(
       'mod.example',
       '/modules/example',
@@ -688,11 +691,15 @@ describe('ModulesDispatcherController.dispatch', () => {
     );
     // Stub: factory.build devuelve un cliente de prueba que graba la
     // invocación. Verifica que el dispatcher pasó moduleId + didactaConfig.
-    const buildSpy = vi.fn(() => ({
-      users: {
-        upsertByExternalRef: vi.fn(async () => ({ id: 'u-1' }) as any),
-      },
-    }));
+    // El doble declara los parámetros reales de `DidactaApiFactory.build()`
+    // (moduleId, didactaConfig, coreServices) para poder afirmar sobre ellos.
+    const buildSpy = vi.fn(
+      (_moduleId: string, _didactaConfig: unknown, _coreServices?: unknown) => ({
+        users: {
+          upsertByExternalRef: vi.fn(async () => ({ id: 'u-1' }) as any),
+        },
+      }),
+    );
     const fakeFactory = { build: buildSpy } as any;
     const ctrl = new ModulesDispatcherController(
       router,
@@ -716,8 +723,8 @@ describe('ModulesDispatcherController.dispatch', () => {
     await ctrl.dispatch(req, reply, undefined);
 
     expect(buildSpy).toHaveBeenCalledTimes(1);
-    expect(buildSpy.mock.calls[0][0]).toBe('mod.example');
-    expect(buildSpy.mock.calls[0][1]).toEqual({
+    expect(buildSpy.mock.calls[0]![0]).toBe('mod.example');
+    expect(buildSpy.mock.calls[0]![1]).toEqual({
       externalSource: 'learndash',
       permissions: ['users.upsertByExternalRef'],
     });

--- a/apps/api/tests/marketplace/sandboxed-db.service.test.ts
+++ b/apps/api/tests/marketplace/sandboxed-db.service.test.ts
@@ -440,7 +440,7 @@ function makePrismaMock(opts: PrismaMockState = { txCount: 0, executed: [] }): {
 
   const prisma = {
     $transaction: vi.fn(
-      async (cb: (tx: typeof tx) => Promise<unknown>, _opts?: { timeout?: number }) => {
+      async (cb: (tx: unknown) => Promise<unknown>, _opts?: { timeout?: number }) => {
         state.txCount++;
         return cb(tx);
       },

--- a/apps/api/tests/marketplace/sandboxed-http.service.test.ts
+++ b/apps/api/tests/marketplace/sandboxed-http.service.test.ts
@@ -185,7 +185,7 @@ describe('SandboxedHttpService — SSRF guard', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function mockFetchWith(handler: (url: string, init: RequestInit) => Response | Promise<Response>) {
-  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+  globalThis.fetch = vi.fn(async (input: unknown, init: RequestInit = {}) => {
     return handler(String(input), init);
   }) as unknown as typeof globalThis.fetch;
 }

--- a/apps/api/tests/member-registration-admin-renewal.controller.test.ts
+++ b/apps/api/tests/member-registration-admin-renewal.controller.test.ts
@@ -31,14 +31,18 @@ const MATCH = {
   subscriptionId: 'sub_1',
 };
 
+/// Implementación de doble. Los overrides eran `unknown`, que `vi.fn()` no
+/// acepta: el typecheck lo destapa en cuanto entra en cobertura.
+type FakeImpl = (...args: any[]) => any;
+
 function build(overrides?: {
-  getUserEmail?: unknown;
-  getForUser?: unknown;
-  runAndStore?: unknown;
-  resolveRenewalUrlByRef?: unknown;
-  getRenewalTemplate?: unknown;
-  resolve?: unknown;
-  send?: unknown;
+  getUserEmail?: FakeImpl;
+  getForUser?: FakeImpl;
+  runAndStore?: FakeImpl;
+  resolveRenewalUrlByRef?: FakeImpl;
+  getRenewalTemplate?: FakeImpl;
+  resolve?: FakeImpl;
+  send?: FakeImpl;
 }) {
   const registration = {
     getUserEmail: vi.fn(overrides?.getUserEmail ?? (async () => 'aspirante@x.com')),

--- a/apps/api/tests/member-registration-controller-flow.test.ts
+++ b/apps/api/tests/member-registration-controller-flow.test.ts
@@ -198,7 +198,7 @@ describe('MemberRegistrationPublicController · otp/verify', () => {
       password: 'x'.repeat(12),
       verificationToken,
     } as never);
-    const input = registration.createPending.mock.calls[0][1];
+    const input = registration.createPending.mock.calls[0]![1];
     expect(input.telegramId).toBeNull();
     expect(input.inGroup).toBe('unknown');
     expect(input.email).toBe('a@x.com');
@@ -236,7 +236,7 @@ describe('MemberRegistrationPublicController · register', () => {
       email: ' Ana@X.com ',
     } as never);
     expect(res).toEqual({ ok: true, status: 'PENDING' });
-    const input = registration.createPending.mock.calls[0][1];
+    const input = registration.createPending.mock.calls[0]![1];
     expect(input.email).toBe('ana@x.com');
     expect(input.telegramId).toBeNull();
   });
@@ -283,7 +283,7 @@ describe('MemberRegistrationPublicController · register', () => {
       email: 'a@x.com',
       ticket,
     } as never);
-    const input = registration.createPending.mock.calls[0][1];
+    const input = registration.createPending.mock.calls[0]![1];
     expect(input.telegramId).toBe('42');
     expect(input.inGroup).toBe('false');
     expect(input.email).toBe('a@x.com');

--- a/apps/api/tests/member-registration-decision.test.ts
+++ b/apps/api/tests/member-registration-decision.test.ts
@@ -230,13 +230,13 @@ describe('MemberDecisionService.decide', () => {
     const result = await h.service.decide(approveToken, CTX);
 
     expect(result).toEqual({ outcome: 'approved', tenantId: TENANT_ID });
-    expect(h.users[0].status).toBe('ACTIVE');
-    expect(h.users[0].approvalDecidedAt).not.toBeNull();
+    expect(h.users[0]!.status).toBe('ACTIVE');
+    expect(h.users[0]!.approvalDecidedAt).not.toBeNull();
     expect(h.tokens.every((t) => t.decidedAt !== null)).toBe(true);
     // Delega el acceso en mod.access-groups (grupo por defecto al aprobar).
     expect(h.assignDefaultGroupOnApproval).toHaveBeenCalledTimes(1);
     expect(h.assignDefaultGroupOnApproval).toHaveBeenCalledWith(TENANT_ID, USER_ID);
-    expect(h.auditLog.record.mock.calls[0][0].action).toBe('member.approved');
+    expect(h.auditLog.record.mock.calls[0]![0].action).toBe('member.approved');
   });
 
   it('REJECT válido → User DEACTIVATED y devuelve rejected (sin asignar grupo)', async () => {
@@ -246,9 +246,9 @@ describe('MemberDecisionService.decide', () => {
     const result = await h.service.decide(rejectToken, CTX);
 
     expect(result).toEqual({ outcome: 'rejected', tenantId: TENANT_ID });
-    expect(h.users[0].status).toBe('DEACTIVATED');
+    expect(h.users[0]!.status).toBe('DEACTIVATED');
     expect(h.tokens.every((t) => t.decidedAt !== null)).toBe(true);
     expect(h.assignDefaultGroupOnApproval).not.toHaveBeenCalled();
-    expect(h.auditLog.record.mock.calls[0][0].action).toBe('member.rejected');
+    expect(h.auditLog.record.mock.calls[0]![0].action).toBe('member.rejected');
   });
 });

--- a/apps/api/tests/member-registration-email-verification.test.ts
+++ b/apps/api/tests/member-registration-email-verification.test.ts
@@ -179,19 +179,19 @@ describe('EmailVerificationService.requestCode', () => {
     expect(expiresInSeconds).toBe(600); // 10 minutos.
     expect(prisma.codes).toHaveLength(1);
     const row = prisma.codes[0];
-    expect(row.tenantId).toBe(TENANT_ID);
-    expect(row.email).toBe(EMAIL);
-    expect(row.attempts).toBe(0);
-    expect(row.usedAt).toBeNull();
+    expect(row!.tenantId).toBe(TENANT_ID);
+    expect(row!.email).toBe(EMAIL);
+    expect(row!.attempts).toBe(0);
+    expect(row!.usedAt).toBeNull();
     // El codeHash es SHA-256 hex de 64 chars; nunca el código en claro.
-    expect(row.codeHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(row!.codeHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it('expira a los 10 minutos del request', async () => {
     const { service, prisma } = makeService();
     const before = Date.now();
     await service.requestCode(TENANT_ID, EMAIL, CTX);
-    const delta = prisma.codes[0].expiresAt.getTime() - before;
+    const delta = prisma.codes[0]!.expiresAt.getTime() - before;
     expect(delta).toBeGreaterThanOrEqual(9 * 60_000);
     expect(delta).toBeLessThanOrEqual(11 * 60_000);
   });
@@ -203,8 +203,8 @@ describe('EmailVerificationService.requestCode', () => {
 
     expect(prisma.codes).toHaveLength(2);
     // El primero quedó invalidado (usedAt seteado), el segundo sigue vigente.
-    expect(prisma.codes[0].usedAt).not.toBeNull();
-    expect(prisma.codes[1].usedAt).toBeNull();
+    expect(prisma.codes[0]!.usedAt).not.toBeNull();
+    expect(prisma.codes[1]!.usedAt).toBeNull();
   });
 
   it('llama al SMTP con el código (envío best-effort)', async () => {
@@ -255,7 +255,7 @@ describe('EmailVerificationService.verifyCode', () => {
 
     const ok = await service.verifyCode(TENANT_ID, EMAIL, '123456', CTX);
     expect(ok).toBe(true);
-    expect(prisma.codes[0].usedAt).not.toBeNull();
+    expect(prisma.codes[0]!.usedAt).not.toBeNull();
   });
 
   it('con un código incorrecto devuelve false e incrementa attempts', async () => {
@@ -264,8 +264,8 @@ describe('EmailVerificationService.verifyCode', () => {
 
     const ok = await service.verifyCode(TENANT_ID, EMAIL, '000000', CTX);
     expect(ok).toBe(false);
-    expect(prisma.codes[0].attempts).toBe(1);
-    expect(prisma.codes[0].usedAt).toBeNull();
+    expect(prisma.codes[0]!.attempts).toBe(1);
+    expect(prisma.codes[0]!.usedAt).toBeNull();
   });
 
   it('rechaza (false) cuando ya se alcanzó el máximo de intentos', async () => {
@@ -276,7 +276,7 @@ describe('EmailVerificationService.verifyCode', () => {
     const ok = await service.verifyCode(TENANT_ID, EMAIL, '123456', CTX);
     expect(ok).toBe(false);
     // No incrementa más allá del máximo (la guarda corta antes).
-    expect(prisma.codes[0].attempts).toBe(5);
+    expect(prisma.codes[0]!.attempts).toBe(5);
   });
 
   it('rechaza (false) un código expirado aunque el dígito sea correcto', async () => {
@@ -288,7 +288,7 @@ describe('EmailVerificationService.verifyCode', () => {
 
     const ok = await service.verifyCode(TENANT_ID, EMAIL, '123456', CTX);
     expect(ok).toBe(false);
-    expect(prisma.codes[0].usedAt).toBeNull();
+    expect(prisma.codes[0]!.usedAt).toBeNull();
   });
 
   it('devuelve false cuando no hay ninguna fila vigente para (tenant, email)', async () => {

--- a/apps/api/tests/member-registration-payment-flag.test.ts
+++ b/apps/api/tests/member-registration-payment-flag.test.ts
@@ -135,7 +135,7 @@ function makeFakePrisma(users: UserRow[] = []) {
     async deleteMany(args: { where: { tenantId: string; id: string } }) {
       let count = 0;
       for (let i = flags.length - 1; i >= 0; i--) {
-        if (flags[i].tenantId === args.where.tenantId && flags[i].id === args.where.id) {
+        if (flags[i]!.tenantId === args.where.tenantId && flags[i]!.id === args.where.id) {
           flags.splice(i, 1);
           count++;
         }
@@ -218,7 +218,7 @@ describe('MemberPaymentFlagService.upsert', () => {
   it('normaliza el email a minúsculas y sin espacios', async () => {
     const { service, prisma } = makeService();
     await service.upsert(TENANT_ID, dto({ email: ' Moroso@Example.com ' }), ACTOR_ID, CTX);
-    expect(prisma.flags[0].email).toBe('moroso@example.com');
+    expect(prisma.flags[0]!.email).toBe('moroso@example.com');
   });
 
   it('es idempotente por email: re-upsert actualiza la fila existente', async () => {
@@ -238,8 +238,8 @@ describe('MemberPaymentFlagService.upsert', () => {
 
     expect(second.id).toBe(first.id);
     expect(prisma.flags).toHaveLength(1);
-    expect(prisma.flags[0].isDelinquent).toBe(false);
-    expect(prisma.flags[0].name).toBe('Ya pagó');
+    expect(prisma.flags[0]!.isDelinquent).toBe(false);
+    expect(prisma.flags[0]!.name).toBe('Ya pagó');
   });
 
   it('migra una fila legacy: match por telegramId y adopción del email nuevo', async () => {
@@ -275,8 +275,8 @@ describe('MemberPaymentFlagService.upsert', () => {
   it('normaliza name y note ausentes a null', async () => {
     const { service, prisma } = makeService();
     await service.upsert(TENANT_ID, dto({ email: 'x@example.com' }), ACTOR_ID, CTX);
-    expect(prisma.flags[0].name).toBeNull();
-    expect(prisma.flags[0].note).toBeNull();
+    expect(prisma.flags[0]!.name).toBeNull();
+    expect(prisma.flags[0]!.note).toBeNull();
   });
 });
 
@@ -288,7 +288,7 @@ describe('MemberPaymentFlagService.list', () => {
 
     const rows = await service.list(TENANT_ID);
     expect(rows).toHaveLength(1);
-    expect(rows[0].email).toBe('a@example.com');
+    expect(rows[0]!.email).toBe('a@example.com');
     // La fila del otro tenant sigue persistida pero no se devuelve.
     expect(prisma.flags).toHaveLength(2);
   });
@@ -312,7 +312,7 @@ describe('MemberPaymentFlagService.list', () => {
     const onlyDelinquent = await service.list(TENANT_ID, { delinquentOnly: true });
     expect(all).toHaveLength(2);
     expect(onlyDelinquent).toHaveLength(1);
-    expect(onlyDelinquent[0].email).toBe('a@example.com');
+    expect(onlyDelinquent[0]!.email).toBe('a@example.com');
   });
 
   it('con q hace match parcial por email, telegramId o name (case-insensitive)', async () => {
@@ -332,15 +332,15 @@ describe('MemberPaymentFlagService.list', () => {
 
     const byId = await service.list(TENANT_ID, { q: '123' });
     expect(byId).toHaveLength(1);
-    expect(byId[0].telegramId).toBe('12345');
+    expect(byId[0]!.telegramId).toBe('12345');
 
     const byName = await service.list(TENANT_ID, { q: 'marta' });
     expect(byName).toHaveLength(1);
-    expect(byName[0].name).toBe('Marta');
+    expect(byName[0]!.name).toBe('Marta');
 
     const byEmail = await service.list(TENANT_ID, { q: 'CARLOS@EX' });
     expect(byEmail).toHaveLength(1);
-    expect(byEmail[0].email).toBe('carlos@example.com');
+    expect(byEmail[0]!.email).toBe('carlos@example.com');
   });
 });
 

--- a/apps/api/tests/member-registration-service.test.ts
+++ b/apps/api/tests/member-registration-service.test.ts
@@ -86,11 +86,14 @@ function makeHarness(
     hash: vi.fn(async (plain: string) => `hashed:${plain}`),
   } as never;
 
+  // Los dobles sobre los que el test afirma NO se castean a `never` en su
+  // declaración: con `never` no se les puede leer ninguna propiedad. El cast
+  // se aplica donde se inyectan, que es el único sitio donde hace falta.
   const decision = {
     issueDecisionTokens: vi
       .fn()
       .mockResolvedValue({ approveToken: 'raw-approve', rejectToken: 'raw-reject' }),
-  } as never;
+  };
 
   const paymentFlags = {
     lookup: vi.fn().mockResolvedValue({ isDelinquent: false, name: null }),
@@ -105,7 +108,7 @@ function makeHarness(
   // El lookup de suscripción corre en background; por defecto no encuentra nada.
   const subscriptionLookup = {
     runAndStore: vi.fn().mockResolvedValue({ matches: [], failures: [] }),
-  } as never;
+  };
 
   const smtp = { send: vi.fn().mockResolvedValue({ ok: true }) };
   const smtpResolver = {
@@ -113,20 +116,20 @@ function makeHarness(
   } as never;
   const auditLog = { record: vi.fn().mockResolvedValue(undefined) };
   const events = { publish: vi.fn().mockResolvedValue(undefined) };
-  const logger = { warn: vi.fn(), log: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+  const logger = { warn: vi.fn(), log: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
   const service = new MemberRegistrationService(
     prisma,
     passwords,
-    decision,
+    decision as never,
     paymentFlags,
     settings,
-    subscriptionLookup,
+    subscriptionLookup as never,
     smtp as never,
     smtpResolver,
     auditLog as never,
     events as never,
-    logger,
+    logger as never,
   );
 
   return {
@@ -162,7 +165,7 @@ describe('MemberRegistrationService.createPending', () => {
     expect(result).toEqual({ userId: 'new-user', created: true, status: 'PENDING' });
 
     // El create persiste status PENDING + telegramId + telegramInGroup (true → boolean true).
-    const createArg = h.txUser.create.mock.calls[0][0].data;
+    const createArg = h.txUser.create.mock.calls[0]![0].data;
     expect(createArg.status).toBe('PENDING');
     expect(createArg.telegramId).toBe('99887766');
     expect(createArg.telegramInGroup).toBe(true);
@@ -179,7 +182,7 @@ describe('MemberRegistrationService.createPending', () => {
     const result = await h.service.createPending(TENANT_ID, input, WEB_BASE_URL, CTX);
 
     expect(result).toEqual({ userId: 'new-user', created: true, status: 'PENDING' });
-    const createArg = h.txUser.create.mock.calls[0][0].data;
+    const createArg = h.txUser.create.mock.calls[0]![0].data;
     expect(createArg.telegramId).toBeNull();
     expect(createArg.telegramInGroup).toBeNull();
 
@@ -217,7 +220,7 @@ describe('MemberRegistrationService.createPending', () => {
     expect(h.decision.issueDecisionTokens).toHaveBeenCalledWith('tenant-1', 'new-user', CTX);
 
     // Email enviado al aprobador (destinatario del env).
-    const [, message] = h.smtp.send.mock.calls[0];
+    const [, message] = h.smtp.send.mock.calls[0]!;
     expect(message.to).toBe('aprobador@example.com');
     // Los enlaces firmados van embebidos en el cuerpo.
     expect(message.text).toContain('raw-approve');
@@ -230,7 +233,7 @@ describe('MemberRegistrationService.createPending', () => {
     await h.service.createPending(TENANT_ID, BASE_INPUT, WEB_BASE_URL, CTX);
 
     expect(h.auditLog.record).toHaveBeenCalledTimes(1);
-    const entry = h.auditLog.record.mock.calls[0][0];
+    const entry = h.auditLog.record.mock.calls[0]![0];
     expect(entry.action).toBe('member.inscription.created');
     expect(entry.tenantId).toBe('tenant-1');
     expect(entry.actorId).toBe('new-user');

--- a/apps/api/tests/mfa-policy.controller.test.ts
+++ b/apps/api/tests/mfa-policy.controller.test.ts
@@ -151,7 +151,7 @@ describe('MfaPolicyController · gate feat:mfa.enforcement (A.1)', () => {
         gracePeriodDays: 7,
       });
       expect(recordSpy).toHaveBeenCalledTimes(1);
-      const entry = recordSpy.mock.calls[0][0];
+      const entry = recordSpy.mock.calls[0]![0];
       expect(entry.action).toBe('auth.mfa_policy.updated');
       expect(entry.tenantId).toBe('tenant-1');
       expect(entry.actorId).toBe('user-1');
@@ -175,7 +175,7 @@ describe('MfaPolicyController · gate feat:mfa.enforcement (A.1)', () => {
         gracePeriodDays: 3,
       });
       expect(recordSpy).toHaveBeenCalledTimes(2);
-      const entry2 = recordSpy.mock.calls[1][0];
+      const entry2 = recordSpy.mock.calls[1]![0];
       expect(entry2.metadata.previous).toEqual({
         requiredForAll: true,
         gracePeriodDays: 30,

--- a/apps/api/tests/notification-hub.service.test.ts
+++ b/apps/api/tests/notification-hub.service.test.ts
@@ -76,7 +76,7 @@ function makeFakePrisma(users: UserRow[] = [], prefs: PrefRow[] = []) {
           failedAt: null,
           failureReason: null,
           createdAt: new Date('2026-06-03T10:00:00.000Z'),
-          ...(args.data as NotificationRow),
+          ...args.data,
         };
         rows.push(row);
         return row;
@@ -100,7 +100,7 @@ function makeFakePrisma(users: UserRow[] = [], prefs: PrefRow[] = []) {
       // Stub: el render usa este lookup para overrides per-tenant. En
       // estos tests no hay overrides — devolvemos null y dejamos que
       // caiga al template hardcoded del producto.
-      async findUnique(): Promise<null> {
+      async findUnique(_args: unknown): Promise<null> {
         return null;
       },
     },
@@ -149,7 +149,7 @@ describe('PrismaNotificationHubService', () => {
       });
 
       expect(prisma._rows).toHaveLength(1);
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.channel).toBe('IN_APP');
       expect(n.sentAt).toBeInstanceOf(Date);
       expect(n.subject).toBe('Te matriculaste en NodeJS Avanzado');
@@ -168,7 +168,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'TS', number: 'LS-2026-000001' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.sentAt).toBeNull();
       expect(n.failedAt).toBeInstanceOf(Date);
       expect(n.failureReason).toBe('smtp_not_configured');
@@ -187,7 +187,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'X' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.failureReason).toBe('webhook_adapter_not_implemented');
     });
 
@@ -202,7 +202,7 @@ describe('PrismaNotificationHubService', () => {
         to: 'u1',
         variables: { foo: 'bar' },
       });
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.subject).toBe('inexistente.template');
       expect(n.body).toContain('"foo":"bar"');
     });
@@ -224,7 +224,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'A' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.sentAt).toBeNull();
       expect(n.failedAt).toBeInstanceOf(Date);
       expect(n.failureReason).toBe('smtp_not_configured');
@@ -251,7 +251,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'A' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.failureReason?.startsWith('smtp_config_invalid:')).toBe(true);
     });
 
@@ -274,7 +274,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'A' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.failureReason).toBe('recipient_email_not_found');
     });
 
@@ -298,7 +298,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'TS', number: 'LS-1' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.sentAt).toBeInstanceOf(Date);
       expect(n.failedAt).toBeNull();
       expect(smtp.send).toHaveBeenCalledWith(
@@ -334,7 +334,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'A' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.sentAt).toBeNull();
       expect(n.failureReason).toContain('smtp_send_failed');
       expect(n.failureReason).toContain('connection refused');
@@ -365,7 +365,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'NodeJS' },
       });
 
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(realtime.publishInApp).toHaveBeenCalledTimes(1);
       expect(realtime.publishInApp).toHaveBeenCalledWith(
         't1',
@@ -601,7 +601,7 @@ describe('PrismaNotificationHubService', () => {
         to: 'u1',
         variables: { authorName: 'AutorEjemplo', commentId: 'c1', postId: null, handle: 'ana' },
       });
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.body).toContain('AutorEjemplo te mencionó en un comentario');
       expect(n.body).not.toContain('{{');
     });
@@ -617,7 +617,7 @@ describe('PrismaNotificationHubService', () => {
         to: 'u1',
         variables: { authorName: 'Ana', commentId: null, postId: 'p1', handle: 'ana' },
       });
-      const [n] = prisma._rows;
+      const n = prisma._rows[0]!;
       expect(n.body).toContain('Ana te mencionó en un post');
       expect(n.body).not.toContain('comentario');
       expect(n.body).not.toContain('{{');
@@ -650,27 +650,27 @@ describe('PrismaNotificationHubService', () => {
       const n = await sendWithoutLocale([
         { id: 'u1', tenantId: 't1', email: 'a@example.com', locale: 'en-US' },
       ]);
-      expect(n.subject).toBe('You enrolled in NodeJS');
-      expect(n.body).toContain(EN_ENROLLMENT);
+      expect(n!.subject).toBe('You enrolled in NodeJS');
+      expect(n!.body).toContain(EN_ENROLLMENT);
     });
 
     it('el usuario en es-ES sigue recibiendo el copy español', async () => {
       const n = await sendWithoutLocale([
         { id: 'u1', tenantId: 't1', email: 'a@example.com', locale: 'es-ES' },
       ]);
-      expect(n.body).toContain(ES_ENROLLMENT);
+      expect(n!.body).toContain(ES_ENROLLMENT);
     });
 
     it('degradado (a): destinatario inexistente → es-ES, sin romper el envío', async () => {
       const n = await sendWithoutLocale([]);
-      expect(n.body).toContain(ES_ENROLLMENT);
+      expect(n!.body).toContain(ES_ENROLLMENT);
     });
 
     it('degradado (a): destinatario de otro tenant → es-ES', async () => {
       const n = await sendWithoutLocale([
         { id: 'u1', tenantId: 'OTRO', email: 'a@example.com', locale: 'en-US' },
       ]);
-      expect(n.body).toContain(ES_ENROLLMENT);
+      expect(n!.body).toContain(ES_ENROLLMENT);
     });
 
     it('degradado (a): si el lookup lanza, el envío continúa en es-ES', async () => {
@@ -686,7 +686,7 @@ describe('PrismaNotificationHubService', () => {
           variables: { course: 'NodeJS' },
         }),
       ).resolves.toBeUndefined();
-      expect(prisma._rows[0].body).toContain(ES_ENROLLMENT);
+      expect(prisma._rows[0]!.body).toContain(ES_ENROLLMENT);
     });
 
     it('degradado (b): usuario con locale vacío o en blanco → es-ES', async () => {
@@ -694,7 +694,7 @@ describe('PrismaNotificationHubService', () => {
         const n = await sendWithoutLocale([
           { id: 'u1', tenantId: 't1', email: 'a@example.com', locale },
         ]);
-        expect(n.body, `locale=${JSON.stringify(locale)}`).toContain(ES_ENROLLMENT);
+        expect(n!.body, `locale=${JSON.stringify(locale)}`).toContain(ES_ENROLLMENT);
       }
     });
 
@@ -702,8 +702,8 @@ describe('PrismaNotificationHubService', () => {
       const n = await sendWithoutLocale([
         { id: 'u1', tenantId: 't1', email: 'a@example.com', locale: 'pt-BR' },
       ]);
-      expect(n.body).toContain(ES_ENROLLMENT);
-      expect(n.body).not.toContain('{{');
+      expect(n!.body).toContain(ES_ENROLLMENT);
+      expect(n!.body).not.toContain('{{');
     });
 
     it('el locale explícito del caller manda sobre el del usuario', async () => {
@@ -719,7 +719,7 @@ describe('PrismaNotificationHubService', () => {
         to: 'u1',
         variables: { course: 'NodeJS' },
       });
-      expect(prisma._rows[0].body).toContain(ES_ENROLLMENT);
+      expect(prisma._rows[0]!.body).toContain(ES_ENROLLMENT);
     });
 
     it('con locale explícito NO consulta al usuario (sin query de más)', async () => {
@@ -760,7 +760,7 @@ describe('PrismaNotificationHubService', () => {
         variables: { course: 'NodeJS' },
       });
       expect(seen).toEqual(['en-US']);
-      expect(prisma._rows[0].subject).toBe('Custom NodeJS');
+      expect(prisma._rows[0]!.subject).toBe('Custom NodeJS');
     });
   });
 });

--- a/apps/api/tests/notification-realtime.publisher.test.ts
+++ b/apps/api/tests/notification-realtime.publisher.test.ts
@@ -9,7 +9,7 @@ const noopLogger = { warn: vi.fn(), log: vi.fn(), error: vi.fn() } as never;
 
 describe('NotificationRealtimePublisher', () => {
   it('publica en el canal correcto con el payload serializado', async () => {
-    const publish = vi.fn(async () => 1);
+    const publish = vi.fn(async (_channel: string, _message: string) => 1);
     const redis: RealtimePublisherRedis = { publish };
     const pub = new NotificationRealtimePublisher(redis, noopLogger);
 
@@ -22,7 +22,7 @@ describe('NotificationRealtimePublisher', () => {
     });
 
     expect(publish).toHaveBeenCalledTimes(1);
-    const [channel, message] = publish.mock.calls[0];
+    const [channel, message] = publish.mock.calls[0]!;
     expect(channel).toBe(channelFor('t1', 'u1'));
     expect(channel).toBe('didacta:rt:notif:t1:u1');
     const parsed = JSON.parse(message as string);
@@ -35,7 +35,7 @@ describe('NotificationRealtimePublisher', () => {
   });
 
   it('serializa createdAt string tal cual', async () => {
-    const publish = vi.fn(async () => 1);
+    const publish = vi.fn(async (_channel: string, _message: string) => 1);
     const pub = new NotificationRealtimePublisher({ publish }, noopLogger);
     await pub.publishInApp('t1', 'u1', {
       id: 'n-2',
@@ -43,7 +43,7 @@ describe('NotificationRealtimePublisher', () => {
       subject: null,
       createdAt: '2026-06-03T11:00:00.000Z',
     });
-    const parsed = JSON.parse(publish.mock.calls[0][1] as string);
+    const parsed = JSON.parse(publish.mock.calls[0]![1] as string);
     expect(parsed.createdAt).toBe('2026-06-03T11:00:00.000Z');
     expect(parsed.subject).toBeNull();
   });

--- a/apps/api/tests/notification-stream.service.test.ts
+++ b/apps/api/tests/notification-stream.service.test.ts
@@ -52,7 +52,7 @@ describe('NotificationStreamService', () => {
     const notifB = b.filter((e) => e.type === 'notification');
     expect(notifA).toHaveLength(1);
     expect(notifB).toHaveLength(1);
-    expect((notifA[0].data as { id: string }).id).toBe('n-1');
+    expect((notifA[0]!.data as { id: string }).id).toBe('n-1');
 
     subA.unsubscribe();
     subB.unsubscribe();

--- a/apps/api/tests/notification-templates.controller.test.ts
+++ b/apps/api/tests/notification-templates.controller.test.ts
@@ -15,6 +15,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'admin@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/oidc-admin.controller.test.ts
+++ b/apps/api/tests/oidc-admin.controller.test.ts
@@ -141,8 +141,14 @@ describe('OidcAdminController.getConfig', () => {
     );
     const result = await ctrl.getConfig(adminUser());
     expect(result.exists).toBe(true);
-    expect((result as { config: Record<string, unknown> }).config['hasSecret']).toBe(true);
-    expect((result as { config: Record<string, unknown> }).config['clientSecret']).toBeUndefined();
+    // `getConfig` devuelve una unión (rama sin config / rama con config). Se
+    // estrecha con `in` en vez de castear: el cast a `{ config: … }` no solapa
+    // con la otra rama y ocultaba que el tipo del resultado había cambiado.
+    if (!('config' in result) || !result.config) {
+      throw new Error('esperaba la rama exists:true con config');
+    }
+    expect(result.config.hasSecret).toBe(true);
+    expect(result.config).not.toHaveProperty('clientSecret');
   });
 });
 

--- a/apps/api/tests/oidc.service.test.ts
+++ b/apps/api/tests/oidc.service.test.ts
@@ -219,9 +219,14 @@ class TestOidcService extends OidcService {
   public issuerStub: IssuerStub | null = null;
   public clientStub: ClientStub | null = null;
   public discoveryFails: Error | null = null;
+  // vitest 2 cambió el genérico de `vi.fn<[Args], Ret>` a `vi.fn<(…) => Ret>`.
+  // Con la forma vieja los parámetros llegaban implícitamente `any` y
+  // `mock.calls[0][1]` no tenía tipo.
   public buildSpy = vi.fn<
-    [unknown, { scope: string; state: string; nonce: string; codeChallenge: string }],
-    string
+    (
+      c: unknown,
+      p: { scope: string; state: string; nonce: string; codeChallenge: string },
+    ) => string
   >(
     (_c, p) =>
       `https://idp.example.com/authorize?state=${p.state}&nonce=${p.nonce}&scope=${encodeURIComponent(p.scope)}`,
@@ -245,19 +250,19 @@ class TestOidcService extends OidcService {
       }>)
     | null = null;
 
-  protected async discoverIssuer(): Promise<{ issuer: unknown; client: unknown }> {
+  protected override async discoverIssuer(): Promise<{ issuer: unknown; client: unknown }> {
     if (this.discoveryFails) throw this.discoveryFails;
     return { issuer: this.issuerStub, client: this.clientStub };
   }
 
-  protected buildAuthorizationUrl(
+  protected override buildAuthorizationUrl(
     client: unknown,
     params: { scope: string; state: string; nonce: string; codeChallenge: string },
   ): string {
     return this.buildSpy(client, params);
   }
 
-  protected async exchangeCode(
+  protected override async exchangeCode(
     _client: unknown,
     params: { code: string; state: string; nonce: string; codeVerifier: string },
   ): Promise<{
@@ -401,7 +406,7 @@ describe('OidcService.getSafeConfig', () => {
     const safe = await svc.getSafeConfig(tenantId);
     expect(safe).toBeTruthy();
     expect(safe!.hasSecret).toBe(true);
-    expect((safe as Record<string, unknown>)['clientSecret']).toBeUndefined();
+    expect(safe).not.toHaveProperty('clientSecret');
     expect(safe!.clientId).toBe(CLIENT_ID);
     expect(safe!.issuer).toBe(ISSUER);
     expect(safe!.redirectUri).toContain('/api/v1/auth/oidc/callback');

--- a/apps/api/tests/password-reset.test.ts
+++ b/apps/api/tests/password-reset.test.ts
@@ -242,7 +242,7 @@ describe('PasswordResetService.request', () => {
     expect(result?.rawToken).toMatch(/^[a-f0-9]{64}$/);
     expect(prisma.tokens).toHaveLength(1);
     // El token persistido es el hash, no el raw.
-    expect(prisma.tokens[0].tokenHash).toBe(hash(result!.rawToken));
+    expect(prisma.tokens[0]!.tokenHash).toBe(hash(result!.rawToken));
   });
 
   it('expone el idioma del DESTINATARIO para que el email salga en su lengua', async () => {
@@ -292,15 +292,15 @@ describe('PasswordResetService.request', () => {
     expect(b).not.toBeNull();
     // Ambos rows existen, el primero tiene usedAt seteado por la invalidación.
     expect(prisma.tokens).toHaveLength(2);
-    expect(prisma.tokens[0].usedAt).not.toBeNull();
-    expect(prisma.tokens[1].usedAt).toBeNull();
+    expect(prisma.tokens[0]!.usedAt).not.toBeNull();
+    expect(prisma.tokens[1]!.usedAt).toBeNull();
   });
 
   it('expira en 60 minutos por default', async () => {
     const { service, prisma } = makeService();
     const before = Date.now();
     await service.request({ tenantSlug: 'demo', email: 'ana@example.com' });
-    const expiresAt = prisma.tokens[0].expiresAt.getTime();
+    const expiresAt = prisma.tokens[0]!.expiresAt.getTime();
     expect(expiresAt - before).toBeGreaterThanOrEqual(59 * 60_000);
     expect(expiresAt - before).toBeLessThanOrEqual(61 * 60_000);
   });
@@ -383,8 +383,8 @@ describe('PasswordResetService.reset', () => {
     const result = await service.request({ tenantSlug: 'demo', email: 'ana@example.com' });
     expect(result).not.toBeNull();
     await service.reset(result!.rawToken, 'NuevaPasswordSegura123');
-    expect(prisma.users[0].passwordHash).toBe('argon2:NuevaPasswordSegura123');
-    expect(prisma.tokens[0].usedAt).not.toBeNull();
+    expect(prisma.users[0]!.passwordHash).toBe('argon2:NuevaPasswordSegura123');
+    expect(prisma.tokens[0]!.usedAt).not.toBeNull();
   });
 
   it('rechaza si el token no existe', async () => {
@@ -407,7 +407,7 @@ describe('PasswordResetService.reset', () => {
     const { service, prisma } = makeService();
     const result = await service.request({ tenantSlug: 'demo', email: 'ana@example.com' });
     // Forzamos expiración manualmente.
-    prisma.tokens[0].expiresAt = new Date(Date.now() - 1000);
+    prisma.tokens[0]!.expiresAt = new Date(Date.now() - 1000);
     await expect(service.reset(result!.rawToken, 'NuevaPasswordSegura123')).rejects.toBeInstanceOf(
       UnauthorizedException,
     );
@@ -468,7 +468,7 @@ describe('PasswordResetService.reset', () => {
     const { service, prisma } = makeService();
     const result = await service.request({ tenantSlug: 'demo', email: 'ana@example.com' });
     await service.reset(result!.rawToken, 'NuevaPasswordSegura123');
-    expect(prisma.users[0].status).toBe('ACTIVE');
+    expect(prisma.users[0]!.status).toBe('ACTIVE');
   });
 });
 

--- a/apps/api/tests/persistent-event-bus.test.ts
+++ b/apps/api/tests/persistent-event-bus.test.ts
@@ -168,8 +168,8 @@ describe('PersistentEventBus', () => {
 
     expect(handler).toHaveBeenCalledOnce();
     const row = [...prisma._rows.values()][0];
-    expect(row.processedAt).toBeInstanceOf(Date);
-    expect(row.processingAttempts).toBe(0);
+    expect(row!.processedAt).toBeInstanceOf(Date);
+    expect(row!.processingAttempts).toBe(0);
   });
 
   it('abre el contexto ALS del tenant del evento alrededor de los handlers (RLS F1)', async () => {
@@ -267,7 +267,7 @@ describe('PersistentEventBus', () => {
       const row = [...prisma._rows.values()][0]!;
       expect(row.lastError).toBe('NO_HANDLER: billing.order.completed');
 
-      const bridge = vi.fn(async () => {});
+      const bridge = vi.fn(async (_event: unknown) => {});
       bus.subscribe('billing.order.completed', bridge);
 
       const result = await bus.replayUndelivered();
@@ -285,7 +285,7 @@ describe('PersistentEventBus', () => {
     it('no re-entrega dos veces: tras el replay la fila ya no es elegible', async () => {
       const bus = new PersistentEventBus(prisma as never, silentLogger);
       await bus.publish(makeEvent('billing.order.completed', {}, 'idem-once'));
-      const bridge = vi.fn(async () => {});
+      const bridge = vi.fn(async (_event: unknown) => {});
       bus.subscribe('billing.order.completed', bridge);
 
       await bus.replayUndelivered();
@@ -315,7 +315,7 @@ describe('PersistentEventBus', () => {
       // no puede desencadenar una re-entrega masiva de historia.
       row.createdAt = new Date(Date.now() - NO_HANDLER_REPLAY_WINDOW_MS - 60_000);
 
-      const bridge = vi.fn(async () => {});
+      const bridge = vi.fn(async (_event: unknown) => {});
       bus.subscribe('billing.order.completed', bridge);
 
       const result = await bus.replayUndelivered();
@@ -352,9 +352,9 @@ describe('PersistentEventBus', () => {
     await bus.publish(makeEvent('learning.course.completed'));
 
     const row = [...prisma._rows.values()][0];
-    expect(row.processedAt).toBeNull();
-    expect(row.processingAttempts).toBe(1);
-    expect(row.lastError).toContain('boom');
+    expect(row!.processedAt).toBeNull();
+    expect(row!.processingAttempts).toBe(1);
+    expect(row!.lastError).toContain('boom');
   });
 
   it('upsert por idempotencyKey: no duplica si llega el mismo evento dos veces', async () => {
@@ -390,7 +390,7 @@ describe('PersistentEventBus', () => {
     expect(result.processed).toBe(1);
     expect(ok).toHaveBeenCalledOnce();
     const row = [...prisma._rows.values()][0];
-    expect(row.processedAt).toBeInstanceOf(Date);
+    expect(row!.processedAt).toBeInstanceOf(Date);
   });
 
   describe('con OutboxDispatcher async (BullMQ)', () => {
@@ -405,7 +405,7 @@ describe('PersistentEventBus', () => {
       expect(handler).not.toHaveBeenCalled(); // delegó a la queue
       expect(dispatcher.enqueued).toHaveLength(1);
       const row = [...prisma._rows.values()][0];
-      expect(row.processedAt).toBeNull(); // queda pendiente hasta que el worker lo procese
+      expect(row!.processedAt).toBeNull(); // queda pendiente hasta que el worker lo procese
     });
 
     it('dispatcher.enabled=false hace fallback a in-process', async () => {
@@ -436,7 +436,7 @@ describe('PersistentEventBus', () => {
 
       expect(handler).toHaveBeenCalledOnce();
       const row = [...prisma._rows.values()][0];
-      expect(row.processedAt).toBeInstanceOf(Date);
+      expect(row!.processedAt).toBeInstanceOf(Date);
     });
 
     it('processOutboxId ejecuta los handlers para una fila pendiente', async () => {
@@ -446,7 +446,7 @@ describe('PersistentEventBus', () => {
       bus.subscribe('learning.course.completed', handler);
 
       await bus.publish(makeEvent('learning.course.completed', {}, 'idem-proc'));
-      const [row] = [...prisma._rows.values()];
+      const row = [...prisma._rows.values()][0]!;
       expect(row.processedAt).toBeNull();
 
       // Simulamos al worker BullMQ levantando el job
@@ -463,7 +463,7 @@ describe('PersistentEventBus', () => {
       bus.subscribe('learning.course.completed', handler);
 
       await bus.publish(makeEvent('learning.course.completed', {}, 'idem-i'));
-      const [row] = [...prisma._rows.values()];
+      const row = [...prisma._rows.values()][0]!;
       await bus.processOutboxId(row.id);
       expect(handler).toHaveBeenCalledTimes(1);
 
@@ -479,7 +479,7 @@ describe('PersistentEventBus', () => {
       });
 
       await bus.publish(makeEvent('learning.course.completed', {}, 'idem-throw'));
-      const [row] = [...prisma._rows.values()];
+      const row = [...prisma._rows.values()][0]!;
 
       await expect(bus.processOutboxId(row.id)).rejects.toThrow(/outbox dispatch falló/);
       expect(row.processedAt).toBeNull();
@@ -491,7 +491,7 @@ describe('PersistentEventBus', () => {
       const bus = new PersistentEventBus(prisma as never, silentLogger, dispatcher);
 
       await bus.publish(makeEvent('nadie.escucha', {}, 'idem-nohandler-q'));
-      const [row] = [...prisma._rows.values()];
+      const row = [...prisma._rows.values()][0]!;
 
       // Lanzar haría que BullMQ reintentara 5 veces con backoff CADA evento sin
       // consumidor. Reintentar contra un set de handlers vacío no arregla nada:
@@ -514,7 +514,7 @@ describe('PersistentEventBus', () => {
         throw new Error('first fail');
       });
       await bus.publish(makeEvent('learning.course.completed', {}, 'idem-rec-q'));
-      const [row] = [...prisma._rows.values()];
+      const row = [...prisma._rows.values()][0]!;
       expect(row.processedAt).toBeNull();
 
       // Ahora Redis vuelve, recoverPending debería reencolar (no procesar local)
@@ -536,7 +536,7 @@ describe('PersistentEventBus', () => {
 
       dispatcher.enabled = false;
       await bus.publish(makeEvent('learning.course.completed', {}, 'idem-dedup'));
-      const [row] = [...prisma._rows.values()];
+      const row = [...prisma._rows.values()][0]!;
       row.processedAt = null; // pendiente, como si el despacho original no hubiera ido
 
       dispatcher.enabled = true;

--- a/apps/api/tests/prisma-instance-config.service.test.ts
+++ b/apps/api/tests/prisma-instance-config.service.test.ts
@@ -73,13 +73,14 @@ function makeFakePrisma() {
           : {}),
       };
       if (idx >= 0) {
-        rows[idx] = { ...rows[idx], ...normalizedUpdate, updatedAt: now };
+        rows[idx] = { ...rows[idx]!, ...normalizedUpdate, updatedAt: now };
         return rows[idx];
       }
+      // scope/key NO se ponen aquí: `args.create` los trae siempre (su tipo
+      // los declara obligatorios) y el spread de abajo los pisaba, así que
+      // ponerlos era código muerto.
       const row: SettingRow = {
         id: String(nextId++),
-        scope,
-        key,
         isSecret: false,
         valueJson: null,
         valueCipher: null,
@@ -138,10 +139,10 @@ describe('PrismaInstanceConfigService', () => {
       const jwt = 'eyJhbGciOiJFUzI1NiJ9.super-secreto.firma';
       await svc.set('license', 'key', jwt, { isSecret: true });
       const row = prisma._rows[0];
-      expect(row.isSecret).toBe(true);
-      expect(row.valueJson).toBeNull();
-      expect(row.valueCipher).not.toBeNull();
-      expect(row.valueCipher!.toString('utf8')).not.toContain('super-secreto');
+      expect(row!.isSecret).toBe(true);
+      expect(row!.valueJson).toBeNull();
+      expect(row!.valueCipher).not.toBeNull();
+      expect(row!.valueCipher!.toString('utf8')).not.toContain('super-secreto');
     });
 
     it('get descifra transparentemente', async () => {
@@ -176,7 +177,7 @@ describe('PrismaInstanceConfigService', () => {
       await svc.set('telemetry', 'disabled', true);
       const onlyLicense = await svc.list('license');
       expect(onlyLicense).toHaveLength(1);
-      expect(onlyLicense[0].scope).toBe('license');
+      expect(onlyLicense[0]!.scope).toBe('license');
     });
 
     it('has devuelve true/false correctamente', async () => {

--- a/apps/api/tests/prisma-tenant-config.service.test.ts
+++ b/apps/api/tests/prisma-tenant-config.service.test.ts
@@ -91,14 +91,14 @@ function makeFakePrisma() {
           : {}),
       };
       if (idx >= 0) {
-        rows[idx] = { ...rows[idx], ...normalizedUpdate, updatedAt: now };
+        rows[idx] = { ...rows[idx]!, ...normalizedUpdate, updatedAt: now };
         return rows[idx];
       }
+      // tenantId/moduleName/key NO se ponen aquí: `args.create` los trae
+      // siempre (su tipo los declara obligatorios) y el spread de abajo los
+      // pisaba, así que ponerlos era código muerto.
       const row: SettingRow = {
         id: String(nextId++),
-        tenantId,
-        moduleName,
-        key,
         isSecret: false,
         valueJson: null,
         valueCipher: null,
@@ -171,11 +171,11 @@ describe('PrismaTenantConfigService', () => {
     it('persiste en valueJson y NO en valueCipher cuando isSecret=false', async () => {
       await svc.set(TENANT_A, 'mod', 'k', { foo: 'bar' });
       const row = prisma._rows[0];
-      expect(row.isSecret).toBe(false);
-      expect(row.valueJson).toEqual({ foo: 'bar' });
-      expect(row.valueCipher).toBeNull();
-      expect(row.valueIv).toBeNull();
-      expect(row.valueTag).toBeNull();
+      expect(row!.isSecret).toBe(false);
+      expect(row!.valueJson).toEqual({ foo: 'bar' });
+      expect(row!.valueCipher).toBeNull();
+      expect(row!.valueIv).toBeNull();
+      expect(row!.valueTag).toBeNull();
     });
 
     it('un set posterior overridea el anterior', async () => {
@@ -198,13 +198,13 @@ describe('PrismaTenantConfigService', () => {
         },
       );
       const row = prisma._rows[0];
-      expect(row.isSecret).toBe(true);
-      expect(row.valueJson).toBeNull();
-      expect(row.valueCipher).not.toBeNull();
-      expect(row.valueIv).toHaveLength(12);
-      expect(row.valueTag).toHaveLength(16);
+      expect(row!.isSecret).toBe(true);
+      expect(row!.valueJson).toBeNull();
+      expect(row!.valueCipher).not.toBeNull();
+      expect(row!.valueIv).toHaveLength(12);
+      expect(row!.valueTag).toHaveLength(16);
       // El ciphertext NO debe contener el plaintext en claro
-      expect(row.valueCipher!.toString('utf8')).not.toContain('p4ss!');
+      expect(row!.valueCipher!.toString('utf8')).not.toContain('p4ss!');
     });
 
     it('get descifra transparentemente', async () => {
@@ -217,20 +217,20 @@ describe('PrismaTenantConfigService', () => {
       await svc.set(TENANT_A, 'mod', 'k', 'old-secret', { isSecret: true });
       await svc.set(TENANT_A, 'mod', 'k', 'now-public', { isSecret: false });
       const row = prisma._rows[0];
-      expect(row.isSecret).toBe(false);
-      expect(row.valueJson).toBe('now-public');
-      expect(row.valueCipher).toBeNull();
-      expect(row.valueIv).toBeNull();
-      expect(row.valueTag).toBeNull();
+      expect(row!.isSecret).toBe(false);
+      expect(row!.valueJson).toBe('now-public');
+      expect(row!.valueCipher).toBeNull();
+      expect(row!.valueIv).toBeNull();
+      expect(row!.valueTag).toBeNull();
     });
 
     it('cambiar de no-secret a secret limpia valueJson', async () => {
       await svc.set(TENANT_A, 'mod', 'k', 'public');
       await svc.set(TENANT_A, 'mod', 'k', 'now-secret', { isSecret: true });
       const row = prisma._rows[0];
-      expect(row.isSecret).toBe(true);
-      expect(row.valueJson).toBeNull();
-      expect(row.valueCipher).not.toBeNull();
+      expect(row!.isSecret).toBe(true);
+      expect(row!.valueJson).toBeNull();
+      expect(row!.valueCipher).not.toBeNull();
     });
   });
 
@@ -246,9 +246,9 @@ describe('PrismaTenantConfigService', () => {
       const a = await svc.list(TENANT_A);
       const b = await svc.list(TENANT_B);
       expect(a).toHaveLength(1);
-      expect(a[0].key).toBe('k1');
+      expect(a[0]!.key).toBe('k1');
       expect(b).toHaveLength(1);
-      expect(b[0].key).toBe('k2');
+      expect(b[0]!.key).toBe('k2');
     });
   });
 
@@ -270,7 +270,7 @@ describe('PrismaTenantConfigService', () => {
       await svc.set(TENANT_A, 'zoom', 'k2', 'v2');
       const onlyNotif = await svc.list(TENANT_A, 'notifications');
       expect(onlyNotif).toHaveLength(1);
-      expect(onlyNotif[0].moduleName).toBe('notifications');
+      expect(onlyNotif[0]!.moduleName).toBe('notifications');
     });
 
     it('has devuelve true/false correctamente', async () => {
@@ -325,7 +325,7 @@ describe('PrismaTenantConfigService', () => {
 
     it('audit metadata incluye flag isSecret', async () => {
       await svc.set(TENANT_A, 'mod', 'k', 'v', { isSecret: true });
-      expect(audit.entries[0].metadata).toMatchObject({ isSecret: true });
+      expect(audit.entries[0]!.metadata).toMatchObject({ isSecret: true });
     });
   });
 });

--- a/apps/api/tests/referrals-approval.worker.test.ts
+++ b/apps/api/tests/referrals-approval.worker.test.ts
@@ -10,9 +10,9 @@ const noopLogger = {
 
 function buildRegistryStub(opts: { approvedByTenant?: Record<string, number> } = {}) {
   const approvedByTenant = opts.approvedByTenant ?? {};
-  const findTenantsWithDueCommissions = vi.fn(async () => Object.keys(approvedByTenant));
+  const findTenantsWithDueCommissions = vi.fn(async (_now: Date) => Object.keys(approvedByTenant));
   const approveDueCommissionsForTenant = vi.fn(
-    async (tenantId: string) => approvedByTenant[tenantId] ?? 0,
+    async (tenantId: string, _now: Date) => approvedByTenant[tenantId] ?? 0,
   );
   const registry = {
     getReferralsService: vi.fn(() => ({
@@ -53,7 +53,7 @@ describe('ReferralsApprovalWorker.triggerNow (degraded mode, sin Redis)', () => 
 
   it('el procesado por tenant corre bajo el contexto ALS de ESE tenant (patrón F3)', async () => {
     const seenContexts: Array<string | undefined> = [];
-    const findTenantsWithDueCommissions = vi.fn(async () => ['t1', 't2']);
+    const findTenantsWithDueCommissions = vi.fn(async (_now: Date) => ['t1', 't2']);
     const approveDueCommissionsForTenant = vi.fn(async () => {
       seenContexts.push(tenantContextStorage.getStore()?.tenantId);
       return 0;

--- a/apps/api/tests/registry.controller.test.ts
+++ b/apps/api/tests/registry.controller.test.ts
@@ -17,6 +17,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['tenant_admin'],
     email: 'a@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/rls-enforcement.extension.test.ts
+++ b/apps/api/tests/rls-enforcement.extension.test.ts
@@ -207,8 +207,10 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
 
   it('forma batch con contexto sin gucApplied: antepone el set_config y descarta su resultado', async () => {
     const { runWithGucApplied, wasOpened } = makeRunner();
-    const original = vi.fn(async (members: unknown[]) =>
-      members.map((_, i) => (i === 0 ? 'setcfg' : `row-${i}`)),
+    // `runCallerTransaction.original` es `(...args: unknown[]) => Promise<unknown>`:
+    // un doble con par谩metros posicionales no es asignable a esa firma.
+    const original = vi.fn(async (...args: unknown[]) =>
+      (args[0] as unknown[]).map((_, i) => (i === 0 ? 'setcfg' : `row-${i}`)),
     );
     const out = await runCallerTransaction({
       original,
@@ -234,7 +236,9 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
         return Promise.resolve();
       },
     };
-    const original = vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx));
+    const original = vi.fn(async (...args: unknown[]) =>
+      (args[0] as (t: typeof tx) => Promise<unknown>)(tx),
+    );
     const userCallback = vi.fn(async () => 'result');
     const out = await runCallerTransaction({
       original,
@@ -251,7 +255,7 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
 
   it('con gucApplied: no inyecta nada, solo marca el scope de transacci贸n', async () => {
     const { runWithGucApplied, wasOpened } = makeRunner();
-    const original = vi.fn(async () => 'passthrough');
+    const original = vi.fn(async (..._args: unknown[]) => 'passthrough');
     const inTxDuringCall = { seen: false };
     const out = await runCallerTransaction({
       original: async (...a: unknown[]) => {
@@ -271,7 +275,7 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
 
   it('sin contexto de tenant: passthrough con solo el marker de transacci贸n', async () => {
     const { runWithGucApplied, wasOpened } = makeRunner();
-    const original = vi.fn(async () => 'no-ctx');
+    const original = vi.fn(async (..._args: unknown[]) => 'no-ctx');
     const out = await runCallerTransaction({
       original,
       args: [['op']],
@@ -288,8 +292,8 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
   it('sancionado sin tenantId, forma batch: antepone SET LOCAL ROLE y descarta su resultado', async () => {
     const SET_ROLE = { __setRole: true };
     const makeSetRole = () => SET_ROLE;
-    const original = vi.fn(async (members: unknown[]) =>
-      members.map((_, i) => (i === 0 ? 'setrole' : `row-${i}`)),
+    const original = vi.fn(async (...args: unknown[]) =>
+      (args[0] as unknown[]).map((_, i) => (i === 0 ? 'setrole' : `row-${i}`)),
     );
     const out = await runCallerTransaction({
       original,
@@ -314,7 +318,9 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
         return Promise.resolve();
       },
     };
-    const original = vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx));
+    const original = vi.fn(async (...args: unknown[]) =>
+      (args[0] as (t: typeof tx) => Promise<unknown>)(tx),
+    );
     const userCallback = vi.fn(async () => 'result');
     const out = await runCallerTransaction({
       original,
@@ -332,7 +338,7 @@ describe('runCallerTransaction (inyecci贸n del GUC en $transaction del caller 鈥
 
   it('sancionado pero ya gucApplied: no inyecta el rol (ya hay GUC de tenant en la tx)', async () => {
     const makeSetRole = vi.fn(() => ({}));
-    const original = vi.fn(async () => 'passthrough');
+    const original = vi.fn(async (..._args: unknown[]) => 'passthrough');
     const out = await runCallerTransaction({
       original,
       args: [['op']],

--- a/apps/api/tests/saml.service.test.ts
+++ b/apps/api/tests/saml.service.test.ts
@@ -186,7 +186,7 @@ class TestSamlService extends SamlService {
   public parsedStub: ParsedSamlAssertion | null = null;
   public parseFails: Error | null = null;
 
-  protected buildProvider(): {
+  protected override buildProvider(): {
     getAuthorizeUrlAsync: ReturnType<typeof vi.fn>;
     validatePostResponseAsync: ReturnType<typeof vi.fn>;
     generateServiceProviderMetadata: ReturnType<typeof vi.fn>;
@@ -196,13 +196,13 @@ class TestSamlService extends SamlService {
     return this.providerStub;
   }
 
-  protected async validateAndParse(): Promise<ParsedSamlAssertion> {
+  protected override async validateAndParse(): Promise<ParsedSamlAssertion> {
     if (this.parseFails) throw this.parseFails;
     if (!this.parsedStub) throw new Error('parsedStub no configurado.');
     return this.parsedStub;
   }
 
-  protected inspectCertificate(pem: string): {
+  protected override inspectCertificate(pem: string): {
     subject?: string;
     notAfter?: string;
     signatureAlgorithm?: string;

--- a/apps/api/tests/secret-cipher.service.test.ts
+++ b/apps/api/tests/secret-cipher.service.test.ts
@@ -61,7 +61,7 @@ describe('SecretCipherService', () => {
       const cipher = new SecretCipherService(VALID_KEY);
       const payload = cipher.encrypt('importante');
       const tampered = { ...payload, cipher: Buffer.from(payload.cipher) };
-      tampered.cipher[0] ^= 0xff;
+      tampered.cipher[0] = tampered.cipher[0]! ^ 0xff;
       expect(() => cipher.decrypt(tampered)).toThrow();
     });
 
@@ -69,7 +69,7 @@ describe('SecretCipherService', () => {
       const cipher = new SecretCipherService(VALID_KEY);
       const payload = cipher.encrypt('importante');
       const tampered = { ...payload, tag: Buffer.from(payload.tag) };
-      tampered.tag[0] ^= 0xff;
+      tampered.tag[0] = tampered.tag[0]! ^ 0xff;
       expect(() => cipher.decrypt(tampered)).toThrow();
     });
 
@@ -77,7 +77,7 @@ describe('SecretCipherService', () => {
       const cipher = new SecretCipherService(VALID_KEY);
       const payload = cipher.encrypt('importante');
       const tampered = { ...payload, iv: Buffer.from(payload.iv) };
-      tampered.iv[0] ^= 0xff;
+      tampered.iv[0] = tampered.iv[0]! ^ 0xff;
       expect(() => cipher.decrypt(tampered)).toThrow();
     });
 

--- a/apps/api/tests/setup.service.test.ts
+++ b/apps/api/tests/setup.service.test.ts
@@ -178,7 +178,9 @@ function makeFakePrisma() {
     tenantModule: {
       createMany: vi.fn(async () => ({ count: 0 })),
     },
-    $transaction: async (cb: (tx: typeof client) => Promise<unknown>) => cb(client),
+    // El callback recibe el propio cliente; tiparlo como `typeof client` haría
+    // que `client` se refiriese a sí mismo en su propio inicializador (TS7022).
+    $transaction: async (cb: (tx: unknown) => Promise<unknown>) => cb(client),
   };
 
   return { state, client };

--- a/apps/api/tests/smtp-adapter.service.test.ts
+++ b/apps/api/tests/smtp-adapter.service.test.ts
@@ -102,7 +102,7 @@ describe('SmtpAdapterService', () => {
         { to: 'a@b.com', subject: 's', text: 't' },
         'Mal\r\nBcc: victim@x.com "raro"',
       );
-      const arg = sendMailMock.mock.calls[0][0] as { from: { name: string; address: string } };
+      const arg = sendMailMock.mock.calls[0]![0] as { from: { name: string; address: string } };
       expect(arg.from.name).not.toContain('\n');
       expect(arg.from.name).not.toContain('\r');
       expect(arg.from.name).not.toContain('"');

--- a/apps/api/tests/storage.controller.test.ts
+++ b/apps/api/tests/storage.controller.test.ts
@@ -20,6 +20,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-1',
     roles: ['formador'],
     email: 'foo@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/subscriptions-grace-expiration.worker.test.ts
+++ b/apps/api/tests/subscriptions-grace-expiration.worker.test.ts
@@ -12,9 +12,13 @@ function buildRegistryStub(
   opts: { initialized?: boolean; expiredByTenant?: Record<string, unknown[]> } = {},
 ) {
   const expiredByTenant = opts.expiredByTenant ?? {};
-  const findTenantsWithExpiredGrace = vi.fn(async () => Object.keys(expiredByTenant));
+  // Los parámetros se declaran aunque el doble no los use: el worker llama
+  // `findTenantsWithExpiredGrace(now)` y `expireGracePeriodsForTenant(tenantId, now)`.
+  // Sin declararlos, `mock.calls[0][0]` no existe para el typecheck y la
+  // aserción sobre el `now` propagado sería incomprobable.
+  const findTenantsWithExpiredGrace = vi.fn(async (_now: Date) => Object.keys(expiredByTenant));
   const expireGracePeriodsForTenant = vi.fn(
-    async (tenantId: string) => expiredByTenant[tenantId] ?? [],
+    async (tenantId: string, _now: Date) => expiredByTenant[tenantId] ?? [],
   );
   const service = { findTenantsWithExpiredGrace, expireGracePeriodsForTenant };
   const registry = {
@@ -24,7 +28,7 @@ function buildRegistryStub(
       }
       return service;
     }),
-  } as never;
+  };
   return { registry, service, findTenantsWithExpiredGrace, expireGracePeriodsForTenant };
 }
 
@@ -55,7 +59,7 @@ describe('SubscriptionsGraceExpirationWorker.triggerNow (degraded mode, sin Redi
         },
       });
 
-    const worker = new SubscriptionsGraceExpirationWorker(registry, noopLogger);
+    const worker = new SubscriptionsGraceExpirationWorker(registry as never, noopLogger);
 
     // Sin onApplicationBootstrap (no Redis). triggerNow debe degradar a in-process.
     await worker.triggerNow();
@@ -83,7 +87,7 @@ describe('SubscriptionsGraceExpirationWorker.triggerNow (degraded mode, sin Redi
       })),
     } as never;
 
-    const worker = new SubscriptionsGraceExpirationWorker(registry, noopLogger);
+    const worker = new SubscriptionsGraceExpirationWorker(registry as never, noopLogger);
     await worker.triggerNow();
 
     expect(seenContexts).toEqual(['t1', 't2']);
@@ -95,9 +99,9 @@ describe('SubscriptionsGraceExpirationWorker.triggerNow (degraded mode, sin Redi
       log: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as never;
+    };
 
-    const worker = new SubscriptionsGraceExpirationWorker(registry, logger);
+    const worker = new SubscriptionsGraceExpirationWorker(registry as never, logger as never);
 
     await expect(worker.triggerNow()).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalled();
@@ -117,7 +121,7 @@ describe('SubscriptionsGraceExpirationWorker.triggerNow (degraded mode, sin Redi
       })),
     } as never;
 
-    const worker = new SubscriptionsGraceExpirationWorker(registry, noopLogger);
+    const worker = new SubscriptionsGraceExpirationWorker(registry as never, noopLogger);
 
     await expect(worker.triggerNow()).rejects.toThrow('boom');
     expect(findTenantsWithExpiredGrace).toHaveBeenCalledTimes(1);
@@ -148,9 +152,9 @@ describe('SubscriptionsGraceExpirationWorker.onApplicationBootstrap', () => {
       log: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as never;
+    };
 
-    const worker = new SubscriptionsGraceExpirationWorker(registry, logger);
+    const worker = new SubscriptionsGraceExpirationWorker(registry as never, logger as never);
     await worker.onApplicationBootstrap();
 
     expect(logger.warn).toHaveBeenCalled();
@@ -165,9 +169,9 @@ describe('SubscriptionsGraceExpirationWorker.onApplicationBootstrap', () => {
       log: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as never;
+    };
 
-    const worker = new SubscriptionsGraceExpirationWorker(registry, logger);
+    const worker = new SubscriptionsGraceExpirationWorker(registry as never, logger as never);
 
     // No debe intentar conectar a Redis ni loguear "scheduler activo".
     await worker.onApplicationBootstrap();

--- a/apps/api/tests/super-users.service.test.ts
+++ b/apps/api/tests/super-users.service.test.ts
@@ -101,7 +101,7 @@ describe('SuperUsersService · listings cross-tenant (follow-up multi_tenant.rea
       const prisma = makePrisma([]);
       const svc = new SuperUsersService(...([prisma, license] as unknown as ServiceCtor));
       await svc.list({ tenantId: 't-99' });
-      const args = prisma.user.findMany.mock.calls[0][0];
+      const args = prisma.user.findMany.mock.calls[0]![0];
       expect(args.where).toMatchObject({ tenantId: 't-99', deletedAt: null });
     });
 
@@ -109,7 +109,7 @@ describe('SuperUsersService · listings cross-tenant (follow-up multi_tenant.rea
       const prisma = makePrisma([]);
       const svc = new SuperUsersService(...([prisma, license] as unknown as ServiceCtor));
       await svc.list({ search: 'alice' });
-      const args = prisma.user.findMany.mock.calls[0][0];
+      const args = prisma.user.findMany.mock.calls[0]![0];
       expect(args.where.OR).toEqual([
         { email: { contains: 'alice', mode: 'insensitive' } },
         { name: { contains: 'alice', mode: 'insensitive' } },
@@ -120,11 +120,11 @@ describe('SuperUsersService · listings cross-tenant (follow-up multi_tenant.rea
       const prisma = makePrisma([]);
       const svc = new SuperUsersService(...([prisma, license] as unknown as ServiceCtor));
       await svc.list({});
-      expect(prisma.user.findMany.mock.calls[0][0].take).toBe(50);
+      expect(prisma.user.findMany.mock.calls[0]![0].take).toBe(50);
       await svc.list({ limit: 9999 });
-      expect(prisma.user.findMany.mock.calls[1][0].take).toBe(200);
+      expect(prisma.user.findMany.mock.calls[1]![0].take).toBe(200);
       await svc.list({ limit: 0 });
-      expect(prisma.user.findMany.mock.calls[2][0].take).toBe(1);
+      expect(prisma.user.findMany.mock.calls[2]![0].take).toBe(1);
     });
 
     it('filtro role se aplica post-fetch', async () => {
@@ -135,7 +135,7 @@ describe('SuperUsersService · listings cross-tenant (follow-up multi_tenant.rea
       const svc = new SuperUsersService(...([prisma, license] as unknown as ServiceCtor));
       const result = await svc.list({ role: 'alumno' });
       expect(result.items).toHaveLength(1);
-      expect(result.items[0].id).toBe('u-2');
+      expect(result.items[0]!.id).toBe('u-2');
       // total refleja el count pre-filtro de rol (limitación documentada).
       expect(result.total).toBe(2);
     });

--- a/apps/api/tests/telemetry-heartbeat.test.ts
+++ b/apps/api/tests/telemetry-heartbeat.test.ts
@@ -123,7 +123,7 @@ describe('TelemetryHeartbeatService · envío', () => {
 
   it('con receptor accesible, entrega el latido', async () => {
     const svc = service();
-    const sendHeartbeat = vi.fn(() => Promise.resolve());
+    const sendHeartbeat = vi.fn((_payload: unknown) => Promise.resolve());
     (svc as never as { client: unknown }).client = { sendHeartbeat };
     await expect(svc.sendNow()).resolves.toBe(true);
     expect(sendHeartbeat).toHaveBeenCalledTimes(1);

--- a/apps/api/tests/tenant-modules.service.test.ts
+++ b/apps/api/tests/tenant-modules.service.test.ts
@@ -148,13 +148,19 @@ function setup(modules: DidactaModule[], tenantExists = true) {
 
   const auditLog = {
     record: vi.fn(async () => {}),
-  } as never;
+  };
 
   const accessCache = {
     invalidate: vi.fn(),
   } as never;
 
-  const service = new TenantModulesService(prisma, registryService, factory, auditLog, accessCache);
+  const service = new TenantModulesService(
+    prisma,
+    registryService,
+    factory,
+    auditLog as never,
+    accessCache,
+  );
 
   return {
     service,
@@ -337,6 +343,6 @@ describe('TenantModulesService · módulos categoría core', () => {
     const modules = [fakeModule('mod.a')];
     const { service } = setup(modules);
     const list = await service.list('t1');
-    expect(list[0].isCore).toBe(false);
+    expect(list[0]!.isCore).toBe(false);
   });
 });

--- a/apps/api/tests/theming-white-label-gate.test.ts
+++ b/apps/api/tests/theming-white-label-gate.test.ts
@@ -27,6 +27,7 @@ const adminUser = {
   sub: 'user-1',
   tenantId: 'tenant-1',
   roles: ['tenant_admin'],
+  mfaVerified: true,
   email: 'admin@tenant.test',
 } as Parameters<ThemingController['updateMine']>[0];
 

--- a/apps/api/tests/webhooks.service.test.ts
+++ b/apps/api/tests/webhooks.service.test.ts
@@ -138,19 +138,24 @@ class FakeEndpointRepo {
   }
 }
 
-class FakeDeadLetterRepo {
-  rows: Array<{
-    id: string;
-    tenantId: string;
-    endpointId: string;
-    eventType: string;
-    payload: unknown;
-    lastError: string;
-    attempts: number;
-    createdAt: Date;
-  }> = [];
+// La fila se nombra en vez de derivarla con `(typeof this.rows)[number]`:
+// dentro de la firma de un método, `this` no tiene tipo y el parámetro caía
+// a `any` implícito.
+interface DeadLetterRow {
+  id: string;
+  tenantId: string;
+  endpointId: string;
+  eventType: string;
+  payload: unknown;
+  lastError: string;
+  attempts: number;
+  createdAt: Date;
+}
 
-  async create(args: { data: Omit<(typeof this.rows)[number], 'id' | 'createdAt'> }) {
+class FakeDeadLetterRepo {
+  rows: DeadLetterRow[] = [];
+
+  async create(args: { data: Omit<DeadLetterRow, 'id' | 'createdAt'> }) {
     const row = {
       id: `dl-${this.rows.length + 1}`,
       ...args.data,

--- a/apps/api/tests/white-label-auth.controller.test.ts
+++ b/apps/api/tests/white-label-auth.controller.test.ts
@@ -29,6 +29,7 @@ function makeUser(overrides: Partial<SessionClaims> = {}): SessionClaims {
     tenantId: 'tenant-A',
     roles: ['alumno'],
     email: 'a@example.com',
+    mfaVerified: true,
     ...(overrides as Record<string, unknown>),
   } as SessionClaims;
 }

--- a/apps/api/tests/wp-sso.service.test.ts
+++ b/apps/api/tests/wp-sso.service.test.ts
@@ -135,7 +135,7 @@ describe('WpSsoService.exchange', () => {
       await makeToken({ email: 'nuevo@example.com', name: 'Nuevo' }),
     );
     expect(m.prisma.user.create).toHaveBeenCalledTimes(1);
-    const createArg = m.prisma.user.create.mock.calls[0][0];
+    const createArg = m.prisma.user.create.mock.calls[0]![0];
     expect(createArg.data.roles.create.roleId).toBe('role-alumno');
     expect(out.tokens).toEqual({ accessToken: 'AT', refreshToken: 'RT' });
     expect(out.user.roles).toContain('alumno');
@@ -184,7 +184,7 @@ describe('WpSsoService.exchange', () => {
     expect(m.prisma.userExternalIdentity.findUnique).toHaveBeenCalledTimes(1);
     expect(m.prisma.user.create).toHaveBeenCalledTimes(1);
     expect(m.prisma.userExternalIdentity.create).toHaveBeenCalledTimes(1);
-    const linkArg = m.prisma.userExternalIdentity.create.mock.calls[0][0];
+    const linkArg = m.prisma.userExternalIdentity.create.mock.calls[0]![0];
     expect(linkArg.data.externalId).toBe('wp-100');
     expect(linkArg.data.provider).toBe('wp');
     expect(linkArg.data.linkMethod).toBe('auto_provision');
@@ -225,7 +225,7 @@ describe('WpSsoService.exchange', () => {
     );
     expect(m.prisma.user.create).not.toHaveBeenCalled();
     expect(m.prisma.userExternalIdentity.create).toHaveBeenCalledTimes(1);
-    expect(m.prisma.userExternalIdentity.create.mock.calls[0][0].data.linkMethod).toBe(
+    expect(m.prisma.userExternalIdentity.create.mock.calls[0]![0].data.linkMethod).toBe(
       'auto_email',
     );
     expect(out.user.id).toBe('user-9');

--- a/apps/api/tsconfig.tests.json
+++ b/apps/api/tsconfig.tests.json
@@ -1,0 +1,21 @@
+{
+  "//": "Typecheck de TODO lo que no entra en el build. `tsconfig.json` es el config de build (nest-cli lo usa para emitir a dist/) y por eso se limita a src/**. Este config añade tests/ y scripts/ para que `tsc --noEmit` los cubra: sin él, una firma cambiada en src rompe los tests en silencio y solo se ve en runtime (y solo si el test ejercita esa ruta).",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // `tsconfig.json` compila a CommonJS porque eso es lo que ejecuta
+    // producción. Los tests NO: vitest los transforma con swc a ES modules
+    // (`module: { type: 'es6' }` en vitest.config.ts), así que `import.meta`
+    // es legal en runtime. Con CommonJS aquí, tsc lo rechazaría (TS1343)
+    // pese a funcionar. ES2022 es el módulo que realmente corren.
+    "module": "ES2022",
+    // Los tests viven fuera de `rootDir: ./src`; sin ensancharlo, tsc
+    // rechaza el programa entero.
+    "rootDir": ".",
+    // Buildinfo aparte: `tsconfig.json` lo escribe en dist/ y nest-cli borra
+    // ese directorio en cada build. Compartirlo dejaría dist vacío.
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/access-groups/package.json
+++ b/modules/access-groups/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/access-groups/tsconfig.tests.json
+++ b/modules/access-groups/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/ai-content/package.json
+++ b/modules/ai-content/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/ai-content/tests/ai-content.service.test.ts
+++ b/modules/ai-content/tests/ai-content.service.test.ts
@@ -170,7 +170,7 @@ describe('AiContentService — generate', () => {
     expect((draft.content as { text: string }).text).toContain('Resumen');
     expect(draft.inputTokens).toBe(100);
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('ai-content.draft.generated');
+    expect(publisher.events[0]!.name).toBe('ai-content.draft.generated');
   });
 
   it('FLASHCARDS: valida shape (cards array no vacío, front/back strings)', async () => {
@@ -302,7 +302,7 @@ describe('AiContentService — transiciones', () => {
     expect(updated.status).toBe('PUBLISHED');
     expect(updated.reviewedBy).toBe('reviewer');
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('ai-content.draft.published');
+    expect(publisher.events[0]!.name).toBe('ai-content.draft.published');
   });
 
   it('publish desde PUBLISHED lanza DraftNotInDraftStateError', async () => {
@@ -319,7 +319,7 @@ describe('AiContentService — transiciones', () => {
     const updated = await svc.reject('t1', 'reviewer', draft.id, 'No es preciso');
     expect(updated.status).toBe('REJECTED');
     expect(updated.rejectReason).toBe('No es preciso');
-    expect(publisher.events[0].name).toBe('ai-content.draft.rejected');
+    expect(publisher.events[0]!.name).toBe('ai-content.draft.rejected');
   });
 
   it('updateContent en DRAFT: revalida shape', async () => {

--- a/modules/ai-content/tsconfig.tests.json
+++ b/modules/ai-content/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/ai-grader/package.json
+++ b/modules/ai-grader/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/ai-grader/tests/rubric.service.test.ts
+++ b/modules/ai-grader/tests/rubric.service.test.ts
@@ -18,8 +18,10 @@ function makePrisma(opts: {
   existingRubric?: { id: string } | null;
 }) {
   const findQuestion = vi.fn(async () => opts.question ?? null);
-  const findRubric = vi.fn(async () => null as unknown);
-  const findRubricFirst = vi.fn(async () => opts.existingRubric ?? null);
+  const findRubric = vi.fn(async (_q: { where: Record<string, unknown> }) => null as unknown);
+  const findRubricFirst = vi.fn(
+    async (_q: { where: Record<string, unknown> }) => opts.existingRubric ?? null,
+  );
   const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
     id: 'new-rubric-id',
     questionId: data.questionId,

--- a/modules/ai-grader/tsconfig.tests.json
+++ b/modules/ai-grader/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/modules/ai-tutor/package.json
+++ b/modules/ai-tutor/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/ai-tutor/tests/chat.service.test.ts
+++ b/modules/ai-tutor/tests/chat.service.test.ts
@@ -12,11 +12,14 @@ import {
   DailyQuestionQuotaExceededError,
 } from '../src/errors.js';
 
+// Los dobles NO se castean a `never` al declararse: con `never` no se les
+// puede leer ninguna propiedad y las aserciones sobre sus espías dejan de
+// typechequearse. El cast va donde se inyectan, que es donde hace falta.
 function makeContext() {
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() },
     eventBus: { publish: vi.fn(async () => {}) },
-  } as never;
+  };
 }
 
 interface FakeChunkRow {
@@ -110,7 +113,7 @@ function makeFakePrisma(opts: {
     }),
     ejecutados,
     $transaction: vi.fn(async (queries: Promise<unknown>[]) => Promise.all(queries)),
-  } as never;
+  };
 }
 
 const makeEmbed =
@@ -137,7 +140,12 @@ const sampleRetrieved: FakeChunkRow[] = [
 describe('AiTutorChatService.ask (LMS-90.D)', () => {
   it('lanza CourseNotIndexedError si no hay chunks', async () => {
     const prisma = makeFakePrisma({ chunkCount: 0 });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     await expect(svc.ask('t1', 'u1', 'c1', { question: 'qué es vlookup' })).rejects.toBeInstanceOf(
       CourseNotIndexedError,
     );
@@ -158,7 +166,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
         { id: 'chunk-2', content: 'INDEX y MATCH combinados son más flexibles' },
       ],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     const result = await svc.ask('t1', 'u1', 'c1', { question: 'qué es vlookup' });
 
     expect(result.conversationId).toBeTruthy();
@@ -182,7 +195,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
         { id: 'chunk-2', content: 'b' },
       ],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     const result = await svc.ask('t1', 'u1', 'c1', {
       question: 'q',
       conversationId: 'existing-conv',
@@ -207,7 +225,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
         { id: 'chunk-2', content: 'b' },
       ],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'q' });
     const messageCreates = prisma.created.filter((c) => c.table === 'msg');
     expect(messageCreates).toHaveLength(2);
@@ -232,7 +255,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
         { id: 'chunk-2', content: 'INDEX-MATCH es más flexible que VLOOKUP' },
       ],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     const result = await svc.ask('t1', 'u1', 'c1', { question: 'q' });
     expect(result.citations).toHaveLength(2);
     expect(result.citations[0]!.lessonId).toBe('l1');
@@ -256,7 +284,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
       ],
       tokenUsageExisting: null,
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'q' });
     const usageCreate = prisma.created.find((c) => c.table === 'usage');
     expect(usageCreate).toBeDefined();
@@ -281,7 +314,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
       ],
       tokenUsageExisting: { id: 'usage-existing' },
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'q' });
     const usageUpdate = prisma.updated.find((u) => u.table === 'usage');
     expect(usageUpdate).toBeDefined();
@@ -303,7 +341,7 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
         { id: 'chunk-2', content: 'b' },
       ],
     });
-    const svc = new AiTutorChatService(prisma, ctx, makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(prisma as never, ctx as never, makeEmbed(), makeChat());
     await svc.ask('t1', 'u1', 'c1', { question: 'q' });
     expect(ctx.eventBus.publish).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -323,7 +361,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
     const failingChat: ChatFn = async () => {
       throw new Error('rate limit');
     };
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), failingChat);
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      failingChat,
+    );
     await expect(svc.ask('t1', 'u1', 'c1', { question: 'q' })).rejects.toBeInstanceOf(
       ChatProviderError,
     );
@@ -344,7 +387,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
         { id: 'chunk-2', content: 'b' },
       ],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'q', topK: 10 });
     // queryRawUnsafe se llamó con LIMIT 10 como parámetro
     const queryCall = (prisma.$queryRawUnsafe as ReturnType<typeof vi.fn>).mock.calls[0]!;
@@ -378,7 +426,12 @@ describe('AiTutorChatService.ask (LMS-90.D)', () => {
       inputTokens: 1,
       outputTokens: 1,
     }));
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), chatSpy);
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      chatSpy,
+    );
     await svc.ask('t1', 'u1', 'c1', {
       question: 'nueva',
       conversationId: '11111111-1111-4111-8111-111111111111',
@@ -406,8 +459,8 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
     const prisma = makeFakePrisma({ ...base, enrollment: null });
     const embedSpy = vi.fn(makeEmbed());
     const svc = new AiTutorChatService(
-      prisma,
-      makeContext(),
+      prisma as never,
+      makeContext() as never,
       embedSpy as unknown as EmbedFn,
       makeChat(),
     );
@@ -419,7 +472,12 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
 
   it('staff responde sin matrícula y sin consumir cuota', async () => {
     const prisma = makeFakePrisma({ ...base, enrollment: null });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     const r = await svc.ask('t1', 'u1', 'c1', { question: 'hola' }, { staff: true });
     expect(r.answer).toBeTruthy();
     const usage = prisma.created.find((c) => c.table === 'usage');
@@ -433,8 +491,8 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
     });
     const embedSpy = vi.fn(makeEmbed());
     const svc = new AiTutorChatService(
-      prisma,
-      makeContext(),
+      prisma as never,
+      makeContext() as never,
       embedSpy as unknown as EmbedFn,
       makeChat(),
     );
@@ -449,7 +507,12 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
       ...base,
       tokenUsageExisting: { id: 'usage-1', questions: DAILY_QUESTION_LIMIT - 1 },
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat());
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat(),
+    );
     const r = await svc.ask('t1', 'u1', 'c1', { question: 'hola' });
     expect(r.quota).toEqual({
       used: DAILY_QUESTION_LIMIT,
@@ -465,7 +528,12 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
     const chatRoto: ChatFn = async () => {
       throw new Error('502 del proveedor');
     };
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), chatRoto);
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      chatRoto,
+    );
     await expect(svc.ask('t1', 'u1', 'c1', { question: 'hola' })).rejects.toBeInstanceOf(
       ChatProviderError,
     );
@@ -482,7 +550,12 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
       inputTokens: 1,
       outputTokens: 1,
     }));
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), chatSpy);
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      chatSpy,
+    );
     await svc.ask('t1', 'u1', 'c1', {
       question: 'no me va',
       lessonId: 'l1',
@@ -504,7 +577,12 @@ describe('AiTutorChatService.ask · acceso y cuota', () => {
       ...base,
       hydrationChunks: [{ id: 'chunk-1', content: '[12:34] el webhook expone tu workflow' }],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat('Mira [1].'));
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat('Mira [1].'),
+    );
     const r = await svc.ask('t1', 'u1', 'c1', { question: 'webhook?' });
     expect(r.citations[0]!.startSeconds).toBe(754);
   });
@@ -542,7 +620,12 @@ describe('AiTutorChatService.ask · conocimiento validado', () => {
       inputTokens: 1,
       outputTokens: 1,
     }));
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), chatSpy);
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      chatSpy,
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'dónde saco la factura' });
 
     const system = (chatSpy as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0].system;
@@ -570,7 +653,12 @@ describe('AiTutorChatService.ask · conocimiento validado', () => {
       inputTokens: 1,
       outputTokens: 1,
     }));
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), chatSpy);
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      chatSpy,
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'qué es un webhook' });
 
     const system = (chatSpy as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0].system;
@@ -582,7 +670,12 @@ describe('AiTutorChatService.ask · conocimiento validado', () => {
       ...base,
       correcciones: [{ id: 'corr-1', question: 'p', answer: 'r', distance: 0.1 }],
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat('ok'));
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat('ok'),
+    );
     await svc.ask('t1', 'u1', 'c1', { question: 'una duda' });
 
     const sqls = prisma.ejecutados.map((e) => e.sql);
@@ -597,7 +690,12 @@ describe('AiTutorChatService.ask · conocimiento validado', () => {
       if (sql.includes('mod_ai_tutor_correction')) throw new Error('relation does not exist');
       return sampleRetrieved;
     });
-    const svc = new AiTutorChatService(prisma, makeContext(), makeEmbed(), makeChat('Mira [1].'));
+    const svc = new AiTutorChatService(
+      prisma as never,
+      makeContext() as never,
+      makeEmbed(),
+      makeChat('Mira [1].'),
+    );
     const r = await svc.ask('t1', 'u1', 'c1', { question: 'q' });
     expect(r.answer).toContain('[1]');
   });

--- a/modules/ai-tutor/tests/indexer.service.test.ts
+++ b/modules/ai-tutor/tests/indexer.service.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { CourseNotPublishedError, EmbeddingsProviderError } from '../src/errors.js';
 import { AiTutorIndexerService, type EmbedFn } from '../src/indexer.service.js';
 
+// Los dobles NO se castean a `never` al declararse: con `never` no se les
+// puede leer ninguna propiedad y las aserciones sobre sus espías dejan de
+// typechequearse. El cast va donde se inyectan, que es donde hace falta.
 function makeContext() {
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() },
     eventBus: { publish: vi.fn(async () => {}) },
-  } as never;
+  };
 }
 
 interface FakeRows {
@@ -42,7 +45,7 @@ function makeFakePrisma(opts: FakeRows) {
       }
       return 0;
     }),
-  } as never;
+  };
 }
 
 const fakeEmbed =
@@ -58,7 +61,7 @@ const fakeEmbed =
 describe('AiTutorIndexerService (LMS-90.C)', () => {
   it('lanza si curso no existe', async () => {
     const prisma = makeFakePrisma({ course: null });
-    const svc = new AiTutorIndexerService(prisma, makeContext(), fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, makeContext() as never, fakeEmbed());
     await expect(svc.indexCourse('t1', 'c-missing')).rejects.toThrow(/not found/);
   });
 
@@ -66,7 +69,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
     const prisma = makeFakePrisma({
       course: { id: 'c1', tenantId: 't1', status: 'DRAFT' },
     });
-    const svc = new AiTutorIndexerService(prisma, makeContext(), fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, makeContext() as never, fakeEmbed());
     await expect(svc.indexCourse('t1', 'c1')).rejects.toBeInstanceOf(CourseNotPublishedError);
   });
 
@@ -75,7 +78,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
       course: { id: 'c1', tenantId: 't1', status: 'DRAFT' },
       modules: [],
     });
-    const svc = new AiTutorIndexerService(prisma, makeContext(), fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, makeContext() as never, fakeEmbed());
     const result = await svc.indexCourse('t1', 'c1', { allowDraft: true });
     expect(result.lessonsProcessed).toBe(0);
     expect(result.chunksGenerated).toBe(0);
@@ -87,7 +90,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
       course: { id: 'c1', tenantId: 't1', status: 'PUBLISHED' },
       modules: [],
     });
-    const svc = new AiTutorIndexerService(prisma, ctx, fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, ctx as never, fakeEmbed());
     const result = await svc.indexCourse('t1', 'c1');
     expect(result.chunksGenerated).toBe(0);
     expect(result.lessonsProcessed).toBe(0);
@@ -120,7 +123,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
         },
       ],
     });
-    const svc = new AiTutorIndexerService(prisma, ctx, fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, ctx as never, fakeEmbed());
     const result = await svc.indexCourse('t1', 'c1');
 
     expect(result.lessonsProcessed).toBe(2);
@@ -172,7 +175,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
         },
       ],
     });
-    const svc = new AiTutorIndexerService(prisma, makeContext(), fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, makeContext() as never, fakeEmbed());
     const result = await svc.indexCourse('t1', 'c1');
     // Solo cuenta TEXT
     expect(result.lessonsProcessed).toBe(1);
@@ -195,7 +198,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
         },
       ],
     });
-    const svc = new AiTutorIndexerService(prisma, ctx, fakeEmbed(768));
+    const svc = new AiTutorIndexerService(prisma as never, ctx as never, fakeEmbed(768));
     await expect(svc.indexCourse('t1', 'c1')).rejects.toBeInstanceOf(EmbeddingsProviderError);
   });
 
@@ -218,7 +221,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
     const failingEmbed: EmbedFn = async () => {
       throw new Error('rate limit');
     };
-    const svc = new AiTutorIndexerService(prisma, ctx, failingEmbed);
+    const svc = new AiTutorIndexerService(prisma as never, ctx as never, failingEmbed);
     await expect(svc.indexCourse('t1', 'c1')).rejects.toBeInstanceOf(EmbeddingsProviderError);
     expect(ctx.eventBus.publish).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'ai-tutor.course.index-failed' }),
@@ -240,7 +243,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
         },
       ],
     });
-    const svc = new AiTutorIndexerService(prisma, makeContext(), fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, makeContext() as never, fakeEmbed());
     await svc.indexCourse('t1', 'c1');
     expect(prisma.deletes).toHaveLength(1);
     expect(prisma.inserts.length).toBeGreaterThan(0);
@@ -255,7 +258,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
     const prisma = makeFakePrisma({
       course: { id: 'c1', tenantId: 't1', status: 'PUBLISHED' },
     });
-    const svc = new AiTutorIndexerService(prisma, ctx, fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, ctx as never, fakeEmbed());
     await svc.unindexCourse('t1', 'c1');
     expect(prisma.deletes).toHaveLength(1);
     expect(ctx.eventBus.publish).toHaveBeenCalledWith(
@@ -291,7 +294,7 @@ describe('AiTutorIndexerService (LMS-90.C)', () => {
         },
       ],
     });
-    const svc = new AiTutorIndexerService(prisma, makeContext(), fakeEmbed());
+    const svc = new AiTutorIndexerService(prisma as never, makeContext() as never, fakeEmbed());
     await svc.indexCourse('t1', 'c1');
 
     // Cada chunk content (param 5) debe incluir cabecera de módulo

--- a/modules/ai-tutor/tests/review.service.test.ts
+++ b/modules/ai-tutor/tests/review.service.test.ts
@@ -12,11 +12,14 @@ import { listAnswersSchema } from '../src/dto.js';
  * Y que el informe mensual agrupe de verdad, en vez de listar 400 preguntas.
  */
 
+// Los dobles NO se castean a `never` al declararse: con `never` no se les
+// puede leer ninguna propiedad y las aserciones sobre sus espías dejan de
+// typechequearse. El cast va donde se inyectan, que es donde hace falta.
 function makeContext() {
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() },
     eventBus: { publish: vi.fn(async () => {}) },
-  } as never;
+  };
 }
 
 const embedFake: EmbedFn = async ({ texts }) => ({
@@ -85,7 +88,7 @@ function makeFakePrisma(opts: {
       ejecutados.push({ sql, params });
       return 1;
     }),
-  } as never;
+  };
 }
 
 const AHORA = new Date('2026-07-15T10:00:00.000Z');
@@ -115,7 +118,7 @@ describe('AiTutorReviewService.review', () => {
         },
       ],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     const vista = await svc.review('t1', 'msg-1', { status: 'OK' }, 'admin-1');
 
@@ -147,7 +150,7 @@ describe('AiTutorReviewService.review', () => {
         },
       ],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     await svc.review(
       't1',
@@ -195,7 +198,7 @@ describe('AiTutorReviewService.review', () => {
         },
       ],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     await svc.review(
       't1',
@@ -233,7 +236,7 @@ describe('AiTutorReviewService.review', () => {
         },
       ],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     await svc.review(
       't1',
@@ -255,7 +258,7 @@ describe('AiTutorReviewService.review', () => {
 
   it('revisar un mensaje que no existe da MessageNotFoundError', async () => {
     const prisma = makeFakePrisma({ mensaje: null });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
     await expect(svc.review('t1', 'no-existe', { status: 'OK' }, 'admin-1')).rejects.toBeInstanceOf(
       MessageNotFoundError,
     );
@@ -301,7 +304,7 @@ describe('AiTutorReviewService.monthlyReport', () => {
       ],
       cursos: [{ id: 'curso-1', title: 'n8n desde cero' }],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     const informe = await svc.monthlyReport('t1', { mes: '2026-07' });
 
@@ -325,7 +328,7 @@ describe('AiTutorReviewService.monthlyReport', () => {
         pregunta({ id: '3', sin_respaldo: false, embedding: dir(90) }),
       ],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     const informe = await svc.monthlyReport('t1', { mes: '2026-07' });
 
@@ -342,7 +345,7 @@ describe('AiTutorReviewService.monthlyReport', () => {
         pregunta({ id: '2', embedding: null, question: 'otra vieja' }),
       ],
     });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
 
     const informe = await svc.monthlyReport('t1', { mes: '2026-07' });
 
@@ -363,7 +366,7 @@ describe('AiTutorReviewService.monthlyReport', () => {
     const embedRoto: EmbedFn = async () => {
       throw new Error('provider caído');
     };
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedRoto);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedRoto);
 
     const informe = await svc.monthlyReport('t1', { mes: '2026-07' });
 
@@ -375,7 +378,7 @@ describe('AiTutorReviewService.monthlyReport', () => {
 
   it('sin preguntas devuelve un informe vacío, no un error', async () => {
     const prisma = makeFakePrisma({ preguntasDelMes: [] });
-    const svc = new AiTutorReviewService(prisma, makeContext(), embedFake);
+    const svc = new AiTutorReviewService(prisma as never, makeContext() as never, embedFake);
     const informe = await svc.monthlyReport('t1', { mes: '2026-01' });
     expect(informe.totalPreguntas).toBe(0);
     expect(informe.temas).toEqual([]);

--- a/modules/ai-tutor/tsconfig.tests.json
+++ b/modules/ai-tutor/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/modules/assessments/package.json
+++ b/modules/assessments/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/assessments/tests/assessments-service.attempts.test.ts
+++ b/modules/assessments/tests/assessments-service.attempts.test.ts
@@ -143,7 +143,9 @@ function makeFakePrisma(
         return row;
       },
     },
-    async $transaction<T>(cb: (tx: typeof prisma) => Promise<T>): Promise<T> {
+    // `typeof prisma` aquí haría que `prisma` se refiriese a sí mismo en su
+    // propio inicializador (TS7022) y todo el doble caería a `any` implícito.
+    async $transaction<T>(cb: (tx: unknown) => Promise<T>): Promise<T> {
       return cb(prisma);
     },
     _attempts: attempts,

--- a/modules/assessments/tests/assessments-service.grading.test.ts
+++ b/modules/assessments/tests/assessments-service.grading.test.ts
@@ -100,7 +100,8 @@ function makeFakePrisma(opts: {
         return answers.filter((a) => a.attemptId === args.where.attemptId);
       },
     },
-    async $transaction<T>(cb: (tx: typeof prisma) => Promise<T>): Promise<T> {
+    // Idem attempts: `typeof prisma` sería circular (TS7022).
+    async $transaction<T>(cb: (tx: unknown) => Promise<T>): Promise<T> {
       return cb(prisma);
     },
     _attempt: attempt,

--- a/modules/assessments/tsconfig.tests.json
+++ b/modules/assessments/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/billing/package.json
+++ b/modules/billing/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/billing/tests/billing.service.test.ts
+++ b/modules/billing/tests/billing.service.test.ts
@@ -118,14 +118,10 @@ class MockPrisma {
     },
     create: async (args: { data: Omit<ProductRow, 'id' | 'createdAt' | 'updatedAt'> }) => {
       const id = `prod-${this.products.size + 1}`;
+      // Sin defaults muertos: `args.data` declara estos campos obligatorios
+      // y el spread los pisaba siempre.
       const row: ProductRow = {
         id,
-        compareAtAmount: null,
-        name: '',
-        perks: [],
-        sortOrder: 0,
-        isFeatured: false,
-        externalRef: null,
         ...args.data,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -174,7 +170,6 @@ class MockPrisma {
       const row: OrderRow = {
         id,
         amountPaid: null,
-        stripePaymentIntentId: null,
         customerEmail: null,
         completedAt: null,
         refundedAt: null,
@@ -446,8 +441,8 @@ describe('BillingService — startCheckout (alumno)', () => {
     expect(stored?.stripeSessionId).toBe(result.sessionId);
 
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('billing.order.created');
-    expect(publisher.events[0].payload.stripeSessionId).toBe(result.sessionId);
+    expect(publisher.events[0]!.name).toBe('billing.order.created');
+    expect(publisher.events[0]!.payload.stripeSessionId).toBe(result.sessionId);
   });
 
   it('falla si el producto no existe para el curso', async () => {
@@ -721,8 +716,8 @@ describe('BillingService — handleWebhookEvent (idempotente)', () => {
     expect(updated.completedAt).toBeInstanceOf(Date);
 
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('billing.order.completed');
-    expect(publisher.events[0].payload.amountPaid).toBe(1999);
+    expect(publisher.events[0]!.name).toBe('billing.order.completed');
+    expect(publisher.events[0]!.payload.amountPaid).toBe(1999);
   });
 
   async function comprarYCobrar() {
@@ -764,8 +759,8 @@ describe('BillingService — handleWebhookEvent (idempotente)', () => {
     expect(prisma.orders.get(orderId)!.status).toBe('REFUNDED');
     expect(prisma.orders.get(orderId)!.refundedAt).toBeInstanceOf(Date);
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('billing.order.refunded');
-    expect(publisher.events[0].payload.courseId).toBe('course-1');
+    expect(publisher.events[0]!.name).toBe('billing.order.refunded');
+    expect(publisher.events[0]!.payload.courseId).toBe('course-1');
   });
 
   it('un reembolso PARCIAL no retira el acceso ni marca la orden', async () => {
@@ -812,7 +807,7 @@ describe('BillingService — handleWebhookEvent (idempotente)', () => {
     await svc.handleWebhookEvent(reintento, {});
 
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('billing.order.completed');
+    expect(publisher.events[0]!.name).toBe('billing.order.completed');
   });
 
   it('ignora en silencio el checkout de OTRO módulo (membresía) en el endpoint compartido', async () => {
@@ -919,7 +914,7 @@ describe('BillingService — handleWebhookEvent (idempotente)', () => {
 
     expect(prisma.orders.get(checkout.orderId)!.status).toBe('FAILED');
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('billing.order.failed');
+    expect(publisher.events[0]!.name).toBe('billing.order.failed');
   });
 
   it('checkout logueado: el fulfillment NO llama al provisioner (la order ya tiene dueño)', async () => {
@@ -943,8 +938,8 @@ describe('BillingService — handleWebhookEvent (idempotente)', () => {
     );
 
     expect(provision).not.toHaveBeenCalled();
-    expect(publisher.events[0].payload.userId).toBe('u1');
-    expect(publisher.events[0].payload.userCreated).toBe(false);
+    expect(publisher.events[0]!.payload.userId).toBe('u1');
+    expect(publisher.events[0]!.payload.userCreated).toBe(false);
   });
 
   it('eventos no relevantes (ej. invoice.paid) se persisten pero no afectan estado', async () => {
@@ -1024,8 +1019,8 @@ describe('BillingService — checkout PÚBLICO (viaje 2: visitante sin cuenta)',
     // Sin email: lo recoge el checkout hosted de Stripe.
     expect(stripe.lastCheckout?.customerEmail).toBeUndefined();
     // ORDER_CREATED sin actor (no hay usuario todavía).
-    expect(publisher.events[0].name).toBe('billing.order.created');
-    expect(publisher.events[0].actorId).toBeNull();
+    expect(publisher.events[0]!.name).toBe('billing.order.created');
+    expect(publisher.events[0]!.actorId).toBeNull();
   });
 
   it('fulfillment anónimo: materializa al comprador con el email CONFIRMADO en Stripe y emite completed con su userId', async () => {
@@ -1052,9 +1047,9 @@ describe('BillingService — checkout PÚBLICO (viaje 2: visitante sin cuenta)',
     expect(updated.status).toBe('COMPLETED');
     expect(updated.userId).toBe('u-nueva');
     expect(publisher.events).toHaveLength(1);
-    expect(publisher.events[0].name).toBe('billing.order.completed');
-    expect(publisher.events[0].payload.userId).toBe('u-nueva');
-    expect(publisher.events[0].payload.userCreated).toBe(true);
+    expect(publisher.events[0]!.name).toBe('billing.order.completed');
+    expect(publisher.events[0]!.payload.userId).toBe('u-nueva');
+    expect(publisher.events[0]!.payload.userCreated).toBe(true);
   });
 
   it('reentrega del webhook: NO provisiona dos veces ni re-emite el evento', async () => {
@@ -1116,7 +1111,7 @@ describe('BillingService — checkout PÚBLICO (viaje 2: visitante sin cuenta)',
     );
 
     expect(prisma.orders.get(checkout.orderId)!.userId).toBe('u-existente');
-    expect(publisher.events[0].payload.userCreated).toBe(false);
+    expect(publisher.events[0]!.payload.userCreated).toBe(false);
   });
 
   it('getCatalog agrupa las opciones ACTIVAS por curso con el % de descuento derivado', async () => {
@@ -1152,8 +1147,8 @@ describe('BillingService — checkout PÚBLICO (viaje 2: visitante sin cuenta)',
     expect(ids).toEqual(['course-1', 'course-2']);
     const curso2 = catalogo.find((c) => c.courseId === 'course-2')!;
     expect(curso2.options.map((o) => o.name)).toEqual(['Curso', 'Curso Avanzado']);
-    expect(curso2.options[0].discountPercent).toBe(50);
-    expect(curso2.options[1].discountPercent).toBeNull();
+    expect(curso2.options[0]!.discountPercent).toBe(50);
+    expect(curso2.options[1]!.discountPercent).toBeNull();
   });
 
   it('checkout anónimo expirado: order CANCELLED sin provisionar a nadie', async () => {

--- a/modules/billing/tsconfig.tests.json
+++ b/modules/billing/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/certificates/package.json
+++ b/modules/certificates/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/certificates/tsconfig.tests.json
+++ b/modules/certificates/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/community/package.json
+++ b/modules/community/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/community/tests/community.service.test.ts
+++ b/modules/community/tests/community.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CommunityService, excerpt, parseMentionHandles } from '../src/community.service.js';
+import type { CreatePostDto } from '../src/dto.js';
 import {
   CommentNotFoundError,
   NotAuthorError,
@@ -9,6 +10,17 @@ import {
   SpaceNotDeletableError,
   SpaceNotFoundError,
 } from '../src/errors.js';
+
+/**
+ * `CreatePostDto` es el tipo de SALIDA del schema zod: `notifyAll` e
+ * `important` llevan `.default(false)`, así que tras el parse SIEMPRE vienen
+ * y el tipo los declara obligatorios. Estos tests llaman al service directo,
+ * sin pasar por zod, así que rellenan aquí lo que el parse habría puesto —
+ * en vez de repetir los dos campos en cada caso.
+ */
+function postDto(dto: Partial<CreatePostDto> & { title: string; body: string }): CreatePostDto {
+  return { notifyAll: false, important: false, ...dto };
+}
 
 interface PostRow {
   id: string;
@@ -67,7 +79,7 @@ function makeFakePrisma() {
           createdAt: new Date(),
           pinnedAt: null,
           pinnedById: null,
-          ...(args.data as PostRow),
+          ...args.data,
         };
         posts.push(row);
         return row;
@@ -178,7 +190,7 @@ function makeFakePrisma() {
           authorDisplayName: null,
           deletedAt: null,
           createdAt: new Date(),
-          ...(args.data as CommentRow),
+          ...args.data,
         };
         comments.push(row);
         return row;
@@ -223,7 +235,7 @@ function makeFakePrisma() {
           commentId: null,
           authorId: '',
           emoji: '',
-          ...(args.data as ReactionRow),
+          ...args.data,
         };
         reactions.push(row);
         return row;
@@ -263,11 +275,11 @@ describe('CommunityService.createPost', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: 'Ana' },
-      {
+      postDto({
         title: 'Hola',
         body: 'Mundo',
         tags: ['general'],
-      },
+      }),
     );
 
     expect(post.title).toBe('Hola');
@@ -283,22 +295,22 @@ describe('CommunityService.createPost', () => {
     await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      {
+      postDto({
         title: 'A',
         body: 'b',
         courseId: 'c1',
         tags: ['ayuda'],
-      },
+      }),
     );
     await svc.createPost(
       't1',
       { id: 'u2', displayName: null },
-      {
+      postDto({
         title: 'B',
         body: 'b',
         courseId: 'c2',
         tags: ['general'],
-      },
+      }),
     );
 
     const list1 = await svc.listPosts('t1', { courseId: 'c1', limit: 50 });
@@ -316,7 +328,7 @@ describe('CommunityService.createPost', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'P', body: 'body' },
+      postDto({ title: 'P', body: 'body' }),
     );
     await svc.addComment('t1', post.id, { id: 'u2', displayName: null }, { body: 'first' });
     await svc.addComment('t1', post.id, { id: 'u3', displayName: null }, { body: 'second' });
@@ -329,7 +341,11 @@ describe('CommunityService.createPost', () => {
   it('listPosts devuelve _count.comments=0 para post sin comentarios', async () => {
     const prisma = makeFakePrisma();
     const svc = new CommunityService(prisma as never, trackingCtx([]));
-    await svc.createPost('t1', { id: 'u1', displayName: null }, { title: 'P', body: 'body' });
+    await svc.createPost(
+      't1',
+      { id: 'u1', displayName: null },
+      postDto({ title: 'P', body: 'body' }),
+    );
     const list = await svc.listPosts('t1', { limit: 50 });
     expect(list[0]?._count?.comments).toBe(0);
   });
@@ -340,13 +356,13 @@ describe('CommunityService.createPost', () => {
     const a = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'A', body: 'a' },
+      postDto({ title: 'A', body: 'a' }),
     );
     await new Promise((r) => setTimeout(r, 5));
     const b = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'B', body: 'b' },
+      postDto({ title: 'B', body: 'b' }),
     );
 
     const recent = await svc.listPosts('t1', { sort: 'recent', limit: 50 });
@@ -362,7 +378,7 @@ describe('CommunityService.createPost', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'P', body: 'b' },
+      postDto({ title: 'P', body: 'b' }),
     );
     await svc.addReaction('t1', 'u2', { postId: post.id, emoji: '👍' });
     await svc.addReaction('t1', 'u3', { postId: post.id, emoji: '❤️' });
@@ -380,12 +396,12 @@ describe('CommunityService.createPost', () => {
     const a = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'A', body: 'a' },
+      postDto({ title: 'A', body: 'a' }),
     );
     const b = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'B', body: 'b' },
+      postDto({ title: 'B', body: 'b' }),
     );
     // B tiene 2 comentarios, A tiene 1 → B debe quedar primero.
     await svc.addComment('t1', a.id, { id: 'u2', displayName: null }, { body: 'c1' });
@@ -405,10 +421,10 @@ describe('CommunityService.deletePost', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      {
+      postDto({
         title: 'X',
         body: 'y',
-      },
+      }),
     );
     await expect(svc.deletePost('t1', 'otro', post.id)).rejects.toBeInstanceOf(NotAuthorError);
   });
@@ -425,10 +441,10 @@ describe('CommunityService.deletePost', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      {
+      postDto({
         title: 'X',
         body: 'y',
-      },
+      }),
     );
     await svc.deletePost('t1', 'u1', post.id);
     expect(prisma._posts[0]?.deletedAt).toBeInstanceOf(Date);
@@ -451,10 +467,10 @@ describe('CommunityService.addComment', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      {
+      postDto({
         title: 'P',
         body: 'b',
-      },
+      }),
     );
     const comment = await svc.addComment(
       't1',
@@ -475,10 +491,10 @@ describe('CommunityService.deleteComment', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      {
+      postDto({
         title: 'P',
         body: 'b',
-      },
+      }),
     );
     const c = await svc.addComment('t1', post.id, { id: 'u2', displayName: null }, { body: 'x' });
     await expect(svc.deleteComment('t1', 'otro', c.id)).rejects.toBeInstanceOf(NotAuthorError);
@@ -877,7 +893,7 @@ describe('CommunityService.pin', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'Anuncio', body: 'b' },
+      postDto({ title: 'Anuncio', body: 'b' }),
     );
     const pinned = await svc.pinPost('t1', 'admin1', post.id);
     expect(pinned.pinnedAt).toBeInstanceOf(Date);
@@ -890,7 +906,7 @@ describe('CommunityService.pin', () => {
     const post = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'A', body: 'b' },
+      postDto({ title: 'A', body: 'b' }),
     );
     await svc.pinPost('t1', 'admin1', post.id);
     const unpinned = await svc.unpinPost('t1', 'admin1', post.id);
@@ -912,20 +928,20 @@ describe('CommunityService.pin', () => {
     const a = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'A más antiguo', body: 'b' },
+      postDto({ title: 'A más antiguo', body: 'b' }),
     );
     // Espaciamos createdAt para que el orden sea determinístico.
     await new Promise((r) => setTimeout(r, 5));
     const b = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'B medio', body: 'b' },
+      postDto({ title: 'B medio', body: 'b' }),
     );
     await new Promise((r) => setTimeout(r, 5));
     const c = await svc.createPost(
       't1',
       { id: 'u1', displayName: null },
-      { title: 'C más nuevo', body: 'b' },
+      postDto({ title: 'C más nuevo', body: 'b' }),
     );
 
     // Sin pin: orden recent → c, b, a
@@ -1079,7 +1095,7 @@ describe('CommunityService.updatePost', () => {
     const post = await svc.createPost(
       't1',
       { id: 'author-1', displayName: 'Autor' },
-      { title: 'Título original', body: 'cuerpo', tags: ['general'] },
+      postDto({ title: 'Título original', body: 'cuerpo', tags: ['general'] }),
     );
     return { svc, post };
   }
@@ -1145,7 +1161,7 @@ describe('CommunityService.addComment — notificaciones', () => {
     const post = await svc.createPost(
       't1',
       { id: 'author', displayName: 'Autor' },
-      { title: 'Mi post', body: 'b' },
+      postDto({ title: 'Mi post', body: 'b' }),
     );
     await svc.addComment(
       't1',
@@ -1171,7 +1187,7 @@ describe('CommunityService.addComment — notificaciones', () => {
     const post = await svc.createPost(
       't1',
       { id: 'author', displayName: 'Autor' },
-      { title: 'P', body: 'b' },
+      postDto({ title: 'P', body: 'b' }),
     );
     await svc.addComment(
       't1',
@@ -1190,7 +1206,7 @@ describe('CommunityService.addComment — notificaciones', () => {
     const post = await svc.createPost(
       't1',
       { id: 'author', displayName: 'Autor' },
-      { title: 'P', body: 'b' },
+      postDto({ title: 'P', body: 'b' }),
     );
     const root = await svc.addComment(
       't1',
@@ -1232,7 +1248,7 @@ describe('CommunityService.addComment — notificaciones', () => {
     const post = await svc.createPost(
       't1',
       { id: 'author', displayName: 'Autor' },
-      { title: 'P', body: 'b' },
+      postDto({ title: 'P', body: 'b' }),
     );
     await svc.addComment(
       't1',

--- a/modules/community/tsconfig.tests.json
+++ b/modules/community/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/courses/package.json
+++ b/modules/courses/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/courses/tsconfig.tests.json
+++ b/modules/courses/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/fundae/package.json
+++ b/modules/fundae/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/fundae/tests/company.service.test.ts
+++ b/modules/fundae/tests/company.service.test.ts
@@ -82,7 +82,7 @@ function makeFakePrisma(opts: { groupCount?: number } = {}) {
           createdAt: now,
           updatedAt: now,
           deletedAt: null,
-          ...(args.data as CompanyRow),
+          ...args.data,
         };
         rows.push(row);
         return row;
@@ -118,13 +118,13 @@ const ctx = {
   eventBus: {
     publish: vi.fn(async () => {}),
   },
-} as never;
+};
 
 describe('FundaeCompanyService', () => {
   describe('create', () => {
     it('persiste empresa con NIF normalizado y publica evento', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
 
       const created = await svc.create('t-1', 'admin-1', {
         nif: 'A58818501',
@@ -147,7 +147,7 @@ describe('FundaeCompanyService', () => {
 
     it('rechaza NIF duplicado dentro del mismo tenant', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       await svc.create('t-1', null, { nif: 'A58818501', razonSocial: 'Empresa A' });
 
       await expect(
@@ -157,7 +157,7 @@ describe('FundaeCompanyService', () => {
 
     it('NIF duplicado en OTRO tenant es OK (aislamiento por tenant)', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       await svc.create('t-A', null, { nif: 'A58818501', razonSocial: 'Empresa A' });
 
       const created = await svc.create('t-B', null, {
@@ -170,7 +170,7 @@ describe('FundaeCompanyService', () => {
 
     it('crédito disponible es null cuando no se fija total', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa sin crédito declarado',
@@ -183,7 +183,7 @@ describe('FundaeCompanyService', () => {
   describe('list', () => {
     it('list filtra por tenant y excluye soft-deleted por defecto', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       await svc.create('t-1', null, { nif: 'A58818501', razonSocial: 'Empresa Alpha' });
       const beta = await svc.create('t-1', null, {
         nif: 'P1234567D',
@@ -199,7 +199,7 @@ describe('FundaeCompanyService', () => {
 
     it('list con includeDeleted=true devuelve también soft-deleted', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const alpha = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa Alpha',
@@ -213,7 +213,7 @@ describe('FundaeCompanyService', () => {
 
     it('search filtra por NIF (normalizado) o razón social (case-insensitive)', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       await svc.create('t-1', null, { nif: 'A58818501', razonSocial: 'Telefónica' });
       await svc.create('t-1', null, { nif: 'P1234567D', razonSocial: 'Mercadona' });
 
@@ -228,7 +228,7 @@ describe('FundaeCompanyService', () => {
   describe('get', () => {
     it('get devuelve la empresa o lanza CompanyNotFoundError', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa',
@@ -242,7 +242,7 @@ describe('FundaeCompanyService', () => {
 
     it('get aislamiento por tenant — empresa de otro tenant es como si no existiera', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-A', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa Alpha',
@@ -254,7 +254,7 @@ describe('FundaeCompanyService', () => {
   describe('update', () => {
     it('update edita razón social y plantilla; mantiene NIF original', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa Original',
@@ -270,7 +270,7 @@ describe('FundaeCompanyService', () => {
 
     it('update lanza CompanyNotFoundError si id desconocido', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       await expect(
         svc.update('t-1', null, 'fantasma', { razonSocial: 'X' }),
       ).rejects.toBeInstanceOf(CompanyNotFoundError);
@@ -280,7 +280,7 @@ describe('FundaeCompanyService', () => {
   describe('softDelete', () => {
     it('softDelete marca deletedAt y publica evento', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa',
@@ -295,7 +295,7 @@ describe('FundaeCompanyService', () => {
 
     it('softDelete es idempotente sobre empresa ya borrada', async () => {
       const prisma = makeFakePrisma();
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa',
@@ -307,7 +307,7 @@ describe('FundaeCompanyService', () => {
 
     it('softDelete rechaza si hay grupos activos vinculados (forward-compat con LMS-81)', async () => {
       const prisma = makeFakePrisma({ groupCount: 2 });
-      const svc = new FundaeCompanyService(prisma as never, ctx);
+      const svc = new FundaeCompanyService(prisma as never, ctx as never);
       const created = await svc.create('t-1', null, {
         nif: 'A58818501',
         razonSocial: 'Empresa',

--- a/modules/fundae/tests/group-xml-export.test.ts
+++ b/modules/fundae/tests/group-xml-export.test.ts
@@ -36,6 +36,10 @@ const GROUP: GroupView = {
   status: 'DRAFT',
   creditoEstimadoCents: 50_000_00,
   creditoConsumidoCents: 0,
+  // El XML de fin de grupo emite `<umbralFinalizacionPct>`; sin este campo el
+  // fixture generaba `undefined` en la salida y nadie se enteraba. 75 es el
+  // default de la columna en el schema.
+  umbralFinalizacionPct: 75,
   costsByTipo: { DIRECTO: 0, INDIRECTO: 0, ORGANIZACION: 0 },
   notas: null,
   createdAt: '2026-04-29T00:00:00.000Z',

--- a/modules/fundae/tests/rlpt.service.test.ts
+++ b/modules/fundae/tests/rlpt.service.test.ts
@@ -89,7 +89,7 @@ function makeFakePrisma(opts: { companies?: CompanyRow[] } = {}) {
           updatedAt: now,
           deletedAt: null,
           evidence: { hash: 'hash-placeholder', size: BigInt(0) },
-          ...(args.data as RlptRow),
+          ...args.data,
         };
         rlptRows.push(row);
         return row;
@@ -108,7 +108,7 @@ function makeFakePrisma(opts: { companies?: CompanyRow[] } = {}) {
   };
 }
 
-function makeCtx(): never {
+function makeCtx() {
   return {
     logger: {
       debug: vi.fn(),
@@ -127,7 +127,7 @@ function makeCtx(): never {
         storageKey: 'evidence/x',
       })),
     },
-  } as never;
+  };
 }
 
 describe('FundaeRlptService.upload', () => {
@@ -136,7 +136,7 @@ describe('FundaeRlptService.upload', () => {
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
     const ctx = makeCtx();
-    const svc = new FundaeRlptService(prisma as never, ctx);
+    const svc = new FundaeRlptService(prisma as never, ctx as never);
 
     const fecha = new Date('2026-04-01T10:00:00.000Z');
     const view = await svc.upload({
@@ -159,7 +159,7 @@ describe('FundaeRlptService.upload', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     const fecha = '2026-04-15T10:00:00.000Z';
     const view = await svc.upload({
       tenantId: 't-1',
@@ -173,7 +173,7 @@ describe('FundaeRlptService.upload', () => {
 
   it('rechaza con CompanyNotFoundError si la empresa no existe en el tenant', async () => {
     const prisma = makeFakePrisma({ companies: [] });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     await expect(
       svc.upload({
         tenantId: 't-1',
@@ -190,7 +190,7 @@ describe('FundaeRlptService.upload', () => {
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
     const ctx = makeCtx();
-    const svc = new FundaeRlptService(prisma as never, ctx);
+    const svc = new FundaeRlptService(prisma as never, ctx as never);
     await svc.upload({
       tenantId: 't-1',
       companyId: 'c-1',
@@ -209,7 +209,7 @@ describe('FundaeRlptService.assertGroupCanStart', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     await expect(
       svc.assertGroupCanStart({ tenantId: 't-1', companyId: 'c-1' }),
     ).rejects.toBeInstanceOf(RlptNotificacionInicialMissingError);
@@ -219,7 +219,7 @@ describe('FundaeRlptService.assertGroupCanStart', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     const fechaNotif = new Date('2026-04-29T10:00:00.000Z');
     await svc.upload({
       tenantId: 't-1',
@@ -239,7 +239,7 @@ describe('FundaeRlptService.assertGroupCanStart', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     const fechaNotif = new Date('2026-04-01T10:00:00.000Z');
     await svc.upload({
       tenantId: 't-1',
@@ -258,7 +258,7 @@ describe('FundaeRlptService.assertGroupCanStart', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     const hoy = new Date('2026-04-29T10:00:00.000Z');
     await svc.upload({
       tenantId: 't-1',
@@ -286,7 +286,7 @@ describe('FundaeRlptService.list / get / softDelete', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     const a = await svc.upload({
       tenantId: 't-1',
       companyId: 'c-1',
@@ -311,7 +311,7 @@ describe('FundaeRlptService.list / get / softDelete', () => {
 
   it('get rechaza con RlptNotFoundError si la id es desconocida', async () => {
     const prisma = makeFakePrisma();
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     await expect(svc.get('t-1', 'no-existe')).rejects.toBeInstanceOf(RlptNotFoundError);
   });
 
@@ -319,7 +319,7 @@ describe('FundaeRlptService.list / get / softDelete', () => {
     const prisma = makeFakePrisma({
       companies: [{ id: 'c-1', tenantId: 't-1', deletedAt: null }],
     });
-    const svc = new FundaeRlptService(prisma as never, makeCtx());
+    const svc = new FundaeRlptService(prisma as never, makeCtx() as never);
     const created = await svc.upload({
       tenantId: 't-1',
       companyId: 'c-1',

--- a/modules/fundae/tsconfig.tests.json
+++ b/modules/fundae/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/gamification/package.json
+++ b/modules/gamification/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/gamification/tsconfig.tests.json
+++ b/modules/gamification/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/hello-world/package.json
+++ b/modules/hello-world/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/hello-world/tsconfig.tests.json
+++ b/modules/hello-world/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/learning/package.json
+++ b/modules/learning/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/learning/tests/drip.service.test.ts
+++ b/modules/learning/tests/drip.service.test.ts
@@ -102,9 +102,9 @@ describe('LearningService.getCourseAvailability (drip)', () => {
     const svc = build({ schedules: [tierSchedule()], userTier: { manualName: 'Pro' } });
     const res = await svc.getCourseAvailability(TENANT, 'u1', COURSE);
     expect(res.drip).toBe(true);
-    expect(res.lessons['L0'].available).toBe(true);
-    expect(res.lessons['L1'].available).toBe(false);
-    expect(res.lessons['L2'].available).toBe(false);
+    expect(res.lessons['L0']!.available).toBe(true);
+    expect(res.lessons['L1']!.available).toBe(false);
+    expect(res.lessons['L2']!.available).toBe(false);
   });
 
   it('tier del usuario NO coincide con el del schedule → sin drip', async () => {
@@ -120,7 +120,7 @@ describe('LearningService.getCourseAvailability (drip)', () => {
     });
     const res = await svc.getCourseAvailability(TENANT, 'u1', COURSE);
     expect(res.drip).toBe(true);
-    expect(res.lessons['L1'].available).toBe(false);
+    expect(res.lessons['L1']!.available).toBe(false);
   });
 
   it('schedule inactivo → no aplica', async () => {
@@ -138,9 +138,9 @@ describe('LearningService.getCourseAvailability (drip)', () => {
       userTier: { manualName: 'Pro' },
     });
     const res = await svc.getCourseAvailability(TENANT, 'u1', COURSE);
-    expect(res.lessons['L0'].available).toBe(true);
-    expect(res.lessons['L1'].available).toBe(true);
-    expect(res.lessons['L2'].available).toBe(false);
+    expect(res.lessons['L0']!.available).toBe(true);
+    expect(res.lessons['L1']!.available).toBe(true);
+    expect(res.lessons['L2']!.available).toBe(false);
   });
 
   // B2: ancla estable = enrolledAt (no startedAt). Regresión del re-bloqueo.
@@ -155,9 +155,9 @@ describe('LearningService.getCourseAvailability (drip)', () => {
     const res = await svc.getCourseAvailability(TENANT, 'u1', COURSE);
     expect(res.drip).toBe(true);
     // Con ancla=enrolledAt (now), L0 está libre. Si usara startedAt (later) estaría bloqueada.
-    expect(res.lessons['L0'].available).toBe(true);
+    expect(res.lessons['L0']!.available).toBe(true);
     // L1 se libera a enrolledAt + 7d, no a startedAt + 7d.
-    const unlock = new Date(res.lessons['L1'].availableAt).getTime();
+    const unlock = new Date(res.lessons['L1']!.availableAt!).getTime();
     expect(Math.abs(unlock - (now.getTime() + 7 * 24 * 60 * 60 * 1000))).toBeLessThan(2000);
   });
 

--- a/modules/learning/tests/learning.service.test.ts
+++ b/modules/learning/tests/learning.service.test.ts
@@ -164,7 +164,9 @@ function makeFakePrisma() {
         findFirst: vi.fn(async ({ where }: { where: Partial<FakeEnrollment> }) => {
           return (
             [...enrollments.values()].find((e) =>
-              Object.entries(where).every(([k, v]) => (e as Record<string, unknown>)[k] === v),
+              Object.entries(where).every(
+                ([k, v]) => (e as unknown as Record<string, unknown>)[k] === v,
+              ),
             ) ?? null
           );
         }),
@@ -331,7 +333,9 @@ function makeFakePrisma() {
               enrollmentId: string;
               lessonId: string;
             };
-            update: Partial<FakeProgress> & { watchedSeconds?: { increment: number } };
+            update: Omit<Partial<FakeProgress>, 'watchedSeconds'> & {
+              watchedSeconds?: number | { increment: number };
+            };
           }) => {
             const key = `${where.enrollmentId_lessonId.enrollmentId}::${where.enrollmentId_lessonId.lessonId}`;
             const existing = progress.get(key);
@@ -370,9 +374,9 @@ function makeFakePrisma() {
   };
 }
 
-function makeContext(): ModuleContext {
+function makeContext() {
   return {
-    eventBus: { publish: vi.fn().mockResolvedValue(undefined), subscribe: vi.fn() } as never,
+    eventBus: { publish: vi.fn().mockResolvedValue(undefined), subscribe: vi.fn() },
     hookRegistry: { register: vi.fn(), run: vi.fn() } as never,
     storage: {} as never,
     auditLog: { record: vi.fn() } as never,
@@ -397,7 +401,7 @@ describe('LearningService', () => {
   it('rechaza enrollar en curso no publicado', async () => {
     const fake = makeFakePrisma();
     fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'DRAFT', deletedAt: null });
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
     await expect(
       service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' }),
     ).rejects.toBeInstanceOf(CourseNotPublishedError);
@@ -407,7 +411,7 @@ describe('LearningService', () => {
     const fake = makeFakePrisma();
     fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'PUBLISHED', deletedAt: null });
     const ctx = makeContext();
-    const service = new LearningService(fake.prisma as never, ctx);
+    const service = new LearningService(fake.prisma as never, ctx as never);
     const e = await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
     expect(e.status).toBe('ACTIVE');
     expect(ctx.eventBus.publish).toHaveBeenCalledWith(
@@ -418,7 +422,7 @@ describe('LearningService', () => {
   it('rechaza doble enrollment activo en mismo (user, course)', async () => {
     const fake = makeFakePrisma();
     fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'PUBLISHED', deletedAt: null });
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
     await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
     await expect(
       service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' }),
@@ -446,7 +450,7 @@ describe('LearningService', () => {
       completedAt: null,
       cancelledAt: new Date(),
     });
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
 
     const reactivated = await service.enrollFromGroup('t-1', 'u-1', 'c-1');
 
@@ -473,7 +477,7 @@ describe('LearningService', () => {
       completedAt: new Date(),
       cancelledAt: null,
     });
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
 
     const result = await service.enrollFromGroup('t-1', 'u-1', 'c-1');
 
@@ -496,7 +500,7 @@ describe('LearningService', () => {
       expiresAt: null,
       revokedAt: null,
     });
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
     const e = await service.enrollByCode('t-1', 'u-1', { code: 'AAAA-BBBB' });
     expect(e.source).toBe('CODE');
     const inv = [...fake.invitations.values()][0];
@@ -517,7 +521,7 @@ describe('LearningService', () => {
       expiresAt: new Date(Date.now() - 10_000),
       revokedAt: null,
     });
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
     await expect(service.enrollByLink('t-1', 'u-1', { token: 'tok' })).rejects.toBeInstanceOf(
       InvitationInvalidError,
     );
@@ -555,7 +559,7 @@ describe('LearningService', () => {
       deletedAt: null,
     });
     const ctx = makeContext();
-    const service = new LearningService(fake.prisma as never, ctx);
+    const service = new LearningService(fake.prisma as never, ctx as never);
     const enroll = await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
 
     await service.trackProgress('t-1', 'u-1', {
@@ -591,7 +595,7 @@ describe('LearningService', () => {
     const fake = makeFakePrisma();
     fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'PUBLISHED', deletedAt: null });
     const ctx = makeContext();
-    const service = new LearningService(fake.prisma as never, ctx);
+    const service = new LearningService(fake.prisma as never, ctx as never);
     const e = await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
     const cancelled = await service.cancelEnrollment('t-1', 'u-1', e.id);
     expect(cancelled.status).toBe('CANCELLED');
@@ -602,7 +606,7 @@ describe('LearningService', () => {
 
   it('cancelEnrollment falla si no existe para el user', async () => {
     const fake = makeFakePrisma();
-    const service = new LearningService(fake.prisma as never, makeContext());
+    const service = new LearningService(fake.prisma as never, makeContext() as never);
     await expect(service.cancelEnrollment('t-1', 'u-1', 'no-existe')).rejects.toBeInstanceOf(
       EnrollmentNotFoundError,
     );
@@ -613,7 +617,7 @@ describe('LearningService', () => {
       const fake = makeFakePrisma();
       fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'PUBLISHED', deletedAt: null });
       const ctx = makeContext();
-      const service = new LearningService(fake.prisma as never, ctx);
+      const service = new LearningService(fake.prisma as never, ctx as never);
       const e = await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
 
       // 'admin' NO es el dueño de la matrícula: cancelEnrollment se lo negaría.
@@ -629,7 +633,7 @@ describe('LearningService', () => {
       const fake = makeFakePrisma();
       fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'PUBLISHED', deletedAt: null });
       const ctx = makeContext();
-      const service = new LearningService(fake.prisma as never, ctx);
+      const service = new LearningService(fake.prisma as never, ctx as never);
       const e = await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
       await service.cancelEnrollmentByAdmin('t-1', 'admin', e.id);
 
@@ -642,7 +646,7 @@ describe('LearningService', () => {
     it('no cruza tenants: la matrícula de otro tenant es NotFound', async () => {
       const fake = makeFakePrisma();
       fake.courses.set('c-1', { id: 'c-1', tenantId: 't-1', status: 'PUBLISHED', deletedAt: null });
-      const service = new LearningService(fake.prisma as never, makeContext());
+      const service = new LearningService(fake.prisma as never, makeContext() as never);
       const e = await service.enrollByAdmin('t-1', 'admin', { userId: 'u-1', courseId: 'c-1' });
 
       await expect(service.cancelEnrollmentByAdmin('t-2', 'admin', e.id)).rejects.toBeInstanceOf(
@@ -654,7 +658,7 @@ describe('LearningService', () => {
   describe('getEnrollmentProgressDetail (vista del formador)', () => {
     it('lanza EnrollmentNotFoundError si la matrícula no existe', async () => {
       const fake = makeFakePrisma();
-      const service = new LearningService(fake.prisma as never, makeContext());
+      const service = new LearningService(fake.prisma as never, makeContext() as never);
       await expect(
         service.getEnrollmentProgressDetail('t-1', 'c-1', 'no-existe'),
       ).rejects.toBeInstanceOf(EnrollmentNotFoundError);
@@ -722,7 +726,7 @@ describe('LearningService', () => {
         lastAccessedAt,
       });
 
-      const service = new LearningService(fake.prisma as never, makeContext());
+      const service = new LearningService(fake.prisma as never, makeContext() as never);
       const detail = await service.getEnrollmentProgressDetail('t-1', 'c-1', 'en-1');
 
       expect(detail.enrollmentId).toBe('en-1');
@@ -775,7 +779,7 @@ describe('LearningService', () => {
     it('approveLessonComment aprueba un comentario del propio tenant', async () => {
       const fake = makeFakePrisma();
       seedComment(fake, 't-1');
-      const service = new LearningService(fake.prisma as never, makeContext());
+      const service = new LearningService(fake.prisma as never, makeContext() as never);
       const res = await service.approveLessonComment('t-1', 'rev-1', 'cm-1');
       expect((res as { status: string }).status).toBe('APPROVED');
     });
@@ -783,7 +787,7 @@ describe('LearningService', () => {
     it('approveLessonComment NO aprueba un comentario de OTRO tenant (write cross-tenant bloqueado)', async () => {
       const fake = makeFakePrisma();
       seedComment(fake, 't-2'); // comentario del tenant B
-      const service = new LearningService(fake.prisma as never, makeContext());
+      const service = new LearningService(fake.prisma as never, makeContext() as never);
       await expect(service.approveLessonComment('t-1', 'rev-1', 'cm-1')).rejects.toBeInstanceOf(
         EnrollmentNotFoundError,
       );
@@ -794,7 +798,7 @@ describe('LearningService', () => {
     it('rejectLessonComment NO rechaza un comentario de OTRO tenant', async () => {
       const fake = makeFakePrisma();
       seedComment(fake, 't-2');
-      const service = new LearningService(fake.prisma as never, makeContext());
+      const service = new LearningService(fake.prisma as never, makeContext() as never);
       await expect(
         service.rejectLessonComment('t-1', 'rev-1', 'cm-1', 'spam'),
       ).rejects.toBeInstanceOf(EnrollmentNotFoundError);

--- a/modules/learning/tsconfig.tests.json
+++ b/modules/learning/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/member-registration/package.json
+++ b/modules/member-registration/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/member-registration/tests/signed-ticket.test.ts
+++ b/modules/member-registration/tests/signed-ticket.test.ts
@@ -42,7 +42,7 @@ describe('signed-ticket', () => {
       const ticket = signTicket({ a: 1 }, SECRET, 300);
       const [data] = ticket.split('.');
       // Reemplazamos la firma por una de la misma longitud pero inválida.
-      const tampered = `${data}.${'A'.repeat(ticket.split('.')[1].length)}`;
+      const tampered = `${data}.${'A'.repeat(ticket.split('.')[1]!.length)}`;
       expect(verifyTicket(tampered, SECRET)).toBeNull();
     });
 
@@ -50,8 +50,8 @@ describe('signed-ticket', () => {
       const ticket = signTicket({ a: 1 }, SECRET, 300);
       const [data, sig] = ticket.split('.');
       // Misma longitud de data pero contenido distinto ⇒ firma no cuadra.
-      const flippedChar = data[0] === 'A' ? 'B' : 'A';
-      const tamperedData = flippedChar + data.slice(1);
+      const flippedChar = data![0] === 'A' ? 'B' : 'A';
+      const tamperedData = flippedChar + data!.slice(1);
       expect(verifyTicket(`${tamperedData}.${sig}`, SECRET)).toBeNull();
     });
 

--- a/modules/member-registration/tsconfig.tests.json
+++ b/modules/member-registration/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/messaging/package.json
+++ b/modules/messaging/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/messaging/tests/messaging.service.test.ts
+++ b/modules/messaging/tests/messaging.service.test.ts
@@ -301,7 +301,7 @@ const USERS: Record<string, MessagingPublicUser> = {
 };
 
 function callerOf(key: keyof typeof USERS, roles: string[] = ['alumno']): MessagingCaller {
-  return { userId: USERS[key].id, displayName: USERS[key].name, roles };
+  return { userId: USERS[key]!.id, displayName: USERS[key]!.name, roles };
 }
 
 describe('MessagingService', () => {
@@ -320,15 +320,15 @@ describe('MessagingService', () => {
       built.publisher,
       async () => spaces,
       async (_tenantId, ids) => Object.values(USERS).filter((u) => ids.includes(u.id)),
-      async () => [USERS.profe.id],
+      async () => [USERS.profe!.id],
     );
   });
 
   describe('openDm', () => {
     it('crea el DM una sola vez por par (idempotente)', async () => {
-      const first = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const first = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       expect(first.created).toBe(true);
-      const second = await service.openDm(TENANT, callerOf('bob'), USERS.alice.id);
+      const second = await service.openDm(TENANT, callerOf('bob'), USERS.alice!.id);
       expect(second.created).toBe(false);
       expect(second.conversationId).toBe(first.conversationId);
       expect(prisma.conversations.filter((c) => c.type === 'DM')).toHaveLength(1);
@@ -337,7 +337,7 @@ describe('MessagingService', () => {
     });
 
     it('rechaza el DM con uno mismo', async () => {
-      await expect(service.openDm(TENANT, callerOf('alice'), USERS.alice.id)).rejects.toThrow(
+      await expect(service.openDm(TENANT, callerOf('alice'), USERS.alice!.id)).rejects.toThrow(
         SelfDmError,
       );
     });
@@ -349,7 +349,7 @@ describe('MessagingService', () => {
     });
 
     it('resuelve la carrera P2002 devolviendo el DM existente', async () => {
-      await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       // Fuerza la rama de carrera: findFirst inicial "no lo ve".
       const original = prisma.modMessagingConversation.findFirst;
       let calls = 0;
@@ -358,7 +358,7 @@ describe('MessagingService', () => {
         if (calls === 1) return null;
         return original(args);
       }) as never;
-      const raced = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const raced = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       expect(raced.created).toBe(false);
       expect(prisma.conversations.filter((c) => c.type === 'DM')).toHaveLength(1);
     });
@@ -366,7 +366,7 @@ describe('MessagingService', () => {
 
   describe('sendMessage', () => {
     it('valida el cuerpo (vacío y >4000)', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       await expect(
         service.sendMessage(TENANT, callerOf('alice'), conversationId, '   '),
       ).rejects.toThrow(MessageBodyInvalidError);
@@ -376,7 +376,7 @@ describe('MessagingService', () => {
     });
 
     it('persiste, actualiza lastMessageAt y devuelve al otro como destinatario', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       const result = await service.sendMessage(
         TENANT,
         callerOf('alice'),
@@ -385,21 +385,21 @@ describe('MessagingService', () => {
       );
       expect(result.message.body).toBe('Hola 👋');
       expect(result.message.authorDisplayName).toBe('Alice Alumna');
-      expect(result.recipientUserIds).toEqual([USERS.bob.id]);
+      expect(result.recipientUserIds).toEqual([USERS.bob!.id]);
       const conv = prisma.conversations.find((c) => c.id === conversationId);
       expect(conv?.lastMessageAt).not.toBeNull();
       expect(events.some((e) => e.name === 'messaging.message.sent')).toBe(true);
     });
 
     it('rechaza a quien no participa del DM', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       await expect(
         service.sendMessage(TENANT, callerOf('profe', ['alumno']), conversationId, 'intruso'),
       ).rejects.toThrow(NotParticipantError);
     });
 
     it('no encuentra conversaciones de otro tenant (aislamiento)', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       await expect(
         service.sendMessage(OTHER_TENANT, callerOf('alice'), conversationId, 'cruce'),
       ).rejects.toThrow(ConversationNotFoundError);
@@ -429,7 +429,7 @@ describe('MessagingService', () => {
         'hola sala',
       );
       // Alice abrió la sala (fila de participante) → recibe el push.
-      expect(result.recipientUserIds).toEqual([USERS.alice.id]);
+      expect(result.recipientUserIds).toEqual([USERS.alice!.id]);
     });
 
     it('una sala cuyo espacio ya no existe queda archivada (fuera del listado)', async () => {
@@ -478,8 +478,8 @@ describe('MessagingService', () => {
         conversationId,
         'Te respondo ahora mismo',
       );
-      expect(reply.recipientUserIds).toContain(USERS.alice.id);
-      expect(reply.recipientUserIds).not.toContain(USERS.profe.id);
+      expect(reply.recipientUserIds).toContain(USERS.alice!.id);
+      expect(reply.recipientUserIds).not.toContain(USERS.profe!.id);
     });
 
     it('la bandeja del staff solo lista canales con actividad, titulados con el alumno', async () => {
@@ -498,7 +498,7 @@ describe('MessagingService', () => {
 
   describe('no-leídos y lectura', () => {
     it('cuenta solo mensajes ajenos posteriores a lastReadAt y markRead los limpia', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       await service.sendMessage(TENANT, callerOf('alice'), conversationId, 'uno');
       await service.sendMessage(TENANT, callerOf('alice'), conversationId, 'dos');
 
@@ -526,12 +526,12 @@ describe('MessagingService', () => {
 
   describe('autoría del último mensaje (píldora del chat flotante)', () => {
     it('el listado expone el authorId del último mensaje', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       await service.sendMessage(TENANT, callerOf('alice'), conversationId, 'hola');
 
       const list = await service.listConversations(TENANT, callerOf('bob'));
       const dm = list.find((c) => c.id === conversationId);
-      expect(dm?.lastMessage?.authorId).toBe(USERS.alice.id);
+      expect(dm?.lastMessage?.authorId).toBe(USERS.alice!.id);
       expect(dm?.lastMessage?.authorDisplayName).toBe('Alice Alumna');
     });
 
@@ -544,17 +544,17 @@ describe('MessagingService', () => {
 
   describe('destinatarios del indicador de escritura', () => {
     it('en un directo, el otro participante', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       const recipients = await service.recipientsForTyping(
         TENANT,
         callerOf('alice'),
         conversationId,
       );
-      expect(recipients).toEqual([USERS.bob.id]);
+      expect(recipients).toEqual([USERS.bob!.id]);
     });
 
     it('quien no participa no puede anunciar que escribe', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       await expect(
         service.recipientsForTyping(TENANT, callerOf('profe', ['alumno']), conversationId),
       ).rejects.toThrow(NotParticipantError);
@@ -569,7 +569,7 @@ describe('MessagingService', () => {
 
       await service.openSpace(TENANT, callerOf('bob'), 'general');
       expect(await service.recipientsForTyping(TENANT, callerOf('alice'), conversationId)).toEqual([
-        USERS.bob.id,
+        USERS.bob!.id,
       ]);
     });
   });
@@ -583,13 +583,13 @@ describe('MessagingService', () => {
     });
 
     it('pagina el histórico por cursor (50 por página, desc)', async () => {
-      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob.id);
+      const { conversationId } = await service.openDm(TENANT, callerOf('alice'), USERS.bob!.id);
       for (let i = 0; i < 55; i += 1) {
         prisma.messages.push({
           id: `feedf00d-0000-0000-0000-${String(i).padStart(12, '0')}`,
           tenantId: TENANT,
           conversationId,
-          authorId: USERS.alice.id,
+          authorId: USERS.alice!.id,
           authorDisplayName: 'Alice Alumna',
           kind: 'TEXT',
           body: `msg ${i}`,

--- a/modules/messaging/tsconfig.tests.json
+++ b/modules/messaging/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/migrator-learndash/package.json
+++ b/modules/migrator-learndash/package.json
@@ -23,7 +23,7 @@
     "build:ui": "esbuild src/ui/admin.tsx --bundle --platform=browser --target=es2020 --format=iife --global-name=__didacta_module_exports__ --jsx=transform --jsx-factory=React.createElement --jsx-fragment=React.Fragment --outfile=dist/ui/admin.js",
     "build:tsc": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.ui.json --noEmit && tsc -p tsconfig.scripts.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit && tsc -p tsconfig.ui.json --noEmit && tsc -p tsconfig.scripts.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo .vitest-cache"

--- a/modules/migrator-learndash/tests/unit/connector.test.ts
+++ b/modules/migrator-learndash/tests/unit/connector.test.ts
@@ -21,7 +21,7 @@ describe('ApplicationPasswordAuth', () => {
     const auth = new ApplicationPasswordAuth('admin', 'app pass word');
     const header = auth.headers().Authorization;
     expect(header).toMatch(/^Basic /);
-    const decoded = Buffer.from(header.replace('Basic ', ''), 'base64').toString('utf8');
+    const decoded = Buffer.from(header!.replace('Basic ', ''), 'base64').toString('utf8');
     expect(decoded).toBe('admin:app pass word');
   });
 

--- a/modules/migrator-learndash/tests/unit/job-tick.test.ts
+++ b/modules/migrator-learndash/tests/unit/job-tick.test.ts
@@ -102,6 +102,9 @@ function makeCtx(db: unknown, overrides: Record<string, unknown> = {}) {
     db,
     http: {} as unknown,
     didacta: {} as unknown,
+    // El contrato de tick declara `secrets`: sin él el doble no cumple
+    // ModuleJobTickContext y el cast deja de solapar.
+    secrets: {} as unknown,
     ...overrides,
   } as Parameters<typeof onJobTick>[0];
 }

--- a/modules/migrator-learndash/tests/unit/loader-skip-visibility.test.ts
+++ b/modules/migrator-learndash/tests/unit/loader-skip-visibility.test.ts
@@ -94,7 +94,9 @@ function stgRowWithSentinel(opts: {
 
 function makeCtx(db: unknown, overrides: Record<string, unknown> = {}) {
   const log = vi.fn();
-  const lessonsUpsert = vi.fn(async () => ({ id: 'didacta-uuid-of-lesson' }));
+  const lessonsUpsert = vi.fn(async (_input: Record<string, unknown>) => ({
+    id: 'didacta-uuid-of-lesson',
+  }));
   return {
     moduleName: 'mod.migrator-learndash',
     moduleVersion: '1.0.33',
@@ -166,7 +168,9 @@ describe('loader skip visibility (v1.0.33)', () => {
         contentHtml: '<p>content</p>',
       },
     });
-    const lessonsUpsert = vi.fn(async () => ({ id: 'lesson-uuid-202' }));
+    const lessonsUpsert = vi.fn(async (_input: Record<string, unknown>) => ({
+      id: 'lesson-uuid-202',
+    }));
     const { db, calls } = makeDbStub({
       queryRows: [[jobLoadingRow('topics')], [topicRow], []],
       executeRowCounts: [1, 1, 1],

--- a/modules/migrator-learndash/tests/unit/routes-auth.test.ts
+++ b/modules/migrator-learndash/tests/unit/routes-auth.test.ts
@@ -124,9 +124,9 @@ describe('migrator-learndash · POST /preflight con http mockeado', () => {
     appPassword: 'app pass-1234',
   };
 
-  function makeHttp(
-    handler: (url: string) => { status: number; body?: string; headers?: Record<string, string> },
-  ) {
+  type HttpStubResponse = { status: number; body?: string; headers?: Record<string, string> };
+
+  function makeHttp(handler: (url: string) => HttpStubResponse) {
     const make = async (url: string) => {
       const r = handler(url);
       return {
@@ -142,7 +142,7 @@ describe('migrator-learndash · POST /preflight con http mockeado', () => {
   it('happy path: devuelve counts reales leyendo X-WP-Total', async () => {
     const route = routes.find((r) => r.method === 'POST' && r.path === '/preflight')!;
     const calls: string[] = [];
-    const http = makeHttp((url) => {
+    const http = makeHttp((url): HttpStubResponse => {
       calls.push(url);
       if (url.endsWith('/wp-json/')) {
         return {
@@ -219,7 +219,7 @@ describe('migrator-learndash · POST /preflight con http mockeado', () => {
 
   it('LearnDash REST 404 → warning LEARNDASH_REST_UNAVAILABLE pero sigue contando', async () => {
     const route = routes.find((r) => r.method === 'POST' && r.path === '/preflight')!;
-    const http = makeHttp((url) => {
+    const http = makeHttp((url): HttpStubResponse => {
       if (url.endsWith('/wp-json/')) return { status: 200, body: '{}' };
       if (url.includes('/ldlms/v1/')) return { status: 404, body: '' };
       return { status: 200, body: '[]', headers: { 'x-wp-total': '5' } };
@@ -244,7 +244,7 @@ describe('migrator-learndash · POST /preflight con http mockeado', () => {
 
   it('CPT 404 → counts: unknown con warning CPT_NOT_FOUND', async () => {
     const route = routes.find((r) => r.method === 'POST' && r.path === '/preflight')!;
-    const http = makeHttp((url) => {
+    const http = makeHttp((url): HttpStubResponse => {
       if (url.endsWith('/wp-json/')) return { status: 200, body: '{}' };
       if (url.includes('/ldlms/v1/')) return { status: 200, body: '[]' };
       if (url.includes('sfwd-topic')) return { status: 404, body: '' };

--- a/modules/migrator-learndash/tsconfig.tests.json
+++ b/modules/migrator-learndash/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "web", "src/ui"]
+}

--- a/modules/payment-connections/package.json
+++ b/modules/payment-connections/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/payment-connections/tsconfig.tests.json
+++ b/modules/payment-connections/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/referrals/package.json
+++ b/modules/referrals/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/referrals/tsconfig.tests.json
+++ b/modules/referrals/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/resources/package.json
+++ b/modules/resources/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/resources/tsconfig.tests.json
+++ b/modules/resources/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/subscriptions/package.json
+++ b/modules/subscriptions/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/subscriptions/tests/membership.service.test.ts
+++ b/modules/subscriptions/tests/membership.service.test.ts
@@ -28,6 +28,7 @@ import type {
   SubscriptionsStripeAdapter,
   CreateSubscriptionCheckoutParams,
   CreateRecurringPriceParams,
+  EndTrialNowResult,
 } from '../src/stripe-subscriptions.client.js';
 import type { SubscriptionsEventPublisher } from '../src/subscriptions.service.js';
 
@@ -260,14 +261,16 @@ function stubStripe() {
     id: 'cs_test_1',
     url: `https://checkout.stripe.test/${p.priceId}`,
   }));
-  const endTrialNow = vi.fn(async (subscriptionId: string) => ({
-    id: subscriptionId,
-    status: 'active',
-    cancelAtPeriodEnd: false,
-    currentPeriodEnd: Math.floor(Date.now() / 1000) + 86400 * 30,
-    canceledAt: null,
-    latestInvoicePaid: true,
-  }));
+  const endTrialNow = vi.fn(
+    async (subscriptionId: string): Promise<EndTrialNowResult> => ({
+      id: subscriptionId,
+      status: 'active',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: Math.floor(Date.now() / 1000) + 86400 * 30,
+      canceledAt: null,
+      latestInvoicePaid: true,
+    }),
+  );
   const adapter: SubscriptionsStripeAdapter = {
     createCheckoutSession,
     retrievePrice: async () => {

--- a/modules/subscriptions/tsconfig.tests.json
+++ b/modules/subscriptions/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/surveys/package.json
+++ b/modules/surveys/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/surveys/tsconfig.tests.json
+++ b/modules/surveys/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/theming/package.json
+++ b/modules/theming/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/theming/tsconfig.tests.json
+++ b/modules/theming/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/modules/wp-sso/package.json
+++ b/modules/wp-sso/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/wp-sso/tsconfig.tests.json
+++ b/modules/wp-sso/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "wordpress"]
+}

--- a/modules/zoom-live/package.json
+++ b/modules/zoom-live/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/modules/zoom-live/tests/zoom-host-not-found.test.ts
+++ b/modules/zoom-live/tests/zoom-host-not-found.test.ts
@@ -14,7 +14,7 @@ const CREDS = { accountId: 'acc', clientId: 'cid', clientSecret: 'secret' };
 
 const INPUT = {
   topic: 'Masterclass',
-  startTime: new Date('2026-08-03T14:00:00.000Z'),
+  startTime: new Date('2026-08-03T14:00:00.000Z').toISOString(),
   durationMinutes: 90,
   timezone: 'Europe/Madrid',
   hostEmail: 'anfitrion@example.com',

--- a/modules/zoom-live/tsconfig.tests.json
+++ b/modules/zoom-live/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "src/ui"]
+}

--- a/packages/core-kernel/package.json
+++ b/packages/core-kernel/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/packages/core-kernel/tsconfig.tests.json
+++ b/packages/core-kernel/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core-registry/package.json
+++ b/packages/core-registry/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/packages/core-registry/tsconfig.tests.json
+++ b/packages/core-registry/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/license-sdk/package.json
+++ b/packages/license-sdk/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && node -e \"require('fs').cpSync('src/public-keys','dist/public-keys',{recursive:true})\"",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/packages/license-sdk/tsconfig.tests.json
+++ b/packages/license-sdk/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/module-package-spec/package.json
+++ b/packages/module-package-spec/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo"

--- a/packages/module-package-spec/tsconfig.tests.json
+++ b/packages/module-package-spec/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "//": "Typecheck de tests/. tsconfig.json es el config de BUILD (emite a dist/ con rootDir=src) y por eso no puede incluir tests/. Sin este config los tests no se typechequean y un cambio de firma en src/ los rompe en silencio: el fallo solo aparece en runtime, y solo si algún test ejercita esa ruta.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -59,8 +59,37 @@ run_step() {
 
 step_types() {
   # Typecheck de los workspaces principales sin emitir.
-  run_step "typecheck apps/api" $TSC --noEmit -p apps/api/tsconfig.json || return 1
+  #
+  # apps/api usa `tsconfig.tests.json`, NO `tsconfig.json`: el segundo es el
+  # config de BUILD (nest-cli emite a dist/ desde él) y por eso se limita a
+  # `src/**`. El primero es un superconjunto — src + tests + scripts — y es el
+  # único que mira `apps/api/tests/**`. Sin esto, un cambio de firma en src
+  # rompía los tests en silencio: solo saltaba en runtime, y solo si algún
+  # test ejercitaba esa ruta concreta.
+  run_step "typecheck apps/api (src + tests)" $TSC --noEmit -p apps/api/tsconfig.tests.json || return 1
+  # apps/web no necesita config aparte: sus tests viven en `src/**` y ya entran.
   run_step "typecheck apps/web" $TSC --noEmit -p apps/web/tsconfig.json || return 1
+  # apps/e2e ya incluía `tests/**` en su tsconfig; se añade aquí para que
+  # dev-check lo cubra sin depender del workflow e2e.
+  run_step "typecheck apps/e2e" $TSC --noEmit -p apps/e2e/tsconfig.json || return 1
+  # packages/* y modules/* llevan su propio `tsconfig.tests.json` por la misma
+  # razón que apps/api (su `tsconfig.json` emite a dist/ con rootDir=src).
+  step_types_workspaces || return 1
+}
+
+# Typecheck de tests de packages/* y modules/*. Cada workspace con `tests/`
+# tiene un `tsconfig.tests.json`; se recorren todos y se acumulan los fallos
+# para reportar la lista completa en una sola pasada.
+step_types_workspaces() {
+  local failed=0
+  local cfg
+  for cfg in packages/*/tsconfig.tests.json modules/*/tsconfig.tests.json; do
+    [[ -f "$cfg" ]] || continue
+    if ! run_step "typecheck ${cfg%/tsconfig.tests.json} (src + tests)" $TSC --noEmit -p "$cfg"; then
+      failed=1
+    fi
+  done
+  return $failed
 }
 
 step_lint() {


### PR DESCRIPTION
## El defecto

`apps/api/tsconfig.json` solo incluía `src/**`, así que **`apps/api/tests/**` (165 ficheros) quedaba fuera del `tsc`** que corren `dev-check` y CI.

Auditando el resto del monorepo, **el agujero era sistémico**: los 5 `packages/*` y los 24 `modules/*` excluyen `tests` explícitamente. La razón es legítima — su `tsconfig.json` es el config de **build** (`tsc -p tsconfig.json` emite a `dist/` con `rootDir: src`), y meter `tests/` ahí rompería el layout de `dist/` y la superficie publicada. Pero nadie añadió el config complementario, así que **259 ficheros de test no se typechequeaban en ningún sitio**.

| workspace | estado previo |
|---|---|
| `apps/api` | ❌ 165 tests fuera |
| `packages/*` (5) | ❌ 7 tests fuera |
| `modules/*` (24) | ❌ 87 tests fuera |
| `apps/web` | ✅ ya cubierto — sus 41 tests viven en `src/**` |
| `apps/e2e` | ✅ ya cubierto — su `include` ya listaba `tests/`, `helpers/`, `shots/` |

## El arreglo

- **`tsconfig.tests.json` por workspace (29)**: extiende el de build, `noEmit: true`, `rootDir: "."` e `include` con `tests/**`. Conserva el `exclude` original de cada uno (`src/ui`, `web`, `wordpress`) para no arrastrar código que el build tampoco mira. **Ninguna opción de `strict` se relaja** — ni `noUncheckedIndexedAccess`, ni `noImplicitAny`, nada.
- El script `typecheck` de cada `package.json` apunta ahí, así que **`turbo run typecheck` (el paso de CI) lo ejecuta**.
- `dev-check.sh` typechequea api (src+tests), web, e2e y los 29 workspaces.
- En `apps/api/tsconfig.tests.json` el `module` pasa a `ES2022`: el de build es CommonJS porque eso ejecuta producción, pero **vitest transforma los tests a ES modules con swc**, así que `import.meta` (que un test usa) es legal en runtime y con CommonJS `tsc` lo rechazaba (TS1343) pese a funcionar.

## Lo que apareció al encenderlo

**575 errores reales** (364 en `apps/api`, 211 en `modules/*`, 0 en `packages/*`). Todos corregidos **en el test**, salvo un hallazgo de producto. Cero `@ts-ignore` / `@ts-expect-error` añadidos.

### Fixtures desincronizadas con el contrato (la clase que motivó el encargo)

- `SessionClaims` sin `mfaVerified` — **17 ficheros**.
- `AdminUsersService` instanciado con **4 de los 6** argumentos del constructor.
- `CreateInstallingInput` sin `source` (campo añadido en DISC-002).
- El doble de `StorageService` sin `uploadImage`.
- `GroupView` sin `umbralFinalizacionPct`: **el XML de fin de grupo lo emitía como `undefined`** y el test no lo miraba.
- `ModuleJobTickContext` sin `secrets`.

### Dobles que no declaraban los argumentos que producción les pasa

`vi.fn(async () => …)` sin parámetros hace que `mock.calls[0][0]` no exista para el typecheck — es decir, **las aserciones sobre esos argumentos eran incomprobables**. Afectaba a los workers de subscriptions y referrals (el `now` propagado al procesado por tenant), el publisher de realtime, la cola de `mod-jobs` y el dispatcher del marketplace.

### Spreads que mentían

`...(args.data as XRow)` sobre un `Partial<XRow>` hace creer a TS que el spread trae la fila entera, dejando **los defaults de arriba como código muerto** (TS2783). En 5 fakes de Prisma.

### Dobles casteados a `never` en su declaración

Con `never` no se puede leer ninguna propiedad, así que `expect(logger.error).toHaveBeenCalled()` no se typechequeaba. El cast pasa al punto de inyección, donde es lo único que hace falta.

### Accesos indexados bajo `noUncheckedIndexedAccess`

Aserción no-nula en el sitio donde el test **ya comprobó la longitud** justo antes. Donde el ruido era grande se arregló en la raíz: `const [n] = arr` → `const n = arr[0]!` mata 40 errores con una línea.

## Hallazgo de producto (arreglado, 1 línea x2)

`GroqAdapter.embed()` y `OpenRouterAdapter.embed()` declaraban **cero parámetros** al sobrescribir un método de 2. TypeScript lo permite (bivarianza), pero **estrecha la firma pública del subtipo**: llamar `new GroqAdapter().embed(input, config)` — el contrato documentado, y lo que hace el test — no compilaba.

- `apps/api/src/ai/adapters/openai.adapter.ts:160`
- `apps/api/src/ai/adapters/openai.adapter.ts:172`

Es el único cambio en código de producción de todo el PR.

## Verificación

- `dev-check.sh --quick` verde: typecheck de api (src+tests), web, e2e y los 29 workspaces + eslint + prettier.
- `pnpm typecheck` (lo que corre CI): **60/60 tareas turbo**.
- api **2257/2257** · web **356/356** · modules+packages **1300+ tests**, todos verdes.
- `ee-fence`: **0 violaciones** (1404 ficheros).
- Build de api y de los 29 workspaces sin cambios en el layout de `dist/` — verificado que no se cuela ningún test en el artefacto.
- E2E: SKIP, según el encargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
