### PR TITLE
fix(e2e): el job de MFA se puede correr en local con un comando, y pasa

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,17 +83,22 @@ jobs:
         run: pnpm --filter @didacta/e2e exec playwright install --with-deps chromium
 
       - name: Run E2E
-        # mfa-setup.spec.ts y mfa-enforcement.spec.ts quedan fuera: necesitan
+        # `run` es la tanda general: el arnés le aplica el filtro que deja
+        # fuera a mfa-setup.spec.ts y mfa-enforcement.spec.ts, que necesitan
         # DIDACTA_REQUIRE_MFA_ADMIN=true (política opt-in, default off — ver
-        # apps/api/src/auth/mfa-config.ts), y activarlo aquí rompería otros
-        # specs que hacen signin() de admin sin pasar por el flujo MFA
-        # (admin-email-templates, clase-en-comunidad, community-api-posts,
-        # admin-smtp-settings). Corren en el job "mfa-enforcement" de abajo,
-        # con su propio stack.
+        # apps/api/src/auth/mfa-config.ts) y romperían a los specs que hacen
+        # signin() de admin sin pasar por el flujo MFA (admin-email-templates,
+        # clase-en-comunidad, community-api-posts, admin-smtp-settings).
+        # Corren en el job "mfa-enforcement" de abajo, con su propio stack.
+        #
+        # El filtro vive en el script (MFA_GREP) y NO aquí a propósito: escrito
+        # a mano en el workflow era distinto del camino local —que ni existía—
+        # y así es como el job de MFA se pasó meses sin ejecutarse nunca.
+        # Equivalente local exacto:  bash scripts/e2e-stack.sh test
         #
         # setup-wizard.spec.ts no hace falta excluirlo: se auto-skipea cuando
         # no hay E2E_SETUP_TOKEN, que es justo el caso de este job.
-        run: pnpm --filter @didacta/e2e exec playwright test --grep-invert "Auth · MFA"
+        run: bash scripts/e2e-stack.sh run
 
       - name: Logs del stack si algo falló
         if: failure()
@@ -208,9 +213,13 @@ jobs:
     # de admin sin pasar por el flujo MFA. Mismo esquema que el job "e2e"
     # (base sembrada), solo que con la política activa y acotado a los 2 specs
     # que la ejercitan.
-    env:
-      DIDACTA_REQUIRE_MFA_ADMIN: 'true'
-
+    #
+    # La política NO se pone aquí con `env:`, sino dentro del arnés
+    # (`enable_mfa_policy` en scripts/e2e-stack.sh, que usan `mfa-start` y
+    # `mfa-run`). Así el runner y el portátil arrancan la API exactamente
+    # igual, y el equivalente local de este job entero es UN comando:
+    #
+    #   bash scripts/e2e-stack.sh mfa
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
@@ -244,28 +253,22 @@ jobs:
       - name: Build workspace
         run: pnpm build
 
-      - name: Arrancar api y web y esperar a que respondan
-        run: bash scripts/e2e-stack.sh start
+      - name: Arrancar api y web con la política de MFA activa
+        # `mfa-start` = `start` con DIDACTA_REQUIRE_MFA_ADMIN=true. La API sólo
+        # lee la política al arrancar, así que tiene que estar puesta AQUÍ.
+        run: bash scripts/e2e-stack.sh mfa-start
 
       - name: Install Playwright browsers
         run: pnpm --filter @didacta/e2e exec playwright install --with-deps chromium
 
       - name: Run E2E — MFA enforcement
-        # Orden importa: ambos comparten la cuenta admin seedeada (mfaEnabled
-        # es estado real en DB, no por-test). mfa-enforcement completa el
-        # ciclo setup→enable como efecto secundario y lo deja con MFA ya
-        # activado; si corriera primero, mfa-setup.spec.ts navegaría a
-        # /mfa/setup y el FE lo redirige a /mfa/verify (ya configurado) en
-        # vez de mostrar el form de alta. Playwright NO respeta el orden de
-        # argumentos del CLI (ordena los ficheros alfabéticamente pese al
-        # orden dado aquí), así que van en pasos separados para forzarlo.
-        #
-        # El global-setup ve DIDACTA_REQUIRE_MFA_ADMIN y no toca al admin: si
-        # completara el ciclo setup→enable dejaría a mfa-setup.spec.ts sin el
-        # estado inicial que ejercita.
-        run: |
-          pnpm --filter @didacta/e2e exec playwright test tests/mfa-setup.spec.ts
-          pnpm --filter @didacta/e2e exec playwright test tests/mfa-enforcement.spec.ts
+        # `mfa-run` selecciona los specs con el MISMO patrón que la tanda
+        # general invierte (MFA_GREP en scripts/e2e-stack.sh), así que entre
+        # los dos jobs no se puede quedar ninguno sin correr. El global-setup
+        # ve la política, comprueba que la API la lleva de verdad y no toca al
+        # admin: prepararlo obligaría a completar setup→enable y dejaría a
+        # mfa-setup.spec.ts sin el estado inicial que ejercita.
+        run: bash scripts/e2e-stack.sh mfa-run
 
       - name: Upload Playwright report
         if: always()

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -163,6 +163,76 @@ async function assertRateLimitHeadroom(): Promise<void> {
   );
 }
 
