### PR TITLE
fix(i18n): dos etiquetas en español y un Intl que tumbaba el render

### DIFF
--- a/apps/web/src/app/(app)/admin/integraciones/payment-connections/subscriptions-dashboard.tsx
+++ b/apps/web/src/app/(app)/admin/integraciones/payment-connections/subscriptions-dashboard.tsx
@@ -30,6 +30,7 @@ import { authStorage } from '@/lib/auth-storage';
 import { apiErrorMessage } from '@/lib/i18n/api-error';
 import { formatCurrency, formatDate, formatDateTime } from '@/lib/i18n/format';
 import {
+  subscriptionStatusLabel,
   subscriptionsDashboardApi,
   type DashboardSubscriber,
   type SubscribersSummary,
@@ -75,41 +76,6 @@ const CATEGORY_BADGE: Record<string, string> = {
   unknown: 'border-border bg-surface-2 text-text-muted',
 };
 
-type SubStatusKey =
-  | 'active'
-  | 'trialing'
-  | 'pastDue'
-  | 'unpaid'
-  | 'onHold'
-  | 'paused'
-  | 'pendingCancel'
-  | 'canceled'
-  | 'expired'
-  | 'incomplete'
-  | 'pending';
-
-/**
- * Status crudo del proveedor (normalizado a minúsculas) → key de etiqueta en el
- * catálogo. Espejo del diccionario de `classifySubscriptionStatus` de
- * `lib/payment-connections.ts` (aquí solo la PRESENTACIÓN; la categoría ya
- * viene materializada en `statusCategory` desde el backend).
- */
-const SUB_STATUS_KEYS: Record<string, SubStatusKey> = {
-  active: 'active',
-  trialing: 'trialing',
-  past_due: 'pastDue',
-  unpaid: 'unpaid',
-  'on-hold': 'onHold',
-  paused: 'paused',
-  'pending-cancel': 'pendingCancel',
-  canceled: 'canceled',
-  cancelled: 'canceled',
-  expired: 'expired',
-  incomplete: 'incomplete',
-  incomplete_expired: 'incomplete',
-  pending: 'pending',
-};
-
 function fmtDate(iso: string | null): string {
   if (!iso) return '—';
   const d = new Date(iso);
@@ -141,11 +107,6 @@ export function SubscriptionsDashboard() {
   const [syncing, setSyncing] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [emailFor, setEmailFor] = useState<DashboardSubscriber | null>(null);
-
-  const statusLabel = (status: string): string => {
-    const key = SUB_STATUS_KEYS[(status ?? '').toLowerCase().trim()];
-    return key ? t(`subStatus.${key}`) : status || t('subStatus.unknown');
-  };
 
   const load = useCallback(async () => {
     const tk = authStorage.getAccessToken();
@@ -370,7 +331,7 @@ export function SubscriptionsDashboard() {
                           CATEGORY_BADGE[r.statusCategory] ?? CATEGORY_BADGE['unknown']
                         }`}
                       >
-                        {statusLabel(r.status)}
+                        {subscriptionStatusLabel(r.status, t)}
                       </span>
                     </td>
                     <td className="py-2 pr-3">

--- a/apps/web/src/app/(app)/admin/solicitudes-miembros/page.tsx
+++ b/apps/web/src/app/(app)/admin/solicitudes-miembros/page.tsx
@@ -32,6 +32,7 @@ import {
   classifySubscriptionStatus,
   formatAmount,
   paymentTiersApi,
+  subscriptionStatusLabel,
   type PaymentTier,
 } from '@/lib/payment-connections';
 import { authStorage } from '@/lib/auth-storage';
@@ -378,6 +379,9 @@ function SubscriptionBlock({
   onEmail: () => void;
 }) {
   const t = useTranslations('adminUsuarios');
+  // Los estados de suscripción son copy de `adminPagos` aunque los pinte esta
+  // pantalla: el catálogo es uno solo (ver `subscriptionStatusLabel`).
+  const tPagos = useTranslations('adminPagos');
   const lookup = request.lookup;
   if (!lookup || lookup.status === 'PENDING') {
     return (
@@ -434,7 +438,7 @@ function SubscriptionBlock({
             key={m.subscriptionId}
             className="flex flex-wrap items-center justify-between gap-2 text-sm text-text"
           >
-            <span>{describeMatch(m, t)}</span>
+            <span>{describeMatch(m, t, tPagos)}</span>
             <Button variant="ghost" onClick={() => onRemind(m)}>
               {t('requests.sendReminder')}
             </Button>
@@ -486,9 +490,23 @@ function describePurchase(p: MemberPurchaseMatch): string {
   return `${head}${products} (${p.connectionName})`;
 }
 
-function describeMatch(m: MemberSubscriptionMatch, t: TranslatorLike): string {
+/**
+ * Describe una suscripción detectada en una línea: plan · estado · importe.
+ *
+ * `t` = `adminUsuarios` (copy de esta pantalla), `tPagos` = `adminPagos` (las
+ * etiquetas de estado, que son el mismo catálogo que usa el dashboard de
+ * suscripciones). El estado NO sale de `classifySubscriptionStatus`: aquella
+ * redacta en español fijo —es el espejo del enum del backend, no copy— y a un
+ * admin anglófono le pintaba «Activa» / «Dada de baja» en mitad de una UI en
+ * inglés.
+ */
+function describeMatch(
+  m: MemberSubscriptionMatch,
+  t: TranslatorLike,
+  tPagos: TranslatorLike,
+): string {
   const plan = m.planName ?? t('requests.planFallback');
-  const { label } = classifySubscriptionStatus(m.status);
+  const label = subscriptionStatusLabel(m.status, tPagos);
   const amount = m.unitAmount !== null ? ` · ${formatAmount(m.unitAmount, m.currency)}` : '';
   return `${plan} — ${label}${amount} (${m.connectionName})`;
 }

--- a/apps/web/src/lib/i18n/format.test.ts
+++ b/apps/web/src/lib/i18n/format.test.ts
@@ -4,6 +4,7 @@ import es from '@/i18n/messages/es';
 import en from '@/i18n/messages/en';
 import {
   formatCents,
+  formatCentsExact,
   formatCurrency,
   formatDate,
   formatDateTime,
@@ -83,6 +84,99 @@ describe('formatCents', () => {
     expect(formatCents(99900, 'USD', { locale: 'en-US', minimumFractionDigits: 2 })).toBe(
       '$999.00',
     );
+  });
+});
+
+/**
+ * CAMINO DEGRADADO de moneda.
+ *
+ * El bug que cierra: `Intl.NumberFormat` LANZA `RangeError: Invalid currency
+ * code` ante una divisa que no sea ISO-4217 de 3 letras, y la divisa es dato
+ * ajeno (proveedor de pago o configuración del tenant). Los `formatAmount` por
+ * página a los que sustituyó `formatCents` sí tenían `try/catch`; el canónico
+ * nació sin él, así que un código inesperado tumbaba el render de la pantalla.
+ */
+describe('formatCurrency / formatCents · divisa inválida', () => {
+  it('degrada al formato histórico "<importe> <CÓDIGO>" en vez de lanzar', () => {
+    expect(formatCurrency(19.99, 'XXXXX', { locale: 'es-ES' })).toBe('19.99 XXXXX');
+    expect(formatCurrency(1234.5, 'no-es-una-divisa', { locale: 'en-US' })).toBe(
+      '1234.50 NO-ES-UNA-DIVISA',
+    );
+  });
+
+  it('formatCents y formatCentsExact heredan el degradado por delegación', () => {
+    expect(formatCents(1999, 'XXXXX', { locale: 'es-ES' })).toBe('19.99 XXXXX');
+    // Céntimo redondo: el degradado NO aplica la regla de "sin decimales", es
+    // el formato de emergencia de siempre (2 decimales fijos).
+    expect(formatCents(1900, 'XXXXX', { locale: 'es-ES' })).toBe('19.00 XXXXX');
+    expect(formatCentsExact(1900, 'XXXXX', { locale: 'es-ES' })).toBe('19.00 XXXXX');
+  });
+
+  it('divisa vacía: importe legible, sin espacio colgando', () => {
+    expect(formatCents(1999, '', { locale: 'es-ES' })).toBe('19.99');
+  });
+
+  it('la divisa VÁLIDA sigue pasando por Intl (el degradado no se cuela)', () => {
+    // Intl separa importe y símbolo con un espacio DURO (U+00A0): comparar con
+    // un espacio normal daría un falso rojo idéntico a simple vista.
+    expect(formatCents(1900, 'EUR', { locale: 'es-ES' })).toBe('19 €');
+    expect(formatCents(1999, 'USD', { locale: 'en-US' })).toBe('$19.99');
+    expect(formatCentsExact(1900, 'EUR', { locale: 'es-ES' })).toBe('19,00 €');
+  });
+});
+
+/**
+ * CAMINO DEGRADADO de fecha/hora.
+ *
+ * Mismo agujero, peor exposición: la `timeZone` sale del perfil del usuario
+ * (`locale-sync.tsx:58`) y la API la acepta como `z.string().min(1).max(64)`
+ * (`me.controller.ts:68`), sin comprobar que sea IANA. Una zona que Intl no
+ * conoce LANZA `RangeError: Invalid time zone specified` — y eso es TODA
+ * pantalla con una fecha, no una fila.
+ */
+describe('formatDate / formatDateTime / formatTime · timezone inválida', () => {
+  it('reintenta sin timezone y conserva locale, idioma y opciones', () => {
+    const opts = { locale: 'es-ES', timeZone: 'Marte/Olympus_Mons' } as const;
+    expect(formatDate(D, { ...opts, month: 'long' })).toBe('agosto');
+    expect(formatDate(D, { ...opts, year: 'numeric' })).toBe('2026');
+    expect(formatDateTime(D, { ...opts, month: 'long' })).toBe('agosto');
+    expect(formatTime(D, { ...opts, hour: '2-digit', hour12: false })).toMatch(/^\d{2}$/);
+  });
+
+  it('también degrada cuando la tz inválida viene del perfil (singleton)', () => {
+    setUserFormatPrefs({ locale: 'es-ES', timeZone: 'no/es/una/zona' });
+    expect(formatDate(D, { month: 'long' })).toBe('agosto');
+  });
+
+  it('último recurso: ni con locale corrupto lanza', () => {
+    const roto = { locale: 'no_es_un_locale', timeZone: 'Marte/Olympus_Mons' } as const;
+    expect(() => formatDate(D, roto)).not.toThrow();
+    expect(() => formatDateTime(D, roto)).not.toThrow();
+    expect(() => formatTime(D, roto)).not.toThrow();
+    expect(formatDate(D, roto)).not.toBe('');
+  });
+
+  it('una fecha inválida sigue devolviendo "Invalid Date", no una excepción', () => {
+    expect(formatDate('no-es-una-fecha', { locale: 'es-ES', timeZone: 'UTC' })).toBe(
+      'Invalid Date',
+    );
+    expect(formatDate('no-es-una-fecha', { locale: 'es-ES', timeZone: 'Marte/Olympus' })).toBe(
+      'Invalid Date',
+    );
+  });
+
+  it('la timezone VÁLIDA sigue mandando (el degradado no se cuela)', () => {
+    expect(
+      formatTime(D, { locale: 'es-ES', timeZone: 'UTC', hour: '2-digit', hour12: false }),
+    ).toBe('15');
+    expect(
+      formatTime(D, {
+        locale: 'es-ES',
+        timeZone: 'Australia/Sydney',
+        hour: '2-digit',
+        hour12: false,
+      }),
+    ).toBe('01');
   });
 });
 

--- a/apps/web/src/lib/i18n/format.ts
+++ b/apps/web/src/lib/i18n/format.ts
@@ -41,13 +41,51 @@ function resolveTimeZone(o?: FmtOverrides): string | undefined {
   return o?.timeZone ?? getUserFormatPrefs().timeZone ?? getBrowserTimeZone();
 }
 
+type LocaleDateMethod = 'toLocaleDateString' | 'toLocaleString' | 'toLocaleTimeString';
+
+/**
+ * Motor común de `formatDate`/`formatDateTime`/`formatTime` con su CAMINO
+ * DEGRADADO. Los tres reciben una `timeZone` que NO controlamos: sale del
+ * perfil del usuario (`LocaleSync` → `setUserFormatPrefs`, locale-sync.tsx:58)
+ * y la API la acepta como `z.string().min(1).max(64)` (me.controller.ts:68), sin
+ * comprobar que sea una zona IANA. Ante una zona que no reconoce, `Intl` no
+ * devuelve nada raro: LANZA `RangeError: Invalid time zone specified`. Con un
+ * solo perfil mal guardado, eso tumbaba TODA pantalla con una fecha.
+ *
+ * Dos escalones, del menos al más destructivo (el dato se conserva siempre):
+ *  1. Reintento SIN `timeZone` — el único argumento que aquí viene de dato
+ *     ajeno. La fecha sigue formateada en el locale e idioma correctos, solo
+ *     que en la zona del navegador.
+ *  2. Reintento sin locale ni opciones: `d.toLocale*String()` sin argumentos no
+ *     puede lanzar para ningún `Date` (una fecha inválida da "Invalid Date",
+ *     que es exactamente lo que ya devolvía antes este helper).
+ *
+ * El camino feliz queda intacto: si `Intl` no lanza, no se entra en ningún
+ * catch y la salida es byte a byte la de siempre.
+ */
+function formatLocaleDate(
+  d: DateInput,
+  method: LocaleDateMethod,
+  opts?: Intl.DateTimeFormatOptions & FmtOverrides,
+): string {
+  const date = toDate(d);
+  const { locale: _l, timeZone: _tz, ...rest } = opts ?? {};
+  const fmt: (locales?: string, options?: Intl.DateTimeFormatOptions) => string =
+    date[method].bind(date);
+  try {
+    return fmt(resolveLocale(opts), { timeZone: resolveTimeZone(opts), ...rest });
+  } catch {
+    try {
+      return fmt(resolveLocale(opts), rest);
+    } catch {
+      return fmt();
+    }
+  }
+}
+
 /** Reemplazo mecánico de `d.toLocaleDateString('es-ES', opts)`. */
 export function formatDate(d: DateInput, opts?: Intl.DateTimeFormatOptions & FmtOverrides): string {
-  const { locale: _l, timeZone: _tz, ...rest } = opts ?? {};
-  return toDate(d).toLocaleDateString(resolveLocale(opts), {
-    timeZone: resolveTimeZone(opts),
-    ...rest,
-  });
+  return formatLocaleDate(d, 'toLocaleDateString', opts);
 }
 
 /** Reemplazo de `d.toLocaleString('es-ES', opts)` (fecha + hora). */
@@ -55,20 +93,12 @@ export function formatDateTime(
   d: DateInput,
   opts?: Intl.DateTimeFormatOptions & FmtOverrides,
 ): string {
-  const { locale: _l, timeZone: _tz, ...rest } = opts ?? {};
-  return toDate(d).toLocaleString(resolveLocale(opts), {
-    timeZone: resolveTimeZone(opts),
-    ...rest,
-  });
+  return formatLocaleDate(d, 'toLocaleString', opts);
 }
 
 /** Reemplazo de `d.toLocaleTimeString('es-ES', opts)`. */
 export function formatTime(d: DateInput, opts?: Intl.DateTimeFormatOptions & FmtOverrides): string {
-  const { locale: _l, timeZone: _tz, ...rest } = opts ?? {};
-  return toDate(d).toLocaleTimeString(resolveLocale(opts), {
-    timeZone: resolveTimeZone(opts),
-    ...rest,
-  });
+  return formatLocaleDate(d, 'toLocaleTimeString', opts);
 }
 
 /**
@@ -81,15 +111,55 @@ export function formatNumber(n: number, opts?: Intl.NumberFormatOptions & FmtOve
 }
 
 /**
+ * Decimales del importe en el CAMINO DEGRADADO de moneda. No es una preferencia:
+ * es el formato exacto que ya daban los `formatAmount`/`fmtAmount` por página a
+ * los que sustituyeron estos helpers, y que sí llevaban el `try/catch` que aquí
+ * faltaba — `lib/payment-connections.ts:339` (formatAmount),
+ * `modules/subscriptions/client.ts:152`, `modules/billing/client.ts:154`,
+ * `admin/billing/products/page.tsx:48`,
+ * `admin/integraciones/payment-connections/page.tsx:62` y
+ * `…/subscriptions-dashboard.tsx:91` (los dos, fmtAmount). Los seis coinciden
+ * en el mismo texto: `` `${v.toFixed(2)} ${CUR}` ``.
+ */
+const FALLBACK_CURRENCY_FRACTION_DIGITS = 2;
+
+/**
+ * CAMINO DEGRADADO de moneda: "19.99 EUR".
+ *
+ * `Intl.NumberFormat` no tolera un código de divisa que no sea ISO-4217 de tres
+ * letras: LANZA `RangeError: Invalid currency code`. Y la divisa aquí es DATO
+ * AJENO — llega de un proveedor de pago (el `currency` de una suscripción de
+ * Stripe/WooCommerce/PayPal, `subscription-tab.tsx:54`, `user-dossier.tsx:68`,
+ * `renewal-email-modal.tsx:80`) o de la configuración de un tenant
+ * (`admin/membresia/page.tsx:390`, `referidos/page.tsx:228`). Sin este
+ * degradado, un código inesperado no da un importe feo: tumba el render entero
+ * de la pantalla contra el error boundary.
+ */
+function fallbackCurrency(value: number, currency: string): string {
+  const importe = value.toFixed(FALLBACK_CURRENCY_FRACTION_DIGITS);
+  return `${importe} ${String(currency).toUpperCase()}`.trim();
+}
+
+/**
  * Reemplazo del patrón `new Intl.NumberFormat('es-ES', { style: 'currency',
  * currency }).format(v)` (membership, payment-connections, billing, referidos).
+ *
+ * Es el único punto por el que la divisa entra a `Intl`, así que aquí —y no en
+ * `formatNumber`— vive el `try/catch`: `formatCents` y `formatCentsExact` lo
+ * heredan por delegación. `formatNumber` se queda estricto a propósito: su
+ * único argumento con riesgo es el locale, que nunca es dato (sale del conjunto
+ * cerrado de `@/i18n/config`, vía override explícito o vía `LocaleSync`).
  */
 export function formatCurrency(
   n: number,
   currency = 'EUR',
   opts?: Intl.NumberFormatOptions & FmtOverrides,
 ): string {
-  return formatNumber(n, { style: 'currency', currency, ...opts });
+  try {
+    return formatNumber(n, { style: 'currency', currency, ...opts });
+  } catch {
+    return fallbackCurrency(n, opts?.currency ?? currency);
+  }
 }
 
 /**

--- a/apps/web/src/lib/payment-connections.test.ts
+++ b/apps/web/src/lib/payment-connections.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { classifySubscriptionStatus, connectionStatusStyle } from './payment-connections';
+import { createTranslator } from 'next-intl';
+import es from '@/i18n/messages/es';
+import en from '@/i18n/messages/en';
+import {
+  classifySubscriptionStatus,
+  connectionStatusStyle,
+  subscriptionStatusLabel,
+} from './payment-connections';
 
 /**
  * Guardia de PARIDAD de `classifySubscriptionStatus`.
@@ -42,6 +49,59 @@ describe('classifySubscriptionStatus (web · paridad con el módulo)', () => {
     expect(classifySubscriptionStatus('  ACTIVE ').entitled).toBe(true);
     const unknown = classifySubscriptionStatus('rarísimo');
     expect(unknown).toEqual({ category: 'unknown', label: 'rarísimo', entitled: false });
+  });
+});
+
+/**
+ * Etiqueta de PANTALLA del estado de una suscripción.
+ *
+ * El bug que cierra: `/admin/solicitudes-miembros` pintaba el estado con
+ * `classifySubscriptionStatus(...).label`, que redacta en español fijo porque
+ * es el espejo del enum del backend, no copy. Un admin con la UI en inglés leía
+ * «Activa» / «Dada de baja» en mitad de la frase.
+ */
+describe('subscriptionStatusLabel', () => {
+  const tEs = createTranslator({ locale: 'es-ES', messages: es, namespace: 'adminPagos' });
+  const tEn = createTranslator({ locale: 'en-US', messages: en, namespace: 'adminPagos' });
+
+  it('en español sale BYTE A BYTE lo que ya daba classifySubscriptionStatus', () => {
+    for (const status of Object.keys(SUBSCRIPTION_STATUS_TABLE)) {
+      expect(subscriptionStatusLabel(status, tEs), status).toBe(
+        classifySubscriptionStatus(status).label,
+      );
+    }
+  });
+
+  it('en inglés sale del catálogo inglés, no del español', () => {
+    expect(subscriptionStatusLabel('active', tEn)).toBe('Active');
+    expect(subscriptionStatusLabel('canceled', tEn)).toBe('Canceled');
+    expect(subscriptionStatusLabel('cancelled', tEn)).toBe('Canceled');
+    expect(subscriptionStatusLabel('past_due', tEn)).toBe('Past due (overdue)');
+    // Los 13 estados conocidos tienen etiqueta propia en ambos idiomas y NINGUNA
+    // se queda en español dentro de la UI inglesa.
+    for (const status of Object.keys(SUBSCRIPTION_STATUS_TABLE)) {
+      expect(subscriptionStatusLabel(status, tEn), status).not.toBe(
+        subscriptionStatusLabel(status, tEs),
+      );
+    }
+  });
+
+  it('normaliza mayúsculas y espacios igual que la clasificación', () => {
+    expect(subscriptionStatusLabel('  ACTIVE ', tEs)).toBe('Activa');
+    expect(subscriptionStatusLabel('  ACTIVE ', tEn)).toBe('Active');
+  });
+
+  it('CAMINO DEGRADADO: estado desconocido → valor crudo del proveedor, nunca la key', () => {
+    for (const t of [tEs, tEn]) {
+      const salida = subscriptionStatusLabel('paused_indefinitely', t);
+      expect(salida).toBe('paused_indefinitely');
+      expect(salida).not.toContain('subStatus');
+    }
+  });
+
+  it('CAMINO DEGRADADO: solo un estado VACÍO cae a la etiqueta de desconocido', () => {
+    expect(subscriptionStatusLabel('', tEs)).toBe('Desconocido');
+    expect(subscriptionStatusLabel('', tEn)).toBe('Unknown');
   });
 });
 

--- a/apps/web/src/lib/payment-connections.ts
+++ b/apps/web/src/lib/payment-connections.ts
@@ -20,6 +20,7 @@
 
 import { apiFetch } from '@/lib/api-client';
 import { formatCurrency } from '@/lib/i18n/format';
+import type { TranslatorLike } from '@/lib/i18n/labels';
 
 export type PaymentConnectionStatus = 'PENDING' | 'VERIFIED' | 'ERROR' | 'DISCONNECTED';
 
@@ -111,7 +112,12 @@ export type SubscriptionStatusCategory =
 
 export interface SubscriptionStatusInfo {
   category: SubscriptionStatusCategory;
-  /** Etiqueta legible en español (p.ej. "Dada de baja", "En impago"). */
+  /**
+   * Etiqueta legible en español. NO es copy de pantalla: es el espejo del enum
+   * del backend, y existe para que la guardia de paridad con el módulo
+   * (`payment-connections.test.ts`) detecte divergencias. Lo que pinta la UI es
+   * `subscriptionStatusLabel`, que sí resuelve el idioma activo.
+   */
   label: string;
   /** Si el estado concede acceso vigente hoy. */
   entitled: boolean;
@@ -156,6 +162,63 @@ export function classifySubscriptionStatus(status: string): SubscriptionStatusIn
     default:
       return { category: 'unknown', label: status || 'Desconocido', entitled: false };
   }
+}
+
+/** Sufijos de `adminPagos.subStatus.*` con los que la UI nombra cada estado. */
+export type SubscriptionStatusLabelKey =
+  | 'active'
+  | 'trialing'
+  | 'pastDue'
+  | 'unpaid'
+  | 'onHold'
+  | 'paused'
+  | 'pendingCancel'
+  | 'canceled'
+  | 'expired'
+  | 'incomplete'
+  | 'pending'
+  | 'unknown';
+
+/**
+ * Status crudo del proveedor (normalizado a minúsculas) → key de etiqueta en
+ * `adminPagos.subStatus.*`. Espejo de PRESENTACIÓN del diccionario de
+ * `classifySubscriptionStatus`: la categoría y el `entitled` los decide aquella
+ * (y su guardia de paridad con el módulo backend); el texto que ve el admin
+ * sale del catálogo, en el idioma activo.
+ */
+const SUB_STATUS_LABEL_KEYS: Record<string, SubscriptionStatusLabelKey> = {
+  active: 'active',
+  trialing: 'trialing',
+  past_due: 'pastDue',
+  unpaid: 'unpaid',
+  'on-hold': 'onHold',
+  paused: 'paused',
+  'pending-cancel': 'pendingCancel',
+  canceled: 'canceled',
+  cancelled: 'canceled',
+  expired: 'expired',
+  incomplete: 'incomplete',
+  incomplete_expired: 'incomplete',
+  pending: 'pending',
+};
+
+/**
+ * Etiqueta de pantalla del estado de una suscripción, EN EL IDIOMA ACTIVO.
+ *
+ * `t` = `useTranslations('adminPagos')` (los estados de suscripción viven en
+ * ese catálogo aunque los pinte una pantalla de otra sección; duplicar las doce
+ * etiquetas en un segundo namespace solo garantizaría que diverjan).
+ *
+ * CAMINO DEGRADADO: un status que este mapa no conoce devuelve el VALOR CRUDO
+ * del proveedor, nunca la key. Es la misma decisión que la de
+ * `classifySubscriptionStatus` en el módulo backend y se conserva a propósito:
+ * ante un estado nuevo de Stripe, al admin le sirve más «paused_indefinitely»
+ * que «Desconocido», y muchísimo más que ver `subStatus.undefined` en pantalla.
+ * Solo cuando el status llega vacío se cae a la etiqueta de «desconocido».
+ */
+export function subscriptionStatusLabel(status: string, t: TranslatorLike): string {
+  const key = SUB_STATUS_LABEL_KEYS[(status ?? '').toLowerCase().trim()];
+  return key ? t(`subStatus.${key}`) : status || t('subStatus.unknown');
 }
 
 export interface DidactaUserLite {


### PR DESCRIPTION
Dos encargos pequeños e independientes en `apps/web`. El camino feliz no cambia en ningún helper.

---

## 1 — «Activa» / «Dada de baja» en una UI inglesa

`/admin/solicitudes-miembros` pintaba el estado de la suscripción con `classifySubscriptionStatus(...).label`. Esa función redacta en **español fijo** a propósito: es el espejo del enum del backend (con su guardia de paridad contra `modules/payment-connections`), no copy de pantalla. Resultado: un admin con la UI en inglés leía «Activa» / «Dada de baja» en mitad de la frase.

**El camino ya estaba hecho** en el dashboard de suscripciones (`subscriptions-dashboard.tsx`, el `SUB_STATUS_KEYS` + `t('subStatus.*')` de su `:93`): mapa del status crudo a una key de `adminPagos.subStatus.*` y traducción por catálogo. Se replica, pero **extrayéndolo** a `subscriptionStatusLabel` en `lib/payment-connections.ts` en vez de copiar el diccionario por tercera vez — un tercer duplicado sin test de paridad solo garantizaba que divergiera.

- `lib/payment-connections.ts` — `SUB_STATUS_LABEL_KEYS` + `subscriptionStatusLabel(status, t)`
- `solicitudes-miembros/page.tsx:509` — `describeMatch` recibe además el `t` de `adminPagos`
- `subscriptions-dashboard.tsx` — pasa a usar el helper compartido (−39 líneas)

`classifySubscriptionStatus` se queda tal cual (sigue dando `entitled` en `:71` y `:411`, y su `label` sigue siendo lo que ata la guardia de paridad con el módulo backend); solo se documenta que **no** es copy de pantalla.

**Criterios:**

- *Idioma activo* → `subscriptionStatusLabel('active', tEn)` = `Active`; test que además comprueba que **ninguno** de los 13 estados conocidos sale igual en ES y EN.
- *Español byte a byte igual que hoy* → test que compara, estado por estado, contra la etiqueta que devuelve `classifySubscriptionStatus`. Las 12 etiquetas de `adminPagos.subStatus` ES ya coincidían byte a byte con las de la función; tocar una en el catálogo pone el test en rojo (mutación M11).
- *Degradado = valor crudo del proveedor, nunca la key* → `paused_indefinitely` sale tal cual; solo un status **vacío** cae a «Desconocido» / «Unknown».

**Barrido de la pantalla entera:** era la única copy en español. El resto del texto ya sale de `t()`; lo que queda crudo es dato del proveedor por decisión (el `p.status` de un pedido en `describePurchase`, nombres de conexión, planes y emails), coherente con la misma doctrina de «valor crudo del proveedor». `UserChip` ya recibe su fallback traducido (`chip.memberFallback`).

---

## 2 — `formatCents` no protegía contra una moneda inválida

`Intl.NumberFormat` no tolera una divisa que no sea ISO-4217 de tres letras: **lanza** `RangeError: Invalid currency code`. Los `formatAmount`/`fmtAmount` por página a los que sustituyeron estos helpers **sí** llevaban `try/catch`; el canónico nació sin él. Un código inesperado —de un proveedor de pago o de la configuración de un tenant— no daba un importe feo: tumbaba el render entero contra el error boundary.

El guard va en `formatCurrency`, que es el único punto por el que la divisa entra a `Intl`; `formatCents` y `formatCentsExact` lo heredan por delegación.

**Constante nombrada:** `FALLBACK_CURRENCY_FRACTION_DIGITS = 2` + `fallbackCurrency()`. No es una preferencia: es el formato exacto que ya daban los seis wrappers históricos, todos con el mismo texto `` `${v.toFixed(2)} ${CUR}` `` — `lib/payment-connections.ts:339`, `modules/subscriptions/client.ts:152`, `modules/billing/client.ts:154`, `admin/billing/products/page.tsx:48`, `admin/integraciones/payment-connections/page.tsx:62` y `…/subscriptions-dashboard.tsx:91`.

**Call-sites expuestos** (divisa que llega de fuera): `subscription-tab.tsx:54`, `user-dossier.tsx:68`, `renewal-email-modal.tsx:80`, `admin/membresia/page.tsx:390`, `referidos/page.tsx:228`.

### Los otros helpers del fichero

- **Fechas — tienen el mismo agujero, y peor expuesto. Cerrado.** La `timeZone` sale del **perfil del usuario** (`locale-sync.tsx:58`) y la API la acepta como `z.string().min(1).max(64)` (`me.controller.ts:68`), sin comprobar que sea IANA. Una zona que Intl no conoce lanza `RangeError: Invalid time zone specified` — y eso es **toda** pantalla con una fecha, no una fila. (Que el agujero era real ya se notaba: `clase/[id]/page.tsx:67` llevaba su propio `try/catch` local.) Los tres helpers pasan por un motor común `formatLocaleDate` con dos escalones: reintento **sin timezone** (conserva locale, idioma y opciones) y, si el locale también es basura, `toLocale*String()` sin argumentos, que no puede lanzar para ningún `Date`. Una fecha inválida sigue devolviendo `"Invalid Date"`, igual que antes.
- **`formatNumber` — no lo tiene.** Su único argumento con riesgo es el locale, y el locale nunca es dato: sale del conjunto cerrado de `@/i18n/config`, por override explícito o vía `LocaleSync`. Se deja estricto a propósito y documentado, para que nadie lo "arregle" luego.
- **`formatDuration` — no lo tiene.** No toca `Intl` y ya guarda null/undefined/negativo/no-finito.

### Barrido de E2E

Verificado: ningún spec aserta un importe que pudiera cambiar. `referrals-flow.spec.ts:298` aserta `'2,97'` (no redondo), `ficha-venta-prod.spec.ts:60` solo el símbolo `'€'`, y `membresia-plan-flexible.spec.ts` es de API (de hecho comprueba que la API rechaza una moneda malformada con 400). En cualquier caso el degradado solo entra cuando Intl **hoy** ya lanzaría, así que el camino feliz es idéntico byte a byte.

---

## Verificación

- `dev-check.sh --format-fix` + `--quick` → **33/33**
- vitest **api 2323/2323**, **web 378/378** (364 de baseline + 14 nuevos)
- `ee-fence.ts` → **0 violaciones**
- E2E: SKIP

**Camino degradado verificado por MUTACIÓN** (11 mutaciones, las 11 en rojo):

| # | Mutación | Resultado |
|---|---|---|
| M1 | quitar el `try/catch` de `formatCurrency` | 🔴 3 tests |
| M2 | quitar el escalón 1 (reintento sin `timeZone`) | 🔴 2 tests |
| M3 | quitar toda la cadena de degradado de fechas | 🔴 3 tests |
| M4 | `FALLBACK_CURRENCY_FRACTION_DIGITS = 0` | 🔴 3 tests |
| M5 | fallback de moneda sin `.trim()` | 🔴 1 test |
| M6 | escalón 2 devuelve `''` en vez de `fmt()` | 🔴 1 test |
| M7 | degradado devuelve la KEY en vez del valor crudo | 🔴 2 tests |
| M8 | degradado devuelve `unknown` en vez del valor crudo | 🔴 1 test |
| M9 | quitar el alias `cancelled` del mapa | 🔴 2 tests |
| M10 | quitar `toLowerCase()/trim()` | 🔴 1 test |
| M11 | tocar una etiqueta ES del catálogo | 🔴 1 test |
