### PR TITLE
fix(web,api): importes redondos sin decimales en referidos y SCIM apunta a su guía

### DIFF
--- a/apps/api/src/scim/scim.controller.ts
+++ b/apps/api/src/scim/scim.controller.ts
@@ -97,7 +97,10 @@ export class ScimController {
   serviceProviderConfig() {
     return {
       schemas: [SCIM_SCHEMAS.SERVICE_PROVIDER_CONFIG],
-      documentationUri: 'https://docs.didacta.io/enterprise/',
+      // La página de SCIM, no el índice de Enterprise: es lo que el IdP
+      // (Entra ID, Okta) enseña al administrador que está dando de alta el
+      // aprovisionamiento, así que tiene que caer en la guía de ESTE endpoint.
+      documentationUri: 'https://docs.didacta.io/enterprise/scim/',
       patch: { supported: true },
       bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
       filter: { supported: true, maxResults: 200 },

--- a/apps/api/tests/scim.controller.test.ts
+++ b/apps/api/tests/scim.controller.test.ts
@@ -200,6 +200,20 @@ describe('ScimController · discovery (sin gating de capability)', () => {
     expect(schemes[0]?.primary).toBe(true);
   });
 
+  /**
+   * Los dos `documentationUri` del payload los enseña el IdP al administrador
+   * que configura el aprovisionamiento, así que cada uno tiene que caer en la
+   * guía de lo que documenta —no en un índice— y responder 200. El del cuerpo
+   * apuntaba al índice de Enterprise mientras la página de SCIM no existía;
+   * ya existe.
+   */
+  it('GET /ServiceProviderConfig documenta SCIM y su autenticación, no un índice', () => {
+    const r = controller.serviceProviderConfig() as Record<string, unknown>;
+    expect(r['documentationUri']).toBe('https://docs.didacta.io/enterprise/scim/');
+    const schemes = r['authenticationSchemes'] as Array<{ documentationUri: string }>;
+    expect(schemes[0]?.documentationUri).toBe('https://docs.didacta.io/api/autenticacion/');
+  });
+
   it('GET /ResourceTypes lista solo "User" (sin Groups en este piloto)', () => {
     const r = controller.resourceTypes() as Record<string, unknown>;
     expect(r['totalResults']).toBe(1);

--- a/apps/web/src/app/(app)/admin/referidos/page.tsx
+++ b/apps/web/src/app/(app)/admin/referidos/page.tsx
@@ -23,7 +23,7 @@ import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { apiErrorMessage } from '@/lib/i18n/api-error';
-import { formatCentsExact, formatDate } from '@/lib/i18n/format';
+import { formatCents, formatDate } from '@/lib/i18n/format';
 import { labelOr } from '@/lib/i18n/labels';
 import {
   referralsAdminApi,
@@ -75,14 +75,15 @@ function dateLabel(iso: string): string {
 }
 
 /**
- * Céntimos → "12,34 €" en el locale activo.
+ * Céntimos → "2,97 €" / "19 €" en el locale activo.
  *
- * Usa `formatCentsExact` (conserva el céntimo cero), NO el `formatCents`
- * canónico: son liquidaciones de comisión que el admin cuadra contra el pago
- * real al prescriptor. Mismo output byte a byte que el wrapper que sustituye.
+ * Usa el `formatCents` canónico, que quita el céntimo cero en las cantidades
+ * redondas. Es la misma regla que ya ven `/referidos` (la pantalla del
+ * prescriptor, que lee estas MISMAS comisiones), `/unete` y `/catalogo`: las
+ * dos caras del programa de referidos tienen que escribir el importe igual.
  */
 function amountLabel(cents: number, currency = 'eur'): string {
-  return formatCentsExact(cents, currency.toUpperCase());
+  return formatCents(cents, currency.toUpperCase());
 }
 
 export default function AdminReferidosPage() {

--- a/apps/web/src/lib/i18n/format.test.ts
+++ b/apps/web/src/lib/i18n/format.test.ts
@@ -85,6 +85,20 @@ describe('formatCents', () => {
       '$999.00',
     );
   });
+
+  /**
+   * La regla, escrita en el par de importes con el que se decidió: los dos
+   * lados del programa de referidos (`/referidos` y `/admin/referidos`) pintan
+   * la MISMA comisión, así que tienen que escribirla igual. El `amountLabel`
+   * de `/admin/referidos` conservaba el céntimo cero y es el que se unificó.
+   *
+   * NBSP explícito (` `): es lo que mete Intl entre importe y símbolo, y
+   * un espacio normal daría un rojo indistinguible a simple vista.
+   */
+  it('en es-ES: 1900 → "19 €" y 297 → "2,97 €"', () => {
+    expect(formatCents(1900, 'EUR', { locale: 'es-ES' })).toBe('19 €');
+    expect(formatCents(297, 'EUR', { locale: 'es-ES' })).toBe('2,97 €');
+  });
 });
 
 /**

--- a/apps/web/src/lib/i18n/format.ts
+++ b/apps/web/src/lib/i18n/format.ts
@@ -189,9 +189,20 @@ export function formatCents(
  * "19,00 €"). Segunda —y última— regla de céntimos del producto.
  *
  * No es una preferencia estética: estas cifras se cuadran a mano contra un
- * sistema de fuera (el dashboard de Stripe, el expediente Fundae, una factura,
- * una liquidación de comisiones) y ahí "19 €" y "19,00 €" no se leen igual de
- * un vistazo. No la unifiques con `formatCents`.
+ * sistema de fuera (el dashboard de Stripe, el expediente Fundae, una factura)
+ * y ahí "19 €" y "19,00 €" no se leen igual de un vistazo. No la unifiques con
+ * `formatCents`.
+ *
+ * OJO: hoy no le queda ningún call-site. El único que tenía —el `amountLabel`
+ * de `/admin/referidos`— pasó al `formatCents` canónico por decisión de
+ * producto: las comisiones son copy de pantalla, no un cuadre contra un
+ * sistema externo, y la otra cara del mismo programa (`/referidos`, la del
+ * prescriptor) ya escribía "19 €". La regla que codifica esta función SIGUE
+ * VIVA, pero escrita a mano en los cuatro formateadores que sí cuadran contra
+ * fuera: `payment-connections.ts` y `modules/subscriptions/client.ts`
+ * (formatAmount), `modules/billing/client.ts` (formatPrice) y
+ * `modules/fundae/companies-client.ts` (formatCents). Es el sitio al que
+ * unificarlos el día que se toquen; por eso no se borra.
  *
  * No fuerza `minimumFractionDigits`: deja que Intl aplique los dígitos propios
  * de la divisa, que es lo que hacían los wrappers que sustituye (idéntico byte


### PR DESCRIPTION
Tres encargos del lote de decisiones de producto. **Dos llevan cambio; el tercero ya estaba cerrado en la base y se documenta aquí para que no se vuelva a abrir.**

---

## 1 · Importes redondos en referidos: sin decimales

**Síntoma.** `/admin/referidos` escribía «19,00 €» donde `/referidos` —la otra cara del **mismo** programa, leyendo las **mismas** comisiones— escribe «19 €».

**Qué usaba cada pantalla (verificado con grep, no asumido):**

| Pantalla | Helper | Importe redondo |
|---|---|---|
| `/referidos` (prescriptor) | `formatCents` canónico | `19 €` ✅ ya correcto |
| `/admin/referidos` | `formatCentsExact` | `19,00 €` ❌ |

El `amountLabel` de `/admin/referidos` pasa al `formatCents` canónico. Es la regla que ya ven `/unete` y `/catalogo`. Los importes con resto no se mueven: «2,97 €» sigue siendo «2,97 €».

### `formatCentsExact` NO se borra — y esto conviene mirarlo

Grep dice que **tras este cambio se queda con cero call-sites**: el `amountLabel` de `/admin/referidos` era el único (fuera de sus propios tests). Aun así lo dejo, y creo que es lo correcto:

La regla que codifica —el céntimo cero SE ESCRIBE— **sigue viva**, pero escrita a mano en los cuatro formateadores que sí cuadran contra un sistema externo:

- `lib/payment-connections.ts` → `formatAmount`
- `modules/subscriptions/client.ts` → `formatAmount`
- `modules/billing/client.ts` → `formatPrice`
- `modules/fundae/companies-client.ts` → `formatCents`

Es el sitio al que unificarlos el día que se toquen; borrarlo ahora obliga a reescribirlo. Su docstring lo dice ya explícitamente y **deja de citar «una liquidación de comisiones»** como motivo, que es exactamente el caso que se acaba de mover. **Si prefieres recogerlo, es borrar la función y dos líneas de test.**

### Barrido E2E previo (verificado, `apps/e2e/**` intacto)

Los únicos specs que tocan referidos son `referrals-flow.spec.ts` y `arnes-contrato.spec.ts`. El único aserto de importe es:

```
apps/e2e/tests/referrals-flow.spec.ts:300
await expect(page.getByText('2,97').first()).toBeVisible();
```

297 céntimos → no redonda → **no cambia**. Ningún spec aserta una cantidad redonda. Confirmado el barrido previo.

---

## 2 · El typo «lecciónes» — **ya estaba arreglado, sin cambio**

Barrido byte a byte de todo el repo (con detección de tilde combinante U+0301, no solo `ó` precompuesta): **0 apariciones**.

El typo existió y se cerró en `52a6b377` (PR #30, «plural del aria»), que es ancestro de la base `ecb2861d`. `git log -L` sobre las dos líneas lo confirma:

```
-  "lessonCount": "… other {<strong>#</strong> lecciónes}}",
+  "lessonCount": "… other {<strong>#</strong> lecciones}}",
-  "lessonProgressSummary": "… other {# lecciónes}} · {completed} completadas",
+  "lessonProgressSummary": "… other {# lecciones}} · {completed} completadas",
```

Las keys eran las que decía el encargo (`alumnoAprendizaje.lessonCount` y `lessonProgressSummary`) y el inglés ya decía «lessons». **No se ha tocado ningún otro copy español** — los dos retoques descartados de la misma familia («Vos» rioplatense en `lesson-comments.tsx`, «video» vs «vídeo» entre `lesson-player` y `video-embed`) siguen exactamente como estaban.

---

## 3 · `documentationUri` de SCIM

`ServiceProviderConfig` devolvía el índice de Enterprise. Era un parche de cuando la página de SCIM no existía; ya existe y está publicada. Es la URL que el IdP (Entra ID, Okta) enseña al administrador que da de alta el aprovisionamiento, así que tiene que caer en la guía de **este** endpoint.

El `documentationUri` de `authenticationSchemes` **se comprobó antes de tocarlo, ya resolvía bien, y se queda como estaba.**

URLs verificadas con `curl -o /dev/null -w '%{http_code}'`:

| URL | Código |
|---|---|
| `https://docs.didacta.io/enterprise/` (la que se va) | 200 |
| `https://docs.didacta.io/enterprise/scim/` (la que entra) | **200** |
| `https://docs.didacta.io/api/autenticacion/` (`authenticationSchemes`, sin tocar) | **200** |

Un test nuevo fija las dos, para que el índice no vuelva a colarse.

> ⚠️ **Posible choque de merge.** Hay otro worker dentro de `apps/api/src/scim/**` arreglando defectos de SCIM. Mi cambio ahí es **una línea** en `scim.controller.ts` (+ un `it` nuevo en `scim.controller.test.ts`). Si choca, es trivial de resolver a mano.

---

## Frontera respetada

- **Tocado:** `apps/web/src/**`, `apps/api/src/scim/scim.controller.ts` y sus tests.
- **No tocado:** el resto de `apps/api/src/scim/**`, nada del limitador de peticiones ni de los filtros de excepción.
- **`apps/e2e/**`:** solo lectura, cero ficheros modificados.

## Verificación

| Comprobación | Resultado |
|---|---|
| `dev-check.sh --format-fix` + `--quick` | **33/33** |
| vitest `apps/api` | **2324/2324** (baseline 2323 + 1 nuevo) |
| vitest `apps/web` | **379/379** (baseline 378 + 1 nuevo) |
| `pnpm tsx scripts/ee-fence.ts` | **0 violaciones** (1409 ficheros) |
| E2E | SKIP (según encargo) |
