### PR TITLE
fix(e2e): la intermitencia de tres specs era otro proceso comiéndose la cola del outbox

### DIFF
--- a/apps/api/src/modules/admin-system.controller.ts
+++ b/apps/api/src/modules/admin-system.controller.ts
@@ -50,6 +50,14 @@ interface OutboxCheck {
   pendingEvents: number;
   oldestPendingAgeSeconds: number;
   lagWarningThresholdSeconds: number;
+  /**
+   * Workers de BullMQ atados a la cola `didacta.outbox` en ESTE Redis,
+   * incluidos los de otros procesos. Con N réplicas desplegadas debe valer N:
+   * un número mayor significa que hay un proceso de más comiéndose eventos del
+   * bus, y los que se lleva no llegan a los bridges de nadie más. Ver
+   * `OutboxQueueService.countWorkers()`.
+   */
+  dispatchers: number;
   detail?: string | null;
 }
 
@@ -176,13 +184,17 @@ export class AdminSystemController {
 
   private async checkOutbox(): Promise<OutboxCheck> {
     try {
-      const sample = await this.outboxRecovery.sampleLag();
+      const [sample, dispatchers] = await Promise.all([
+        this.outboxRecovery.sampleLag(),
+        this.outboxQueue.countWorkers(),
+      ]);
       const lagging = sample.oldestAgeSeconds > OUTBOX_LAG_WARNING_SECONDS;
       return {
         status: lagging ? 'lagging' : 'ok',
         pendingEvents: sample.pending,
         oldestPendingAgeSeconds: sample.oldestAgeSeconds,
         lagWarningThresholdSeconds: OUTBOX_LAG_WARNING_SECONDS,
+        dispatchers,
       };
     } catch (e) {
       return {
@@ -190,6 +202,7 @@ export class AdminSystemController {
         pendingEvents: 0,
         oldestPendingAgeSeconds: 0,
         lagWarningThresholdSeconds: OUTBOX_LAG_WARNING_SECONDS,
+        dispatchers: 0,
         detail: e instanceof Error ? e.message : String(e),
       };
     }

--- a/apps/api/src/modules/outbox-queue.service.ts
+++ b/apps/api/src/modules/outbox-queue.service.ts
@@ -134,6 +134,34 @@ export class OutboxQueueService implements OnApplicationBootstrap, OnModuleDestr
   }
 
   /**
+   * Cuántos workers hay ENCHUFADOS a esta cola en este Redis, contando los de
+   * otros procesos.
+   *
+   * No es una curiosidad: BullMQ entrega cada job a **un solo** worker. Si dos
+   * procesos distintos se suscriben a `didacta.outbox` sobre el mismo Redis,
+   * los eventos se reparten entre ellos al azar, y los que se lleva el otro
+   * proceso **jamás llegan a los bridges de éste** — pero la fila de
+   * `outbox_event` vuelve marcada `processed_at` sin error, indistinguible de
+   * una entrega correcta. Es exactamente el modo de fallo que dejó tres specs
+   * E2E cayendo de forma intermitente durante varias sesiones: un API huérfano
+   * de otra sesión seguía atado al Redis del arnés y se comía la mitad del
+   * tráfico del bus.
+   *
+   * `getWorkers()` es de BullMQ y no necesita cooperación del otro proceso:
+   * cada worker nombra su conexión bloqueante `bull:<base64(cola)>` al
+   * conectarse, así que un binario viejo también se cuenta.
+   *
+   * En producción con N réplicas el valor esperado es N; el número no es
+   * bueno ni malo por sí solo, por eso se EXPONE (health-detail) en vez de
+   * convertirlo en un error aquí. Quien sabe cuántos debería haber es el
+   * operador — o el arnés E2E, que sabe que debe ser exactamente 1.
+   */
+  async countWorkers(): Promise<number> {
+    if (!this.queue) return 0;
+    return (await this.queue.getWorkers()).length;
+  }
+
+  /**
    * Encola el despacho de un evento ya persistido en outbox_event.
    *
    * El `jobId` sigue derivándose de la fila para que BullMQ deduplique cuando

--- a/apps/api/tests/admin-system.controller.test.ts
+++ b/apps/api/tests/admin-system.controller.test.ts
@@ -17,6 +17,7 @@ function makeController(opts: {
   pending?: number;
   oldestAgeSeconds?: number;
   outboxThrows?: boolean;
+  dispatchers?: number;
 }): AdminSystemController {
   const smtpRows: SmtpRow[] = [];
   for (let i = 0; i < (opts.smtpConfigured ?? 0); i++) {
@@ -40,6 +41,7 @@ function makeController(opts: {
   const outboxQueue = {
     isEnabled: () => opts.redisStatus !== 'disabled',
     ping: async () => opts.redisStatus === 'ok',
+    countWorkers: async () => opts.dispatchers ?? 1,
   };
 
   const outboxRecovery = {
@@ -152,5 +154,23 @@ describe('AdminSystemController.healthDetail', () => {
     const r = await c.healthDetail(ADMIN as never);
     expect(r.checks.outbox.status).toBe('error');
     expect(r.status).toBe('unhealthy');
+  });
+
+  // El número de despachadores atados a la cola del outbox se EXPONE, no se
+  // juzga: con N réplicas desplegadas el valor correcto es N. Quien sabe
+  // cuántos debería haber es el operador — y el arnés E2E, que exige 1.
+  it('expone cuántos procesos consumen la cola del outbox', async () => {
+    const c = makeController({ redisStatus: 'ok', storageKind: 'local', dispatchers: 2 });
+    const r = await c.healthDetail(ADMIN as never);
+    expect(r.checks.outbox.dispatchers).toBe(2);
+    // Dos consumidores no son un error del sistema: es el dato que permite
+    // detectarlo a quien sí sabe cuántos esperaba.
+    expect(r.checks.outbox.status).toBe('ok');
+  });
+
+  it('dispatchers=0 cuando el despachador no está atado', async () => {
+    const c = makeController({ redisStatus: 'disabled', storageKind: 'local', dispatchers: 0 });
+    const r = await c.healthDetail(ADMIN as never);
+    expect(r.checks.outbox.dispatchers).toBe(0);
   });
 });

--- a/apps/api/tests/outbox-queue.service.test.ts
+++ b/apps/api/tests/outbox-queue.service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { OutboxQueueService } from '../src/modules/outbox-queue.service';
+
+/**
+ * `countWorkers()` responde a la pregunta «¿cuántos procesos están consumiendo
+ * esta cola?», que es la que distingue un bus sano de uno en el que otro
+ * proceso se está llevando la mitad de los eventos sin que nadie se entere.
+ */
+describe('OutboxQueueService.countWorkers', () => {
+  function makeService(): OutboxQueueService {
+    const factory = { getEventBus: () => ({}) };
+    const logger = { log() {}, warn() {}, error() {}, debug() {} };
+    const metrics = {
+      recordDispatchDuration() {},
+      recordDispatchFailed() {},
+      recordDispatchCompleted() {},
+      recordEnqueueCollision() {},
+    };
+    return new OutboxQueueService(factory as never, logger as never, metrics as never);
+  }
+
+  it('devuelve 0 sin cola inicializada en vez de reventar', async () => {
+    // Sin REDIS_URL el dispatcher no se monta. Cero es la respuesta honesta —
+    // «no hay nadie despachando»— y es justo lo que el arnés convierte en un
+    // fallo con nombre: un 0 aquí significa que los eventos se van a quedar
+    // pendientes para siempre.
+    expect(await makeService().countWorkers()).toBe(0);
+  });
+
+  it('cuenta los workers que BullMQ ve atados a la cola', async () => {
+    const service = makeService();
+    // La cola es privada a propósito (nadie de fuera debe encolar sin pasar por
+    // `enqueue`), así que el doble se inyecta como lo haría el bootstrap.
+    (service as unknown as { queue: { getWorkers: () => Promise<unknown[]> } }).queue = {
+      getWorkers: async () => [{ id: 'a' }, { id: 'b' }],
+    };
+    expect(await service.countWorkers()).toBe(2);
+  });
+});

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -21,6 +21,8 @@
  *   4. Secretos de webhooks de pago presentes.
  *   5. Espacios de sistema sembrados (`prisma/seed.sql`).
  *   6. Onboarding cerrado para los admins sembrados.
+ *   7. UN SOLO despachador atado a la cola del outbox — ver
+ *      `assertSingleOutboxDispatcher`.
  *
  * Regla que rige todo el fichero: «no he podido comprobarlo» NUNCA se traduce
  * a un estado. Un no-2xx inesperado es un fallo con mensaje, no un estado
@@ -220,6 +222,75 @@ async function assertSystemSpacesSeeded(bearer: string): Promise<void> {
 }
 
 /**
+ * Exige que la cola `didacta.outbox` tenga EXACTAMENTE UN worker atado.
+ *
+ * Esta es la comprobación que le faltaba al arnés y que costó varias sesiones.
+ * BullMQ entrega cada job a **un solo** worker: si otro proceso —un API
+ * huérfano de una sesión anterior, un contenedor viejo, una segunda instancia
+ * arrancada a mano— sigue conectado al MISMO Redis, los eventos del bus se
+ * reparten entre los dos al azar. Los que se lleva el otro proceso no llegan
+ * jamás a los bridges del API bajo test, y sin embargo la fila de
+ * `outbox_event` vuelve marcada `processed_at` y sin error: indistinguible de
+ * una entrega correcta, tanto en la base como en las métricas.
+ *
+ * El síntoma era exactamente el que se ve cuando falla: los specs que afirman
+ * un efecto de bridge (matrícula concedida por membresía, comisión de un
+ * referido, lección marcada al aprobar el quiz) fallaban ~la mitad de las
+ * veces, en una línea distinta cada vez, sin ningún error en los logs.
+ *
+ * Se pregunta al producto (`/admin/system/health-detail` → `outbox.dispatchers`)
+ * porque es el único que puede contarlos sin cooperación del intruso: cada
+ * worker de BullMQ nombra su conexión bloqueante al conectarse, así que hasta
+ * un binario viejo se deja contar.
+ */
+async function assertSingleOutboxDispatcher(bearer: string): Promise<void> {
+  const res = await fetch(`${API_URL}/api/v1/admin/system/health-detail`, {
+    headers: { Authorization: `Bearer ${bearer}` },
+  });
+  if (!res.ok) {
+    fail(
+      `GET /admin/system/health-detail devolvió ${res.status}.`,
+      'Sin él no se puede comprobar cuántos procesos están consumiendo la cola\n' +
+        'del outbox, que es la degradación silenciosa más cara del arnés.',
+    );
+  }
+  const body = (await res.json()) as { checks?: { outbox?: { dispatchers?: unknown } } };
+  const dispatchers = body.checks?.outbox?.dispatchers;
+  if (typeof dispatchers !== 'number') {
+    fail(
+      'El health-detail no trae `checks.outbox.dispatchers` numérico.',
+      `Llegó: ${JSON.stringify(body).slice(0, 300)}\n\n` +
+        'Igual que con el estado de la instancia: "no he podido comprobarlo" no\n' +
+        'se traduce a "está bien".',
+    );
+  }
+  if (dispatchers === 1) return;
+  if (dispatchers === 0) {
+    fail(
+      'La cola del outbox no tiene NINGÚN worker atado.',
+      'El despachador de eventos no está corriendo: todo evento del bus se\n' +
+        'quedará pendiente y ningún bridge se enterará. Comprueba que la API\n' +
+        'arrancó con REDIS_URL y que el log dice "outbox dispatcher activo".',
+    );
+  }
+  fail(
+    `Hay ${dispatchers} procesos consumiendo la cola del outbox y debería haber 1.`,
+    'BullMQ entrega cada job a UN SOLO worker. Con otro proceso atado al mismo\n' +
+      'Redis, los eventos del bus se reparten al azar entre los dos: los que se\n' +
+      'lleva el intruso NO llegan a los bridges de la API bajo test, y la fila de\n' +
+      '`outbox_event` vuelve igualmente marcada como procesada y sin error.\n' +
+      'El resultado son specs que fallan ~la mitad de las veces, en una línea\n' +
+      'distinta cada vez, sin un solo error en los logs.\n\n' +
+      'Casi siempre es un API huérfano de una sesión anterior. Para encontrarlo\n' +
+      '(el puerto de la API no basta: el intruso puede estar en cualquier otro):\n' +
+      '  netstat -ano | findstr 6380          # Windows\n' +
+      '  ss -tnp | grep 6380                  # Linux\n' +
+      'y comprueba antes de matar nada que el PID es tuyo — esta máquina tiene\n' +
+      'huérfanos de otros proyectos.',
+  );
+}
+
+/**
  * Estado de la instancia. Son DOS respuestas válidas, y no hay una tercera:
  * «no he podido preguntar» NO es un estado, es un fallo.
  */
@@ -359,6 +430,7 @@ export default async function globalSetup(): Promise<void> {
 
   const adminToken = await prepareAdmin(tenantSlug, email, password);
   await assertSystemSpacesSeeded(adminToken);
+  await assertSingleOutboxDispatcher(adminToken);
 
   // El tenant de smoke tiene su propio admin sembrado. Se le habla por la API
   // DIRECTA en 127.0.0.1 porque el Host manda sobre el `tenantSlug` del body

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -188,13 +188,51 @@ is_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+api_responds() { curl -sf -o /dev/null "http://localhost:${PORT}/healthz" 2>/dev/null; }
+web_responds() { curl -sf -o /dev/null "${E2E_BASE_URL}/signin" 2>/dev/null; }
+
+# Segundos que lleva viva la API que está contestando. `/healthz` lo expone.
+api_uptime_seconds() {
+  curl -s "http://localhost:${PORT}/healthz" 2>/dev/null |
+    sed -n 's/.*"uptime":[[:space:]]*\([0-9]*\).*/\1/p'
+}
+
+# Marca de tiempo de nuestro último lanzamiento; vacía si reusamos el proceso
+# que ya teníamos. La usa `wait_healthy` para exigir que quien contesta sea el
+# que acabamos de arrancar y no un superviviente.
+API_LAUNCHED_AT=""
+
+# ── Por qué esto no es paranoia ─────────────────────────────────────────────
+# `node dist/main.js` con el puerto ocupado muere al instante con EADDRINUSE,
+# pero como el proceso de antes SIGUE contestando, las sondas de `wait_healthy`
+# daban verde y la suite entera corría contra el binario viejo, con el registro
+# de módulos y los bridges de OTRA generación de la base. Un worker perdió una
+# sesión así: `stop` no había matado nada, `start` no arrancó nada, y nadie se
+# enteró. Ahora el puerto ocupado por alguien que no somos nosotros ES un
+# fallo, y nunca se mata a ciegas: esta máquina tiene huérfanos de otros
+# proyectos.
 start_api() {
   if is_alive "$API_PID_FILE"; then
     log "API ya viva (pid $(cat "$API_PID_FILE"))."
     return
   fi
+  if api_responds; then
+    die "El puerto $PORT ya lo sirve un proceso que NO arrancamos nosotros (lleva $(api_uptime_seconds)s vivo).
+No se mata nada por tu cuenta y riesgo: localiza al dueño y decide tú.
+  netstat -ano | findstr :$PORT      # Windows
+  ss -tlnp | grep :$PORT             # Linux
+Si es un resto de una sesión anterior de este mismo repo, mátalo y repite."
+  fi
   log "Arrancando la API en :$PORT…"
-  ( cd apps/api && "$NODE_BIN" dist/main.js > "$API_LOG" 2>&1 & echo $! > "$API_PID_FILE" )
+  # El subshell anota su PROPIO pid y se convierte en el proceso (`exec`), así
+  # que el fichero guarda el pid del node de verdad. Con `$!` guardaba el del
+  # job del subshell, que en cuanto ese subshell desaparecía dejaba de
+  # resolverse: `is_alive` decía «no está», `stop` no mataba nada y borraba el
+  # pid file tan contento mientras el proceso seguía sirviendo.
+  ( cd apps/api && exec >"$API_LOG" 2>&1
+    echo "$BASHPID" > "$API_PID_FILE"
+    exec "$NODE_BIN" dist/main.js ) &
+  API_LAUNCHED_AT="$(date +%s)"
 }
 
 start_web() {
@@ -202,10 +240,18 @@ start_web() {
     log "Web ya viva (pid $(cat "$WEB_PID_FILE"))."
     return
   fi
+  if web_responds; then
+    die "El puerto 3010 ya lo sirve un proceso que NO arrancamos nosotros.
+Mismo caso que la API: localiza al dueño antes de matar nada.
+  netstat -ano | findstr :3010       # Windows
+  ss -tlnp | grep :3010              # Linux"
+  fi
   # PORT=4000 es de la API y `next start` lo respeta por encima del -p del
   # script; hay que quitarlo del entorno del proceso web.
   log "Arrancando la web en :3010…"
-  ( cd apps/web && unset PORT && "$NODE_BIN" "$NEXT_CLI" start -p 3010 > "$WEB_LOG" 2>&1 & echo $! > "$WEB_PID_FILE" )
+  ( cd apps/web && unset PORT && exec >"$WEB_LOG" 2>&1
+    echo "$BASHPID" > "$WEB_PID_FILE"
+    exec "$NODE_BIN" "$NEXT_CLI" start -p 3010 ) &
 }
 
 stop_pid_file() {
@@ -221,6 +267,45 @@ stop_pid_file() {
   rm -f "$pid_file"
 }
 
+# `kill` puede no llevarse el proceso por delante (pid de MSYS que ya no mapea,
+# hijo que sobrevive al padre…) y hasta ahora eso se tragaba: `stop` decía que
+# había parado y el proceso seguía sirviendo. Comprobar el puerto convierte ese
+# no-op en un fallo con nombre.
+assert_port_stopped() {
+  local probe="$1" label="$2" port="$3"
+  local i=0
+  while [ "$i" -lt 10 ]; do
+    if ! $probe; then return 0; fi
+    sleep 1
+    i=$((i + 1))
+  done
+  die "$label sigue sirviendo en :$port después de pararla.
+El kill no se la llevó por delante. Localiza el proceso y decide tú:
+  netstat -ano | findstr :$port      # Windows
+  ss -tlnp | grep :$port             # Linux
+Seguir sin esto deja la tanda corriendo contra el binario viejo."
+}
+
+# Tercera red, por si el puerto se liberó y lo recuperó otro entre medias: la
+# API que contesta no puede llevar viva más de lo que hace que la lanzamos.
+# `uptime` sale de `/healthz`. El margen absorbe el redondeo a segundos.
+assert_api_is_the_one_we_launched() {
+  [ -n "$API_LAUNCHED_AT" ] || return 0
+  local up now elapsed
+  up="$(api_uptime_seconds)"
+  [ -n "$up" ] || return 0
+  now="$(date +%s)"
+  elapsed=$((now - API_LAUNCHED_AT + 5))
+  if [ "$up" -gt "$elapsed" ]; then
+    die "La API que contesta en :$PORT lleva ${up}s viva y la nuestra la lanzamos hace ${elapsed}s.
+O sea: quien responde NO es el proceso que acabamos de arrancar, sino otro que
+ya estaba. Corriendo la suite contra él, los bridges y el registro de módulos
+son los de otra generación de la base. Localízalo antes de matar nada:
+  netstat -ano | findstr :$PORT      # Windows
+  ss -tlnp | grep :$PORT             # Linux"
+  fi
+}
+
 wait_healthy() {
   local i=0
   log "Esperando a api :$PORT, web y rewrite (máx ${HEALTH_TIMEOUT_SECONDS}s)…"
@@ -234,6 +319,7 @@ wait_healthy() {
     if curl -sf "http://localhost:${PORT}/healthz" >/dev/null 2>&1 \
        && curl -sf -o /dev/null "${E2E_BASE_URL}/signin" 2>/dev/null \
        && curl -sf -o /dev/null "${E2E_API_URL}/api/v1/setup/status" 2>/dev/null; then
+      assert_api_is_the_one_we_launched
       log "api + web + rewrite arriba."
       return 0
     fi
@@ -253,12 +339,18 @@ cmd_start() { start_api; start_web; wait_healthy; }
 cmd_stop() {
   stop_pid_file "$API_PID_FILE" "la API"
   stop_pid_file "$WEB_PID_FILE" "la web"
+  assert_port_stopped api_responds "La API" "$PORT"
+  assert_port_stopped web_responds "La web" 3010
 }
 
 # ── reset entre tandas ──────────────────────────────────────────────────────
 cmd_reset() {
   log "Reset completo: infra nueva + BD nueva + API reiniciada."
   stop_pid_file "$API_PID_FILE" "la API"
+  # Sin esto el reset seguía adelante con la API vieja viva: `start_api` moría
+  # con EADDRINUSE, `wait_healthy` daba verde contra el superviviente y la
+  # tanda entera corría sobre el registro de módulos de la base ANTERIOR.
+  assert_port_stopped api_responds "La API" "$PORT"
   cmd_down
   cmd_up
   cmd_db
@@ -278,7 +370,14 @@ cmd_check() {
   # El camino por el que habla la suite. Si esta línea no es 200 y la de arriba
   # sí, el problema es el rewrite de Next, no la API.
   printf 'api x rewrite  %s\n' "$(curl -s -o /dev/null -w '%{http_code}' "${E2E_API_URL}/api/v1/setup/status" || echo sin-respuesta)"
-  printf 'tenants        %s\n' "$(psql_query 'SELECT string_agg(slug, ", " ORDER BY slug) FROM tenant;' 2>/dev/null || echo n/d)"
+  # Cuántos procesos están consumiendo la cola del outbox. Debe ser 1: con dos,
+  # BullMQ reparte los eventos entre ellos y los que se lleva el intruso no
+  # llegan a los bridges de la API bajo test — pero la fila vuelve marcada como
+  # procesada. Ver `assertSingleOutboxDispatcher` en apps/e2e/global-setup.ts.
+  printf 'outbox workers %s (debe ser 1)\n' \
+    "$(docker exec -i didacta-redis-test redis-cli client list 2>/dev/null |
+        grep -c "name=bull:$(printf %s 'didacta.outbox' | base64)" || echo n/d)"
+  printf 'tenants        %s\n' "$(psql_query $'SELECT string_agg(slug, \', \' ORDER BY slug) FROM tenant;' 2>/dev/null || echo n/d)"
   printf 'espacios       %s\n' "$(psql_query 'SELECT count(*) FROM mod_community_space;' 2>/dev/null || echo n/d)"
 }
 


### PR DESCRIPTION
## La causa

Los tres specs no compartían un bug: compartían un **segundo consumidor de la
cola del outbox**.

En esta máquina había un API de Didacta huérfano (PID 26224, arrancado el
2026-07-30, escuchando en `:4100`) con **50 conexiones vivas al Redis del arnés**
(`:6380`) y atado a la misma base. Su worker de BullMQ estaba suscrito a
`didacta.outbox` con `concurrency: 5`, igual que el de la API bajo test.

BullMQ entrega cada job a **un solo** worker. Con dos suscritos, los eventos del
bus se reparten al azar entre ambos. Y lo que hace este fallo tan caro de
diagnosticar es cómo termina la fila: el intruso ejecuta `processOutboxId`
contra la MISMA base y la deja con `processed_at` puesto, `last_error` NULL y
`processing_attempts = 0` — o sea, **exactamente igual que una entrega
correcta**. No hay pendiente, no hay error, no hay `NO_HANDLER`, no hay lag. El
evento simplemente nunca llegó a los bridges de tu proceso.

Por eso fallaban justo esos tres specs y ningún otro: son los únicos que afirman
un **efecto de bridge cruzado** con un poll de 15–20 s (matrícula concedida por
la membresía, comisión de un referido, lección marcada al aprobar el quiz).
Y por eso la línea cambiaba en cada tanda: la moneda se lanza por evento, no por
spec (`membership-trial:208`, `:336`, `:370`; `referrals-flow:386`, `:409`;
`quiz-flow:96`).

También explica el resultado del PR #43. Su medición era correcta —0 eventos
«sin handler»— y aun así la conclusión no podía salir de ahí: los eventos
robados **no** se marcan sin handler, se marcan entregados. Y explica que a ese
worker le pasaran los tres: montó un stack aislado con su propio Redis, así que
no tenía competencia.

### La cadena de evidencia

Instrumenté el bus (recuento de handlers por despacho, temporal) y correlacioné
encolado contra despacho en una tanda que falló:

| outbox | evento | encolado | despachado |
|---|---|---|---|
| 83 | `subscriptions.membership.activated` | 15:53:17.825 | +3 ms, 2 handlers |
| 84 | `learning.enrollment.created` | 15:53:17.860 | +3 ms, 2 handlers |
| **87** | **`subscriptions.subscription.unpaid`** | **15:53:18.693** | **nunca** |

El 87 es justo el que dispara la revocación que el spec espera en la línea 336.
En Redis su job existe, con `processedOn 1786290798693` y `finishedOn ...696`:
alguien lo ejecutó. En este proceso, `outbox_dispatch_total{completed}` valía 5
de 12 jobs. Y la fila 87 en la base: `processed_at` puesto, sin error, 0
intentos.

`Get-NetTCPConnection -RemotePort 6380` cerró el círculo: dos procesos,
el nuestro y uno de julio.

### Confirmado por intervención

| | tandas | resultado |
|---|---|---|
| con el huérfano vivo | 3 | 2 de 4 tests en rojo **cada vez** |
| sin el huérfano | 3 | **4/4 en verde cada vez** (44 s → 8 s por tanda) |

## Lo que arregla este PR

Matar el huérfano no es un arreglo: vuelve mañana. Lo que se arregla es que
**esto no pueda volver a pasar en silencio**.

### 1. El producto sabe decir cuántos le están comiendo la cola

`OutboxQueueService.countWorkers()` (`apps/api/src/modules/outbox-queue.service.ts:136`)
usa `Queue.getWorkers()` de BullMQ. No necesita cooperación del intruso: cada
worker nombra su conexión bloqueante `bull:<base64(cola)>` al conectarse, así que
**un binario viejo también se deja contar** — que era el requisito, porque el
huérfano es de hace diez días.

Sale por `/admin/system/health-detail` como `checks.outbox.dispatchers`. Se
**expone, no se juzga**: con N réplicas desplegadas el valor correcto es N, y
quien sabe cuántas esperaba es el operador. En producción es el dato que dice
que una réplica vieja sigue enchufada después de un despliegue a medias.

### 2. El arnés lo exige

`assertSingleOutboxDispatcher` (`apps/e2e/global-setup.ts:222`) aborta la tanda
si no hay exactamente 1, con el diagnóstico y el comando para localizar al
intruso. `e2e-stack.sh check` lo enseña también.

Es la misma regla que ya rige ese fichero: «no he podido comprobarlo» no se
traduce a un estado. Un 0 también falla (nadie despachando) y dice por qué.

### 3. Dos agujeros del arnés que salieron por el camino

Ambos reproducidos en vivo durante la sesión, ambos independientes de lo
anterior:

- **`stop` no paraba nada.** El pid file guardaba el pid del *job del subshell*
  (`$!`), que deja de resolverse en cuanto ese subshell muere: `is_alive` decía
  «no está», `stop` no mataba y borraba el fichero tan contento mientras el
  proceso seguía sirviendo. Ahora el proceso anota su propio pid antes de
  `exec`, y `stop`/`reset` **comprueban que el puerto quedó libre**.
- **`start` daba por bueno un proceso ajeno.** Con el puerto ocupado,
  `node dist/main.js` muere al instante con EADDRINUSE — pero el proceso viejo
  sigue contestando y `wait_healthy` daba verde. Me lo encontré ya ocurrido: la
  tanda de referencia de la sesión anterior corrió entera contra un API de hace
  1 h 30, con `dist/` anterior a #43 y el registro de módulos de otra generación
  de la base. Ahora el puerto ocupado por alguien que no arrancamos **es un
  fallo**, y `/healthz` confirma por `uptime` que quien contesta es el que
  acabamos de lanzar.

Ninguno de los dos mata nada por su cuenta: dicen qué pasa y cómo encontrar al
dueño. Esta máquina tiene huérfanos de otros proyectos.

## Verificación

| | resultado |
|---|---|
| detector, por mutación | segunda API contra el mismo Redis → `check` dice 2 y la suite aborta con el mensaje |
| `stop`/`start`, por mutación | con el puerto ocupado, `start` muere en vez de dar verde; `stop` deja el puerto libre |
| vitest api | **2261/2261** (baseline 2257 + 4 nuevos) |
| vitest web | **356/356** |
| dev-check `--format-fix` + `--quick` | OK |
| tanda E2E completa | **270 pasan / 2 fallan / 10 skipped** |

Los 3 del encargo, verdes en la tanda completa: `membership-trial:87`,
`quiz-flow:21`, `referrals-flow:62` y `:339`. Los 2 rojos son `mfa-setup:24` y
`mfa-enforcement:47`, previos y fuera del encargo.

## Frontera

No se ha tocado `persistent-event-bus.ts` (la instrumentación con la que
diagnostiqué era temporal y está revertida), ni `package.json` de ningún
workspace, ni `pnpm-lock.yaml`.

Fuera de `apps/e2e/**` y `scripts/e2e-*.sh` sólo hay dos ficheros, y son la
parte del arreglo que el arnés no puede hacer por sí mismo — contar los
consumidores de la cola requiere hablar con Redis, y quien tiene esa conexión es
la API:

- `apps/api/src/modules/outbox-queue.service.ts` — `countWorkers()`.
- `apps/api/src/modules/admin-system.controller.ts` — un campo más en el check
  del outbox que ya existía.

## Nota para quien retome la máquina

El huérfano de `:4100` (PID 26224, del 30 de julio) está muerto. Si vuelve a
aparecer un proceso así, la tanda ahora lo dice en el arranque en vez de
devolver tres rojos aleatorios.