+type SesionAdmin = Awaited<ReturnType<typeof signin>>;
+
+/** Inicia sesión con el admin sembrado, o falla diciendo que no está. */
+async function adminSignin(
+  tenantSlug: string,
+  email: string,
+  password: string,
+  baseUrl?: string,
+): Promise<SesionAdmin> {
+  try {
+    return await signin({ tenantSlug, email, password }, baseUrl);
+  } catch (err) {
+    return fail(
+      `No se pudo iniciar sesión como ${email} en el tenant "${tenantSlug}".`,
+      `${(err as Error).message}\n\n` +
+        'La base no está sembrada, o lo está con otras credenciales.\n' +
+        'Siémbrala con:  bash scripts/e2e-stack.sh db',
+    );
+  }
+}
+
+/**
+ * ¿Espera esta tanda la política de MFA obligatoria para admins? Se interpreta
+ * la variable EXACTAMENTE igual que el producto (`isAdminMfaEnforced()` en
+ * apps/api/src/auth/mfa-config.ts) para que un `1`, `yes` u `on` no signifique
+ * una cosa aquí y otra allí.
+ */
+function esperaPoliticaMfaAdmin(): boolean {
+  const raw = (process.env['DIDACTA_REQUIRE_MFA_ADMIN'] ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+/**
+ * Exige que la API que está corriendo lleve la MISMA política de MFA que
+ * espera esta tanda.
+ *
+ * Hace falta porque la política la lee el proceso de la API de su propio
+ * entorno AL ARRANCAR: exportarla en el shell de Playwright no la enciende, y
+ * quitarla del shell no la apaga. Los dos desajustes posibles son caros y
+ * mudos:
+ *
+ *   - API con política + tanda general → este arranque cierra el onboarding
+ *     del admin con `PATCH /me/profile`, que NO está exento, y se come un 403
+ *     `mfa_required` que parece un fallo del endpoint de perfil.
+ *   - API sin política + tanda de MFA → los dos specs afirman `mfaRequired` en
+ *     su primera línea y fallan con "admin debe requerir MFA", que suena a bug
+ *     del producto cuando es un stack mal arrancado.
+ *
+ * `mfaRequired` del signin es el reflejo exacto del flag: `shouldRequireMfa()`
+ * (apps/api/src/auth/auth.service.ts) lo decide con la política y el rol, sin
+ * mirar el `mfaEnabled` del usuario.
+ */
+function assertPoliticaMfaCoincide(session: SesionAdmin, email: string, esperada: boolean): void {
+  if (session.mfaRequired === esperada) return;
+  const [dice, deberia] = esperada
+    ? ['NO exige MFA', 'la tanda de MFA la necesita activa']
+    : ['exige MFA', 'la tanda general la necesita desactivada'];
+  fail(
+    `La API arrancó con otra política de MFA que la de esta tanda: ${dice} a ${email}.`,
+    `DIDACTA_REQUIRE_MFA_ADMIN vale "${process.env['DIDACTA_REQUIRE_MFA_ADMIN'] ?? '(sin poner)'}"` +
+      ` en este proceso y ${deberia}.\n\n` +
+      'La API sólo lee la política al arrancar, así que no basta con exportar la\n' +
+      'variable: hay que relanzarla. Cada tanda tiene su comando y ese comando la\n' +
+      'pone por ti:\n\n' +
+      '  tanda general:  bash scripts/e2e-stack.sh test\n' +
+      '  tanda de MFA:   bash scripts/e2e-stack.sh mfa\n\n' +
+      'Para ver qué política lleva la API viva:  bash scripts/e2e-stack.sh check',
+  );
+}
+
 /** Cierra el onboarding del admin sembrado y devuelve su token. */
 async function prepareAdmin(
   tenantSlug: string,
@@ -170,17 +240,11 @@ async function prepareAdmin(
   password: string,
   baseUrl?: string,
 ): Promise<string> {
-  let session;
-  try {
-    session = await signin({ tenantSlug, email, password }, baseUrl);
-  } catch (err) {
-    fail(
-      `No se pudo iniciar sesión como ${email} en el tenant "${tenantSlug}".`,
-      `${(err as Error).message}\n\n` +
-        'La base no está sembrada, o lo está con otras credenciales.\n' +
-        'Siémbrala con:  bash scripts/e2e-stack.sh db',
-    );
-  }
+  const session = await adminSignin(tenantSlug, email, password, baseUrl);
+  // Antes de tocar nada: `completeOnboarding` habla con endpoints que la
+  // política de MFA bloquea, así que si no coincide se dice aquí y no tres
+  // llamadas más allá con un 403 sin contexto.
+  assertPoliticaMfaCoincide(session, email, false);
   const token = session.tokens.accessToken;
   await completeOnboarding(token, baseUrl);
   return token;
@@ -403,20 +467,6 @@ export default async function globalSetup(): Promise<void> {
     return;
   }
 
-  // La política de MFA obligatoria para admins (opt-in, default off) hace que
-  // el token del signin llegue sin verificar. Preparar el onboarding desde
-  // aquí obligaría a completar el ciclo setup→enable y dejaría a
-  // `mfa-setup.spec.ts` sin el estado inicial que ejercita, así que en ese
-  // stack la preparación la hacen los propios specs.
-  if (process.env['DIDACTA_REQUIRE_MFA_ADMIN'] === 'true') {
-    // eslint-disable-next-line no-console
-    console.info(
-      '[arnés E2E] DIDACTA_REQUIRE_MFA_ADMIN activo: la preparación del admin la\n' +
-        '            hacen los specs de MFA, que son los que ejercitan ese flujo.',
-    );
-    return;
-  }
-
   const tenantSlug = process.env.E2E_TENANT_SLUG ?? 'demo';
   const email = process.env.E2E_ADMIN_EMAIL;
   const password = process.env.E2E_ADMIN_PASSWORD;
@@ -426,6 +476,24 @@ export default async function globalSetup(): Promise<void> {
       'Son las credenciales del admin que siembra `seed.ts`. Sin ellas ningún\n' +
         'spec puede autenticarse.',
     );
+  }
+
+  // La política de MFA obligatoria para admins (opt-in, default off) hace que
+  // el token del signin llegue sin verificar, y con él `completeOnboarding`
+  // choca contra el guard. Completar el ciclo setup→enable desde aquí para
+  // esquivarlo dejaría a `mfa-setup.spec.ts` sin el estado inicial que
+  // ejercita, así que en ese stack la preparación la hacen los propios specs.
+  // Lo único que se comprueba —y no es poco— es que la API lleva de verdad la
+  // política que esta tanda da por supuesta.
+  if (esperaPoliticaMfaAdmin()) {
+    assertPoliticaMfaCoincide(await adminSignin(tenantSlug, email, password), email, true);
+    // eslint-disable-next-line no-console
+    console.info(
+      '[arnés E2E] DIDACTA_REQUIRE_MFA_ADMIN activo y la API lo confirma: la\n' +
+        '            preparación del admin la hacen los specs de MFA, que son los\n' +
+        '            que ejercitan ese flujo.',
+    );
+    return;
   }
 
   const adminToken = await prepareAdmin(tenantSlug, email, password);

--- a/apps/e2e/tests/calendario-agenda.spec.ts
+++ b/apps/e2e/tests/calendario-agenda.spec.ts
@@ -79,8 +79,18 @@ test.describe('/calendario · agenda con pasadas, en curso y próximas', () => {
     await page.goto('/calendario');
     await expect(page.getByText('Agenda · Calendario')).toBeVisible();
 
-    // En la rejilla del mes actual NO están (son de otros meses)…
-    await expect(page.getByText(futura)).toHaveCount(0);
+    // La agenda se pide en una petición APARTE de la rejilla y alimenta la
+    // barra lateral. Esperarla no es cortesía: sin ella el "no está en la
+    // rejilla" de la línea siguiente pasaba por vacío —no es que no
+    // estuviera, es que no había llegado nada todavía— y ese era el único
+    // motivo por el que la comprobación estaba en verde.
+    await expect(page.getByRole('complementary').getByRole('list')).toBeVisible();
+
+    // En la rejilla del mes actual NO están (son de otros meses). Se busca la
+    // píldora de la rejilla, que lleva el nombre en `title`, y no el texto
+    // suelto en toda la página: el nombre sale TAMBIÉN en "Próximas citas" de
+    // la barra lateral, que es justo lo que este mismo spec exige más abajo.
+    await expect(page.locator(`[title="${futura}"]`)).toHaveCount(0);
 
     // …pero la Agenda las encuentra sin navegar de mes, cada una en su
     // sección. (`.first()` porque la próxima sale también en la barra

--- a/apps/e2e/tests/mfa-setup.spec.ts
+++ b/apps/e2e/tests/mfa-setup.spec.ts
@@ -1,15 +1,63 @@
+import { execFileSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { authenticator } from 'otplib';
 import { signin } from '../helpers/api';
 import { injectSession } from '../helpers/auth';
 
+const PG_CONTAINER = process.env.E2E_PG_CONTAINER ?? 'didacta-postgres-test';
+const PG_USER = process.env.E2E_PG_USER ?? 'didacta_test';
+const PG_DB = process.env.E2E_PG_DB ?? 'didacta_test';
+
+/** SQL directo contra el Postgres efímero (superuser del compose → sin RLS). */
+function sql(query: string): string {
+  return execFileSync(
+    'docker',
+    ['exec', PG_CONTAINER, 'psql', '-U', PG_USER, '-d', PG_DB, '-t', '-A', '-c', query],
+    { encoding: 'utf8' },
+  ).trim();
+}
+
+/**
+ * Deja al admin como recién sembrado: sin MFA configurada.
+ *
+ * Es el ESTADO INICIAL que este spec ejercita —el alta de primera vez—, y sin
+ * establecerlo el spec sólo pasa la primera vez que se corre sobre una base
+ * recién sembrada. La segunda falla a los 15 s diciendo que no encuentra el
+ * título del formulario, que es de las pistas más falsas posibles, porque el
+ * navegador ni siquiera está en /mfa/setup:
+ *
+ *   1. El shell pide `GET /modules/theming/me` en CADA página, también en las
+ *      de auth. Ese endpoint no está marcado `@MfaExempt`, así que con la
+ *      política activa responde 403 `mfa_required` mientras la sesión no esté
+ *      verificada. Verificado en los logs del arnés.
+ *   2. Ante ese 403 el cliente deriva al flujo MFA por su cuenta
+ *      (apps/web/src/lib/api-client.ts:260) y elige destino con el
+ *      `mfaEnabled` de la sesión guardada: /mfa/verify si ya la tiene,
+ *      /mfa/setup si no.
+ *
+ * O sea que con MFA ya activada el navegador se va a /mfa/verify (a veces con
+ * un `net::ERR_ABORTED` en el propio goto), y con MFA sin activar el destino
+ * coincide con la página actual y no se mueve nadie. De ahí que el spec
+ * alternara pasa/falla/pasa/falla al repetirlo sobre el mismo stack.
+ *
+ * No hay endpoint de producto para desactivar MFA (`mfa.controller.ts` sólo
+ * expone setup/enable/verify), así que se limpia la fila por el mismo camino
+ * que ya usan `catalogo-publico` y `arnes-contrato`.
+ */
+function resetAdminMfa(email: string): void {
+  sql(
+    `UPDATE "user" SET mfa_enabled = false, mfa_secret = NULL, mfa_recovery_codes = '{}' ` +
+      `WHERE email = '${email.replace(/'/g, "''")}'`,
+  );
+}
+
 /**
  * Flujo MFA del admin: setup + enable end-to-end vía UI.
  *
- * El seed admin ya puede o no tener MFA activado de runs anteriores; este
- * spec ejecuta /auth/mfa/setup que genera un secret NUEVO cada vez,
- * sobreescribiendo el anterior. Es idempotente: se puede correr N veces
- * y siempre rota al admin a un secret fresco.
+ * Idempotente de verdad: `resetAdminMfa` devuelve al admin al estado sin MFA
+ * antes de empezar, así que se puede correr N veces seguidas y da igual el
+ * orden respecto a `mfa-enforcement.spec.ts`, que deja al mismo admin con MFA
+ * activada.
  *
  * El flujo:
  * 1. Signin del admin via API → obtiene token (mfaRequired=true).
@@ -31,9 +79,16 @@ test.describe('Auth · MFA admin', () => {
       throw new Error('E2E_ADMIN_EMAIL y E2E_ADMIN_PASSWORD requeridos para el spec de MFA');
     }
 
+    // 0) Estado inicial: admin sin MFA configurada (el porqué, en resetAdminMfa)
+    resetAdminMfa(adminEmail);
+
     // 1) Signin admin → mfaRequired=true
     const session = await signin({ tenantSlug, email: adminEmail, password: adminPassword });
     expect(session.mfaRequired, 'admin debe requerir MFA').toBe(true);
+    expect(
+      session.user.mfaEnabled,
+      'y no la tiene configurada todavía: lo que se ejercita aquí es el ALTA',
+    ).toBe(false);
 
     // 2) Inyectar sesión (todavía sin mfaVerified)
     await page.goto('/signin');
@@ -64,7 +119,12 @@ test.describe('Auth · MFA admin', () => {
     await page.getByLabel(/Código de la app/).fill(code);
     await page.getByRole('button', { name: /Confirmar y activar MFA/ }).click();
 
-    // 7) Esperar redirect a / (la app monta el dashboard del alumno o landing)
+    // 7) Con el enable resuelto, el flujo sale de /mfa/setup a "/" (no hay
+    //    deep link pendiente que consumir). Ahí NO se queda: el admin de este
+    //    stack tiene el onboarding abierto —con la política activa el arranque
+    //    no puede cerrarlo, `PATCH /me/profile` no está exento— y el layout de
+    //    (app) lo manda a /onboarding acto seguido. Lo que se afirma aquí es
+    //    el salto, que es lo que prueba que el enable fue bien.
     await page.waitForURL(/\/$/, { timeout: 20_000 });
   });
 });

--- a/scripts/e2e-env.sh
+++ b/scripts/e2e-env.sh
@@ -57,6 +57,21 @@
 : "${API_PORT:=4000}"
 : "${API_INTERNAL_URL:=http://localhost:4000}"
 
+# ── Política de MFA obligatoria para admins (opt-in del producto) ───────────
+# `isAdminMfaEnforced()` en apps/api/src/auth/mfa-config.ts. Default OFF, que
+# es el estado que el golden path da por supuesto: con la política activa el
+# guard responde 403 `mfa_required` a CUALQUIER llamada admin cuyo token no
+# venga del flujo MFA, y eso tumba a los specs que hacen signin() de admin sin
+# pasar por él (admin-email-templates, clase-en-comunidad, community-api-posts,
+# admin-smtp-settings) además del propio arranque, que cierra el onboarding del
+# admin con `PATCH /me/profile` (no exento).
+#
+# Se declara aquí —aunque el valor sea el default del producto— para que el
+# stack la lleve SIEMPRE explícita y se pueda ver en `e2e-stack.sh check`. Los
+# dos specs que sí la ejercitan corren en su propio arranque, que la pone a
+# true: `bash scripts/e2e-stack.sh mfa`.
+: "${DIDACTA_REQUIRE_MFA_ADMIN:=false}"
+
 # ── Rate limit: ver comentario largo abajo ──────────────────────────────────
 # Con REDIS_URL activo el rate limiter global DEJA de fallar abierto y entra en
 # vigor el cupo por defecto del plan community: 100 req/min autenticadas y
@@ -137,6 +152,7 @@ DATABASE_URL REDIS_URL
 E2E_PG_CONTAINER E2E_PG_USER E2E_PG_DB E2E_PG_PORT
 JWT_SECRET JWT_REFRESH_SECRET AUTH_SECRET AUTH_URL TENANT_SETTINGS_ENC_KEY
 NODE_ENV AUTH_SIGNUP_ENABLED PORT API_PORT API_INTERNAL_URL
+DIDACTA_REQUIRE_MFA_ADMIN
 RATE_LIMIT_COMMUNITY_AUTH_PER_MIN RATE_LIMIT_COMMUNITY_PUBLIC_PER_MIN
 BOOTSTRAP_TENANT_SLUG BOOTSTRAP_EMAIL BOOTSTRAP_PASSWORD
 E2E_SMOKE_TENANT_SLUG E2E_SMOKE_TENANT_DOMAIN E2E_SMOKE_ADMIN_EMAIL E2E_SMOKE_API_URL

--- a/scripts/e2e-stack.sh
+++ b/scripts/e2e-stack.sh
@@ -19,7 +19,11 @@
 #   bash scripts/e2e-stack.sh reset     # BD limpia + REINICIO de la api
 #   bash scripts/e2e-stack.sh check     # diagnóstico del stack
 #   bash scripts/e2e-stack.sh all       # up + db + build + start
-#   bash scripts/e2e-stack.sh test [args…]   # reset + playwright
+#   bash scripts/e2e-stack.sh test [args…]   # reset + tanda general
+#   bash scripts/e2e-stack.sh run  [args…]   # tanda general SIN resetear
+#   bash scripts/e2e-stack.sh mfa            # reset + los 2 specs de MFA
+#   bash scripts/e2e-stack.sh mfa-start      # arranca con la política de MFA
+#   bash scripts/e2e-stack.sh mfa-run        # los 2 specs de MFA, sin tocar el stack
 #
 # `reset` existe porque la suite NO es idempotente: los specs de Fundae usan
 # NIFs fijos y en la segunda pasada devuelven 409. Y reinicia la API a
@@ -57,6 +61,32 @@ TSC_BIN="$REPO_ROOT/node_modules/typescript/bin/tsc"
 NEST_CLI="$REPO_ROOT/node_modules/@nestjs/cli/bin/nest.js"
 NEXT_CLI="$REPO_ROOT/node_modules/next/dist/bin/next"
 PLAYWRIGHT_CLI="$REPO_ROOT/node_modules/@playwright/test/cli.js"
+
+# ── El corte MFA / golden path ──────────────────────────────────────────────
+# Los dos specs de `Auth · MFA` no pueden correr en la tanda general: exigen
+# `DIDACTA_REQUIRE_MFA_ADMIN=true` (política opt-in del producto, default off —
+# apps/api/src/auth/mfa-config.ts) y con ella puesta el guard responde 403
+# `mfa_required` a todo token admin que no venga del flujo MFA. Eso tumba a
+# cuatro specs del golden path (admin-email-templates, clase-en-comunidad,
+# community-api-posts, admin-smtp-settings) y al propio arranque, que cierra el
+# onboarding del admin con `PATCH /me/profile`, que NO está exento.
+#
+# Así que son dos arranques distintos, y los DOS —local y CI— entran por aquí:
+# el filtro y la política se declaran UNA vez, igual que las variables viven
+# una sola vez en `e2e-env.sh`. Antes el filtro estaba escrito a mano en el
+# workflow y no existía en local, que es como el job de MFA se pasó meses sin
+# ejecutarse ni una vez.
+#
+# Un solo patrón para las dos tandas —una lo aplica y la otra lo invierte—, de
+# modo que entre las dos cubren la suite entera y ningún spec se puede quedar
+# sin correr en ninguna: si mañana aparece un tercer `Auth · MFA`, entra solo
+# por los dos lados.
+#
+# El patrón lleva `.` donde el título lleva `·`: es una regex, y así el filtro
+# no depende de que un carácter no-ASCII sobreviva a la línea de comandos de
+# Windows. Verificado con `--list`: 282 tests en total, 280 con el filtro
+# invertido, los 2 de MFA con el filtro directo.
+readonly MFA_GREP='Auth . MFA'
 
 log() { printf '\033[36m[e2e-stack]\033[0m %s\n' "$*"; }
 die() { printf '\033[31m[e2e-stack] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
@@ -379,14 +409,57 @@ cmd_check() {
         grep -c "name=bull:$(printf %s 'didacta.outbox' | base64)" || echo n/d)"
   printf 'tenants        %s\n' "$(psql_query $'SELECT string_agg(slug, \', \' ORDER BY slug) FROM tenant;' 2>/dev/null || echo n/d)"
   printf 'espacios       %s\n' "$(psql_query 'SELECT count(*) FROM mod_community_space;' 2>/dev/null || echo n/d)"
+  # Qué política de MFA lleva la API QUE ESTÁ CORRIENDO, no la de tu shell: la
+  # lee de su propio entorno al arrancar, así que exportarla ahora no cambia
+  # nada hasta reiniciarla. `mfaRequired` del signin del admin es el reflejo
+  # exacto de `isAdminMfaEnforced()` (auth.service.ts: la decide el flag y el
+  # rol, no el `mfaEnabled` del usuario).
+  printf 'MFA admin      shell=%s · api=%s (mfaRequired del signin del admin)\n' \
+    "${DIDACTA_REQUIRE_MFA_ADMIN:-<sin poner>}" "$(api_says_mfa_required)"
+}
+
+# `true`/`false` según lo que conteste la API, o `n/d` si no contesta.
+api_says_mfa_required() {
+  curl -s -X POST "http://localhost:${PORT}/api/v1/auth/signin" \
+    -H 'Content-Type: application/json' \
+    -d "{\"tenantSlug\":\"${BOOTSTRAP_TENANT_SLUG}\",\"email\":\"${BOOTSTRAP_EMAIL}\",\"password\":\"${BOOTSTRAP_PASSWORD}\"}" \
+    2>/dev/null |
+    sed -n 's/.*"mfaRequired":[[:space:]]*\(true\|false\).*/\1/p' |
+    grep . || echo 'n/d'
 }
 
 cmd_all() { cmd_up; cmd_db; cmd_build; cmd_start; }
 
-cmd_test() {
-  cmd_reset
-  ( cd apps/e2e && "$NODE_BIN" "$PLAYWRIGHT_CLI" test "$@" )
-}
+run_playwright() { ( cd apps/e2e && "$NODE_BIN" "$PLAYWRIGHT_CLI" test "$@" ); }
+
+# ── tandas ──────────────────────────────────────────────────────────────────
+# La tanda general, sobre el stack que ya esté en pie. Excluye los 2 specs de
+# MFA (ver MFA_GREP): con el stack del golden path fallarían siempre, porque su
+# premisa es justo la política que este stack no tiene.
+cmd_run() { run_playwright --grep-invert "$MFA_GREP" "$@"; }
+
+cmd_test() { cmd_reset; cmd_run "$@"; }
+
+# La política la lee el proceso de la API (`isAdminMfaEnforced()` mira el env
+# del proceso), así que hay que ponerla ANTES de arrancarla y también en el
+# proceso de Playwright, porque `global-setup.ts` decide con ella si prepara al
+# admin o no. Una sola función para las dos cosas: si se pusiera a mano en cada
+# sitio, el día que uno se olvide la tanda corre contra una API sin política y
+# los specs fallan afirmando lo contrario de lo que pasa.
+enable_mfa_policy() { export DIDACTA_REQUIRE_MFA_ADMIN=true; }
+
+cmd_mfa_start() { enable_mfa_policy; cmd_start; }
+
+# Los 2 specs de MFA, en una sola invocación. El orden entre ellos da igual
+# aunque compartan la cuenta admin y `mfaEnabled` sea estado real en la base:
+# `mfa-setup.spec.ts` se pone su propio estado inicial (ver `resetAdminMfa`
+# allí), que es también lo que lo hace repetible sin volver a sembrar.
+cmd_mfa_run() { enable_mfa_policy; run_playwright --grep "$MFA_GREP" "$@"; }
+
+# Camino local completo, equivalente exacto del job `mfa-enforcement` de CI.
+# El reset reinicia la API, que es la única forma de que empiece a leer la
+# política: sólo la consulta al arrancar.
+cmd_mfa() { enable_mfa_policy; cmd_reset; cmd_mfa_run; }
 
 case "${1:-}" in
   up)     cmd_up ;;
@@ -399,6 +472,10 @@ case "${1:-}" in
   reset) cmd_reset ;;
   check) cmd_check ;;
   all)   cmd_all ;;
+  run)       shift; cmd_run "$@" ;;
+  mfa)       cmd_mfa ;;
+  mfa-start) cmd_mfa_start ;;
+  mfa-run)   shift; cmd_mfa_run "$@" ;;
   test)  shift; cmd_test "$@" ;;
