### PR TITLE
fix(docs): los enlaces a la documentación apuntan al host que responde

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Gracias por reportar. Cuanto más concreto, mejor podemos arreglarlo.
 
-        Guía completa (qué datos recoger y qué anonimizar): **[didacta.io/docs](https://didacta.io/docs)**.
+        Guía completa (qué datos recoger y qué anonimizar): **[docs.didacta.io](https://docs.didacta.io)**.
 
         ⚠️ **Si es una vulnerabilidad de seguridad, no la reportes aquí.** Escribe a `security@didacta.io` — ver [SECURITY.md](https://github.com/va360labs/didacta-io/blob/main/SECURITY.md).
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Cómo reportar un error
-    url: https://didacta.io/docs
+    url: https://docs.didacta.io
     about: Qué mirar antes de abrir la issue, qué datos recoger y qué anonimizar.
   - name: 💬 Preguntas y dudas
     url: https://github.com/va360labs/didacta-io/discussions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,6 @@ jobs:
             docker compose -f docker-compose.alpha.yml up -d
             ```
 
-            Guía de instalación paso a paso y política de versiones: <https://didacta.io/docs>.
+            Guía de instalación paso a paso y política de versiones: <https://docs.didacta.io/instalacion/>.
 
             ${{ steps.version.outputs.is_prerelease == 'true' && '⚠️ **Esta es una pre-release**. No usar en producción con datos reales.' || '' }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ producción real a su primer despliegue (congelado en el tag
 `v0.0.1-alpha.88-va360`); desde el 31 de julio de 2026 el repo vuelve a ser el
 producto whitelabel y prepara su primera versión pública. Guías de
 instalación, actualización y versionado en la documentación oficial:
-[didacta.io/docs](https://didacta.io/docs).
+[docs.didacta.io](https://docs.didacta.io).
 
 Imagen oficial publicada en GitHub Container Registry: `ghcr.io/va360labs/didacta-community`. **Pública** — no requiere `docker login`. El espejo en [Docker Hub](https://hub.docker.com/r/didactaio/community) (`didactaio/community`) todavía no está activo.
 
@@ -110,7 +110,7 @@ Después, descomenta las líneas `S3_*` en `docker-compose.alpha.yml`, dentro de
 
 Para producción real, apunta a tu Hetzner Object Storage, AWS S3 u otro proveedor compatible configurando las variables `S3_*` en `.env`.
 
-El quickstart de esta página cubre el arranque; el manual completo de instalación, actualización y operación vive en [didacta.io/docs](https://didacta.io/docs). Para dudas, bugs o feedback, abre una issue en GitHub — hay plantillas de bug, feedback y feature request. Para vulnerabilidades de seguridad, sigue [`SECURITY.md`](SECURITY.md).
+El quickstart de esta página cubre el arranque; el manual completo de instalación, actualización y operación vive en [docs.didacta.io](https://docs.didacta.io). Para dudas, bugs o feedback, abre una issue en GitHub — hay plantillas de bug, feedback y feature request. Para vulnerabilidades de seguridad, sigue [`SECURITY.md`](SECURITY.md).
 
 ## Camino B — Docker pull + run manual
 
@@ -231,7 +231,7 @@ Aparte existe un **registro opt-in** voluntario (Administración → Registro) d
 
 ## Documentación
 
-- 📚 [didacta.io/docs](https://didacta.io/docs) — Documentación oficial (es/en): instalación, actualización, operación y versionado.
+- 📚 [docs.didacta.io](https://docs.didacta.io) — Documentación oficial (es/en): instalación, actualización, operación y versionado.
 - 🤝 [`CONTRIBUTING.md`](CONTRIBUTING.md) — Guía de contribución.
 - 🔒 [`SECURITY.md`](SECURITY.md) — Política de seguridad y reporte responsable.
 - 📋 [Releases](https://github.com/va360labs/didacta-io/releases) — Historial de cambios de cada versión publicada.

--- a/apps/api/src/scim/scim.controller.ts
+++ b/apps/api/src/scim/scim.controller.ts
@@ -97,7 +97,7 @@ export class ScimController {
   serviceProviderConfig() {
     return {
       schemas: [SCIM_SCHEMAS.SERVICE_PROVIDER_CONFIG],
-      documentationUri: 'https://didacta.io/docs/scim',
+      documentationUri: 'https://docs.didacta.io/enterprise/',
       patch: { supported: true },
       bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
       filter: { supported: true, maxResults: 200 },
@@ -110,7 +110,7 @@ export class ScimController {
           name: 'OAuth Bearer Token',
           description: 'Static API token issued from /admin/scim panel. Per-tenant.',
           specUri: 'https://www.rfc-editor.org/info/rfc6750',
-          documentationUri: 'https://didacta.io/docs/scim#auth',
+          documentationUri: 'https://docs.didacta.io/api/autenticacion/',
           primary: true,
         },
       ],

--- a/infra/docker/entrypoint.sh
+++ b/infra/docker/entrypoint.sh
@@ -12,7 +12,7 @@
 # _prisma_migrations): marcar el baseline como aplicado UNA sola vez antes
 # del primer arranque con esta imagen:
 #   prisma migrate resolve --applied 20260731120000_baseline_faircode
-# (procedimiento completo en https://didacta.io/docs).
+# (procedimiento completo en https://docs.didacta.io/instalacion/actualizacion/).
 #
 # ----------------------------------------------------------------------------
 # RLS F3 — flip real a didacta_app (release post-intermedia alpha.95)
@@ -99,7 +99,7 @@ build_didacta_app_url() {
 resolve_runtime_database_url() {
   if [[ -n "${DATABASE_URL:-}" ]]; then
     if [[ "$DATABASE_URL" != postgres*://didacta_app:* ]]; then
-      log "⚠ DEGRADADO: DATABASE_URL no conecta como 'didacta_app' — RLS no aplica de verdad (el rol actual puede hacer bypass). Para aislamiento real, quita DATABASE_URL del entorno y define ADMIN_DATABASE_URL con el usuario bootstrap; este script derivará la conexión de didacta_app automáticamente. Ver https://didacta.io/docs § flip a didacta_app." >&2
+      log "⚠ DEGRADADO: DATABASE_URL no conecta como 'didacta_app' — RLS no aplica de verdad (el rol actual puede hacer bypass). Para aislamiento real, quita DATABASE_URL del entorno y define ADMIN_DATABASE_URL con el usuario bootstrap; este script derivará la conexión de didacta_app automáticamente. Ver https://docs.didacta.io/instalacion/solucion-de-problemas/" >&2
     fi
     printf '%s' "$DATABASE_URL"
     return 0


### PR DESCRIPTION
El repo enlazaba `https://didacta.io/docs` en **9 sitios** y esa URL devuelve **404**. El sitio se sirve en **`docs.didacta.io`** (CNAME fijado en Pages, 200 en sus 146 rutas: 73 es + 73 en).

| Fichero | Antes | Después |
|---|---|---|
| `README.md` (×3) | `didacta.io/docs` | `docs.didacta.io` |
| `.github/ISSUE_TEMPLATE/bug.yml`, `config.yml` | idem | idem |
| `.github/workflows/release.yml` | idem | `/instalacion/` |
| `infra/docker/entrypoint.sh` (×2) | idem | `/instalacion/actualizacion/` y `/instalacion/solucion-de-problemas/` |
| `apps/api/src/scim/scim.controller.ts` (×2) | `/docs/scim` y `/docs/scim#auth` | `/enterprise/` y `/api/autenticacion/` |

Los dos `documentationUri` de SCIM (RFC 7644) apuntaban a una página **que no existe** en el sitio. Se redirigen a páginas reales, verificadas una a una con 200. **Pendiente: una página propia de SCIM en didacta-docs.**

Verificado: dev-check 33/33, prettier OK, tests de SCIM 61/61.