-  *)     die "uso: e2e-stack.sh {up|down|schema|db|build|start|stop|reset|check|all|test}" ;;
+  *)     die "uso: e2e-stack.sh {up|down|schema|db|build|start|stop|reset|check|all|test|run|mfa|mfa-start|mfa-run}" ;;
 esac


### PR DESCRIPTION
## Por qué

El job `mfa-enforcement` de `.github/workflows/e2e.yml` **no se había ejecutado nunca**: no hay CI de tests y en local no existía forma de levantar el stack con `DIDACTA_REQUIRE_MFA_ADMIN=true`. Y efectivamente no funcionaba — `mfa-setup.spec.ts` fallaba una de cada dos veces por una causa real.

## Qué gana el arnés

| comando | qué hace |
|---|---|
| `bash scripts/e2e-stack.sh mfa` | reset + los 2 specs. **Equivalente exacto del job de CI** |
| `bash scripts/e2e-stack.sh mfa-start` | arranque con la política puesta (lo usa CI) |
| `bash scripts/e2e-stack.sh mfa-run` | sólo los specs, sin tocar el stack (lo usa CI) |
| `bash scripts/e2e-stack.sh run` | la tanda general con el filtro que los excluye (lo usa CI) |

`MFA_GREP` es **un único patrón** que una tanda aplica y la otra invierte, así que entre las dos cubren la suite entera y ningún spec puede quedarse sin correr en ninguna. El workflow ya no lleva ni el filtro ni la política escritos a mano: los toma del script. Era justo esa duplicación —filtro a mano en CI, camino local inexistente— la que dejó el job sin correr durante meses.

`DIDACTA_REQUIRE_MFA_ADMIN` pasa a estar declarada en `scripts/e2e-env.sh` (la única lista de entorno) con su default `false`, de modo que el stack la lleva siempre explícita y `e2e-stack.sh check` la enseña.

## La causa del rojo intermitente

`mfa-setup.spec.ts` ejercita el **alta** de MFA, y eso sólo era cierto con la base recién sembrada. Con MFA ya activada en el admin:

1. El shell pide `GET /modules/theming/me` en cada página, también en las de auth. Ese endpoint no está marcado `@MfaExempt`, así que con la política activa responde **403 `mfa_required`** (verificado en `.e2e-stack/api.log`).
2. Ante ese 403 el cliente deriva solo al flujo MFA y elige destino con el `mfaEnabled` de la sesión guardada — `apps/web/src/lib/api-client.ts:260`. Con MFA activada: `/mfa/verify`.

Resultado: el formulario de alta no llegaba a pintarse (a veces con `net::ERR_ABORTED` en el propio `goto`) y el spec moría a los 15 s diciendo que no encontraba un título. Con MFA sin activar el destino coincidía con la página actual y no se movía nadie — de ahí el patrón pasa/falla/pasa/falla.

Arreglado en la causa: el spec **se pone su propio estado inicial** (`resetAdminMfa`) por el mismo camino que ya usan `catalogo-publico` y `arnes-contrato` (`docker exec … psql`), porque el producto no expone ningún endpoint para desactivar MFA. Ahora es repetible de verdad y el orden entre los dos specs deja de importar — por eso el job pasa de dos invocaciones a una.

No he tocado el producto: el 403 de `theming/me` y la derivación del cliente son coherentes con el enforcement de LMS-109 (el usuario que ya tiene MFA debe verificar, no volver a darse de alta). Queda anotado por si se quiere revisar la lista de `@MfaExempt`.

## El desajuste que ya no puede pasar callado

La política la lee el proceso de la API **al arrancar**: exportarla en el shell de Playwright no la enciende, y quitarla del shell no la apaga. `global-setup.ts` ahora comprueba que la API que responde lleva la misma política que espera la tanda (el `mfaRequired` del signin es el reflejo exacto del flag). Los dos desajustes, probados:

- API con política + tanda general → antes: 403 en `PATCH /me/profile` que parecía un fallo del endpoint de perfil.
- API sin política + tanda de MFA → antes: "admin debe requerir MFA", que sonaba a bug del producto.

Ahora los dos abortan con el comando correcto en el mensaje. `check` añade además la línea `MFA admin shell=… · api=…`.

## Hallazgo aparte: `calendario-agenda.spec.ts`

La tanda general de hoy salió 269/1. **No es de este trabajo** y el rojo era legítimo: el spec afirmaba que la clase de dentro de 40 días no aparece en la página del mes en curso buscando su nombre en TODA la página, pero sí aparece — la barra lateral "Próximas citas" la lista a propósito, que es la regresión que el propio spec comprueba tres líneas más abajo. Como la agenda se pide en una petición aparte de la rejilla, la comprobación sólo pasaba **mientras esa petición llegara tarde**. Hoy llegó a tiempo.

Va en su propio commit: se espera a que la barra lateral tenga datos (el "no está" deja de poder pasar por vacío) y se busca la píldora de la rejilla por su `title` en vez del texto suelto.

## Verificación

- `bash scripts/dev-check.sh --format-fix && bash scripts/dev-check.sh --quick` → **33/33**
- `bash scripts/e2e-stack.sh mfa` → **2 passed** (exit 0). Repetido 5 veces, dos de ellas sin resembrar entre medias.
- Tanda general `bash scripts/e2e-stack.sh test` → **270 passed / 0 failed / 10 skipped** (2,4 min). Los 2 de MFA dejan de contarse porque el filtro es correcto: `--list` da 282 en total y 280 con el filtro invertido.
- Los dos desajustes de política, provocados a mano: abortan con el mensaje esperado.
- Sin tocar producto → no aplican los baselines de vitest.
