### PR TITLE
fix(scim): el tráfico del IdP deja de compartir cupo con internet y los errores hablan SCIM

### DIFF
--- a/apps/api/src/rate-limit/rate-limit.interceptor.ts
+++ b/apps/api/src/rate-limit/rate-limit.interceptor.ts
@@ -6,9 +6,10 @@
  *
  * Aplicado global vía APP_INTERCEPTOR. Para cada request HTTP:
  *   1. Identifica `tenantId` desde `request.user` (lo setea JwtAuthGuard) o
- *      desde un header `x-tenant-id` ya resuelto por TenantMiddleware. Si no
- *      hay nada, trata la request como pública (bucket `'anonymous'`).
- *   2. Decide `isPublic`: si no hay JWT verificado, es pública.
+ *      desde `request.scimTenantId` (lo setea ScimAuthGuard con el Bearer del
+ *      IdP). Si no hay ninguno, trata la request como pública (bucket
+ *      `'anonymous'`).
+ *   2. Decide `isPublic`: si no hay ninguna identidad resuelta, es pública.
  *   3. Llama `RateLimitService.recordRequest`.
  *   4. Setea SIEMPRE los headers estándar (`X-RateLimit-*`).
  *   5. Si la request fue rechazada, lanza `HttpException(429)` con
@@ -74,12 +75,23 @@ export class RateLimitInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    // `request.user` lo setea JwtAuthGuard cuando el endpoint pasa por él.
-    // Para públicos (sin JwtAuthGuard) `request.user` queda undefined → el
-    // bucket es público y `tenantId` es 'anonymous'.
+    // Identidad de la request, en orden de confianza:
+    //
+    //   1. `request.user` — lo setea JwtAuthGuard con los claims del JWT.
+    //   2. `request.scimTenantId` — lo setea ScimAuthGuard tras validar el
+    //      Bearer estático del IdP. Es una identidad DISTINTA del JWT (por eso
+    //      no comparten campo: son trust boundaries separados) pero identifica
+    //      un tenant igual de bien, y contarla como tráfico anónimo metía a
+    //      todos los IdPs de la instancia en el mismo bucket `'anonymous'` que
+    //      el tráfico sin autenticar de internet. Un sync inicial se comía los
+    //      429 del cupo público por culpa de visitantes que no tienen nada que
+    //      ver con el tenant.
+    //
+    // Sin ninguna de las dos, la request es pública → bucket `'anonymous'`.
     const user = request.user;
-    const isPublic = !user;
-    const tenantId = user?.tenantId ?? 'anonymous';
+    const identifiedTenantId = user?.tenantId ?? request.scimTenantId;
+    const isPublic = identifiedTenantId === undefined;
+    const tenantId = identifiedTenantId ?? 'anonymous';
 
     return from(this.rateLimit.recordRequest(tenantId, isPublic)).pipe(
       switchMap((decision) => {

--- a/apps/api/src/scim/scim-auth.guard.ts
+++ b/apps/api/src/scim/scim-auth.guard.ts
@@ -37,6 +37,7 @@ import {
   type CanActivate,
   type ExecutionContext,
   Injectable,
+  Logger,
   UnauthorizedException,
 } from '@nestjs/common';
 import type { FastifyRequest } from 'fastify';
@@ -44,6 +45,21 @@ import { createHash } from 'node:crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import { SCIM_TOKEN_KEY, SCIM_TOKEN_MODULE_NAME, makeScimError } from './scim.types';
 import type { ScimApiTokenRecord } from './scim.types';
+
+/**
+ * Cada cuánto, como mucho, se refresca `lastUsedAt` de un token.
+ *
+ * El panel `/admin/scim` muestra ese campo para responder a una única pregunta:
+ * «¿mi IdP está sincronizando o no?». Con un minuto de resolución la respuesta
+ * es igual de buena y el coste es acotado: un UPDATE por tenant y minuto en el
+ * peor caso, en vez de uno por request (un sync inicial de 500 usuarios son
+ * ~1000 requests en pocos minutos — escribir en todas convertiría una tabla de
+ * configuración en una tabla de log).
+ *
+ * El contador vive en memoria del proceso: con varias réplicas de la API el
+ * peor caso es una escritura por réplica y minuto, que sigue siendo despreciable.
+ */
+export const SCIM_LAST_USED_THROTTLE_MS = 60_000;
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -69,6 +85,11 @@ export function hashScimToken(rawToken: string): string {
 
 @Injectable()
 export class ScimAuthGuard implements CanActivate {
+  private readonly logger = new Logger(ScimAuthGuard.name);
+
+  /** tenantId → epoch ms de la última escritura de `lastUsedAt`. */
+  private readonly lastUsedWrittenAt = new Map<string, number>();
+
   constructor(private readonly prisma: PrismaService) {}
 
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
@@ -108,11 +129,59 @@ export class ScimAuthGuard implements CanActivate {
       if (!record || typeof record.tokenHash !== 'string') continue;
       if (timingSafeEqualStr(record.tokenHash, wantedHash)) {
         req.scimTenantId = row.tenantId;
+        await this.touchLastUsedAt(row.tenantId, record);
         return true;
       }
     }
 
     throw new UnauthorizedException(makeScimError(401, 'Bearer token not recognized.'));
+  }
+
+  /**
+   * Sella `lastUsedAt` del token, como mucho una vez cada
+   * `SCIM_LAST_USED_THROTTLE_MS`.
+   *
+   * Se escribe directo con Prisma en vez de pasar por
+   * `PrismaTenantConfigService.set()` a propósito: ese service registra una
+   * entrada de auditoría por escritura, y esto no es un cambio de configuración
+   * hecho por nadie — es contabilidad de uso. Auditar cada minuto que el IdP
+   * sigue vivo llenaría el log que el admin usa para investigar cambios reales.
+   *
+   * Un fallo escribiendo NO tumba la request: el IdP no puede quedarse sin
+   * provisionar porque hayamos fallado al actualizar un campo informativo.
+   */
+  private async touchLastUsedAt(tenantId: string, record: ScimApiTokenRecord): Promise<void> {
+    const now = Date.now();
+    const previous = this.lastUsedWrittenAt.get(tenantId);
+    if (previous !== undefined && now - previous < SCIM_LAST_USED_THROTTLE_MS) return;
+
+    // Marcamos ANTES de escribir: si el UPDATE falla, no reintentamos en cada
+    // request de la ráfaga — esperamos a la siguiente ventana.
+    this.lastUsedWrittenAt.set(tenantId, now);
+
+    try {
+      await this.prisma.tenantSetting.update({
+        where: {
+          tenantId_moduleName_key: {
+            tenantId,
+            moduleName: SCIM_TOKEN_MODULE_NAME,
+            key: SCIM_TOKEN_KEY,
+          },
+        },
+        data: {
+          valueJson: {
+            ...record,
+            lastUsedAt: new Date(now).toISOString(),
+          },
+        },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `No se pudo actualizar lastUsedAt del token SCIM (tenant ${tenantId}): ${
+          (err as Error).message
+        }`,
+      );
+    }
   }
 }
 

--- a/apps/api/src/scim/scim-content-type.interceptor.ts
+++ b/apps/api/src/scim/scim-content-type.interceptor.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ *
+ * ScimContentTypeInterceptor — pone `application/scim+json` en las respuestas
+ * correctas de `/scim/v2/**`.
+ *
+ * El camino de error lo cubre `ScimExceptionFilter`, que no pasa por aquí (un
+ * filtro escribe la respuesta él mismo). Este interceptor cubre el otro medio:
+ * sin él, `/scim` respondería el estándar en los errores y `application/json`
+ * en los 200, que es un contrato incoherente para un IdP que valida el
+ * content-type de todo lo que recibe (RFC 7644 §3.1).
+ *
+ * El 204 de `DELETE /Users/:id` se deja sin content-type a propósito: no lleva
+ * cuerpo, y anunciar un tipo de medio para un cuerpo vacío confunde a los
+ * clientes que lo intentan parsear.
+ */
+
+import {
+  Injectable,
+  type CallHandler,
+  type ExecutionContext,
+  type NestInterceptor,
+} from '@nestjs/common';
+import type { FastifyReply } from 'fastify';
+import { Observable, tap } from 'rxjs';
+import { SCIM_CONTENT_TYPE } from './scim.types';
+
+@Injectable()
+export class ScimContentTypeInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') {
+      return next.handle();
+    }
+
+    const reply = context.switchToHttp().getResponse<FastifyReply>();
+
+    return next.handle().pipe(
+      tap((payload) => {
+        if (payload === null || payload === undefined) return;
+        reply.header('content-type', SCIM_CONTENT_TYPE);
+      }),
+    );
+  }
+}

--- a/apps/api/src/scim/scim-exception.filter.ts
+++ b/apps/api/src/scim/scim-exception.filter.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ *
+ * ScimExceptionFilter — traduce CUALQUIER excepción que ocurra dentro de
+ * `/scim/v2/**` a un error RFC 7644 §3.12 servido como `application/scim+json`.
+ *
+ * Por qué hace falta un filtro propio:
+ *   El controller ya lanzaba errores SCIM bien formados, pero nunca llegaban
+ *   así al IdP. En el camino se cruzan tres piezas globales que no saben nada
+ *   de SCIM:
+ *     - `HttpExceptionNormalizerFilter` (main.ts) añade `statusCode` y
+ *       `message` al cuerpo → el error deja de ser RFC puro.
+ *     - `LicenseExceptionFilter` (license-sdk) emite su propio shape para el
+ *       402 de `feat:scim`.
+ *     - `RateLimitInterceptor` emite el suyo para el 429.
+ *   Y ninguna de las tres pone el content-type del estándar. Un IdP estricto
+ *   parsea por contrato: si el content-type es `application/json` y el cuerpo
+ *   trae campos que no reconoce, lo trata como respuesta opaca y reporta un
+ *   error genérico al admin.
+ *
+ * Alcance y precedencia:
+ *   Va montado con `@UseFilters` a nivel de CONTROLLER, no global. Nest ordena
+ *   [globales…, clase…, método…] y luego invierte, así que un filtro de clase
+ *   gana a los globales. `@Catch()` sin argumentos captura todo lo que pase por
+ *   las rutas de este controller — incluidos guards (401 del ScimAuthGuard,
+ *   402 del LicenseGuard), interceptores globales (429) y pipes (400 de Zod).
+ *   Fuera de `/scim` no cambia nada: los filtros globales siguen mandando.
+ */
+
+import {
+  Catch,
+  HttpException,
+  HttpStatus,
+  Logger,
+  type ArgumentsHost,
+  type ExceptionFilter,
+} from '@nestjs/common';
+import { CapabilityRequiredError, LicenseSignatureError } from '@didacta/license-sdk';
+import type { FastifyReply } from 'fastify';
+import {
+  SCIM_CONTENT_TYPE,
+  SCIM_SCHEMAS,
+  makeScimError,
+  type ScimError,
+  type ScimErrorType,
+} from './scim.types';
+
+/**
+ * `scimType` por defecto cuando la excepción no trae uno propio.
+ *
+ * RFC 7644 §3.12 sólo define `scimType` para un subconjunto de errores. El
+ * único que podemos deducir sin adivinar es el 400: si llegamos aquí con un
+ * 400 sin `scimType`, viene del `ZodValidationPipe`, es decir "el cuerpo o los
+ * query params no se ajustan al schema" → `invalidSyntax`.
+ */
+function defaultScimType(status: number): ScimErrorType | undefined {
+  return status === HttpStatus.BAD_REQUEST ? 'invalidSyntax' : undefined;
+}
+
+/**
+ * ¿La respuesta de la excepción YA es un error SCIM? El service y el guard
+ * construyen los suyos con `makeScimError`, y en ese caso hay que respetarlos
+ * tal cual (traen `scimType` calculado con contexto que aquí no tenemos:
+ * `uniqueness`, `invalidFilter`, `invalidPath`…).
+ */
+function asScimError(response: unknown): ScimError | null {
+  if (typeof response !== 'object' || response === null) return null;
+  const candidate = response as Record<string, unknown>;
+  const schemas = candidate['schemas'];
+  if (!Array.isArray(schemas) || !schemas.includes(SCIM_SCHEMAS.ERROR)) return null;
+  if (typeof candidate['detail'] !== 'string') return null;
+  return candidate as unknown as ScimError;
+}
+
+/** Texto humano del error a partir del cuerpo de una HttpException. */
+function extractDetail(exception: HttpException, response: unknown): string {
+  if (typeof response === 'string') return response;
+  if (typeof response === 'object' && response !== null) {
+    const message = (response as Record<string, unknown>)['message'];
+    if (typeof message === 'string') return message;
+    if (Array.isArray(message)) return message.join('; ');
+  }
+  return exception.message || 'Error';
+}
+
+/**
+ * Traduce una excepción cualquiera al par (status HTTP, cuerpo SCIM).
+ * Exportada para poder testearla sin levantar la app.
+ */
+export function toScimErrorResponse(exception: unknown): { status: number; body: ScimError } {
+  if (exception instanceof CapabilityRequiredError) {
+    // El mensaje del SDK ya nombra la capability ("feat:scim"), que es
+    // justo el dato que el admin necesita para saber qué le falta.
+    return {
+      status: HttpStatus.PAYMENT_REQUIRED,
+      body: makeScimError(HttpStatus.PAYMENT_REQUIRED, exception.message),
+    };
+  }
+
+  if (exception instanceof LicenseSignatureError) {
+    return {
+      status: HttpStatus.UNAUTHORIZED,
+      body: makeScimError(HttpStatus.UNAUTHORIZED, exception.message),
+    };
+  }
+
+  if (exception instanceof HttpException) {
+    const status = exception.getStatus();
+    const response = exception.getResponse();
+
+    const already = asScimError(response);
+    if (already) {
+      // Realineamos `status` con el HTTP real: es el único campo que puede
+      // desincronizarse si alguien construye el cuerpo con un número y lanza
+      // la excepción con otro.
+      return { status, body: { ...already, status: String(status) } };
+    }
+
+    return {
+      status,
+      body: makeScimError(status, extractDetail(exception, response), defaultScimType(status)),
+    };
+  }
+
+  // Errores no controlados: el IdP recibe un 500 SCIM sin el mensaje interno.
+  // El detalle se queda en el log de la instancia (ver `catch`).
+  return {
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    body: makeScimError(HttpStatus.INTERNAL_SERVER_ERROR, 'Internal server error.'),
+  };
+}
+
+@Catch()
+export class ScimExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(ScimExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    if (host.getType() !== 'http') {
+      throw exception;
+    }
+
+    const { status, body } = toScimErrorResponse(exception);
+
+    // Los 500 los perdía el `BaseExceptionFilter` de Nest si no los
+    // registramos aquí: este filtro es el último que ve la excepción.
+    if (status >= HttpStatus.INTERNAL_SERVER_ERROR) {
+      this.logger.error(
+        `Unhandled error in SCIM endpoint: ${
+          exception instanceof Error ? exception.stack : String(exception)
+        }`,
+      );
+    }
+
+    const reply = host.switchToHttp().getResponse<FastifyReply>();
+    void reply.status(status).header('content-type', SCIM_CONTENT_TYPE).send(body);
+  }
+}

--- a/apps/api/src/scim/scim.controller.ts
+++ b/apps/api/src/scim/scim.controller.ts
@@ -12,6 +12,13 @@
  *   POST   /scim/v2/Users                   gateado feat:scim
  *   PATCH  /scim/v2/Users/:id               gateado feat:scim
  *   DELETE /scim/v2/Users/:id               gateado feat:scim
+ *   ALL    /scim/v2/Groups[/*]              501 Not Implemented (ver abajo)
+ *   ALL    /scim/v2/*                       404 en formato SCIM
+ *
+ * Formato de salida:
+ *   Todo lo que sale de aquí va como `application/scim+json`, y los errores en
+ *   formato RFC 7644 §3.12 — lo garantizan `ScimContentTypeInterceptor` y
+ *   `ScimExceptionFilter`, montados a nivel de controller.
  *
  * Por qué ServiceProviderConfig / ResourceTypes / Schemas no van gateados:
  *   Los IdPs los consultan ANTES de configurar el connector — RFC 7644 §4
@@ -34,6 +41,7 @@
  */
 
 import {
+  All,
   BadRequestException,
   Body,
   Controller,
@@ -41,19 +49,25 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  NotFoundException,
+  NotImplementedException,
   Param,
   Patch,
   Post,
   Query,
   Req,
   UnauthorizedException,
+  UseFilters,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { FastifyRequest } from 'fastify';
 import { LICENSE_CAPABILITIES, RequiresCapability } from '@didacta/license-sdk';
 import { ZodValidationPipe } from '../auth/zod-validation.pipe';
 import { ScimAuthGuard } from './scim-auth.guard';
+import { ScimContentTypeInterceptor } from './scim-content-type.interceptor';
+import { ScimExceptionFilter } from './scim-exception.filter';
 import { ScimService, buildListResponse } from './scim.service';
 import {
   scimCreateUserSchema,
@@ -80,6 +94,11 @@ function requireScimTenant(req: FastifyRequest): string {
 @ApiTags('SCIM v2')
 @Controller('scim/v2')
 @UseGuards(ScimAuthGuard)
+// Todo lo que sale por estas rutas habla el dialecto del estándar: los errores
+// en formato RFC 7644 §3.12 (filtro) y el content-type `application/scim+json`
+// tanto en errores como en respuestas correctas (interceptor).
+@UseFilters(ScimExceptionFilter)
+@UseInterceptors(ScimContentTypeInterceptor)
 export class ScimController {
   constructor(private readonly scim: ScimService) {}
 
@@ -97,7 +116,7 @@ export class ScimController {
   serviceProviderConfig() {
     return {
       schemas: [SCIM_SCHEMAS.SERVICE_PROVIDER_CONFIG],
-      documentationUri: 'https://docs.didacta.io/enterprise/',
+      documentationUri: 'https://docs.didacta.io/enterprise/scim/',
       patch: { supported: true },
       bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
       filter: { supported: true, maxResults: 200 },
@@ -276,10 +295,69 @@ export class ScimController {
     await this.scim.deleteUser(tenantId, id, { actorId: null });
     return null;
   }
+
+  // ---------------------------------------------------------------------------
+  // Groups — ruta del estándar que este servidor NO implementa
+  // ---------------------------------------------------------------------------
+
+  /**
+   * `/Groups` existe en RFC 7643 §4.2 y este servidor no la implementa. La
+   * respuesta correcta para "la ruta es del estándar pero el servidor no sabe
+   * hacerlo" es 501, no 404: un 404 le dice al IdP "esa URL no existe", que es
+   * mentira y le hace dudar de si la URL base está mal configurada.
+   *
+   * Deliberadamente NO va gateado con `feat:scim`: que Groups no esté
+   * implementado es una propiedad de este servidor, no de la licencia — como
+   * los endpoints de discovery, que también responden lo mismo con o sin
+   * Enterprise. El `ResourceTypes` ya declara que el único recurso es `User`;
+   * esto es la misma verdad dicha desde la otra punta.
+   */
+  @All('Groups')
+  @ApiOperation({
+    summary:
+      'Groups NO está implementado en este servidor. Responde 501 Not Implemented ' +
+      'con cuerpo de error SCIM. Solo se soporta el recurso User.',
+  })
+  @ApiResponse({ status: 501, description: 'Groups no implementado.' })
+  groupsNotImplemented(): never {
+    throw new NotImplementedException(
+      makeScimError(
+        501,
+        'Group provisioning is not implemented by this server. Only the User resource is supported — ' +
+          'see GET /scim/v2/ResourceTypes.',
+      ),
+    );
+  }
+
+  /** Misma respuesta para cualquier subruta de Groups (`/Groups/:id`, etc.). */
+  @All('Groups/*')
+  @ApiExcludeEndpoint()
+  groupsSubpathNotImplemented(): never {
+    return this.groupsNotImplemented();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Catch-all — cualquier otra ruta bajo /scim/v2
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Sin esto, una ruta desconocida bajo `/scim/v2` la resuelve el 404 genérico
+   * del router, que no pasa por el `ScimExceptionFilter` (no hay controller que
+   * lo monte) y sale como JSON del API. Declarada la última: en el router radix
+   * de Fastify las rutas estáticas ganan al comodín, así que no ensombrece a
+   * `Users` ni a `Groups`.
+   */
+  @All('*')
+  @ApiExcludeEndpoint()
+  unknownScimRoute(@Req() req: FastifyRequest): never {
+    throw new NotFoundException(
+      makeScimError(404, `Unknown SCIM endpoint: ${req.method} ${(req.url ?? '').split('?')[0]}.`),
+    );
+  }
 }
 
-// Helper que el filtro no captura — re-exportamos el shape del error para los
-// tests que verifican el status string en SCIM error responses.
+// Re-export del shape del error para los tests que verifican el status string
+// en las respuestas de error SCIM.
 export type ScimErrorBody = ScimError;
 
 // Captura para el linter: BadRequestException es importada implicitamente vía

--- a/apps/api/src/scim/scim.module.ts
+++ b/apps/api/src/scim/scim.module.ts
@@ -22,13 +22,19 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { ScimAuthGuard } from './scim-auth.guard';
+import { ScimContentTypeInterceptor } from './scim-content-type.interceptor';
+import { ScimExceptionFilter } from './scim-exception.filter';
 import { ScimController } from './scim.controller';
 import { ScimService } from './scim.service';
 
 @Module({
   imports: [AuthModule],
   controllers: [ScimController],
-  providers: [ScimService, ScimAuthGuard],
+  // El filtro y el interceptor van declarados como providers (no como
+  // instancias en el `@UseFilters` / `@UseInterceptors`) para que Nest los
+  // resuelva por DI: así el filtro puede tener su propio Logger y ambos
+  // participan del ciclo de vida del contenedor.
+  providers: [ScimService, ScimAuthGuard, ScimExceptionFilter, ScimContentTypeInterceptor],
   exports: [ScimService],
 })
 export class ScimModule {}

--- a/apps/api/src/scim/scim.types.ts
+++ b/apps/api/src/scim/scim.types.ts
@@ -37,6 +37,14 @@ export const SCIM_SCHEMAS = {
   SCHEMA: 'urn:ietf:params:scim:schemas:core:2.0:Schema',
 } as const;
 
+/**
+ * Content-type del protocolo SCIM (RFC 7644 §3.1: "the SCIM protocol uses the
+ * media type `application/scim+json`"). Lo emitimos tanto en las respuestas
+ * correctas como en los errores: un IdP estricto parsea por contrato y
+ * `application/json` no es el contrato que anuncia el estándar.
+ */
+export const SCIM_CONTENT_TYPE = 'application/scim+json';
+
 /** Persistencia del token SCIM dentro de `tenant_setting`. */
 export const SCIM_TOKEN_MODULE_NAME = 'scim';
 export const SCIM_TOKEN_KEY = 'api-token';
@@ -51,8 +59,8 @@ export const SCIM_TOKEN_KEY = 'api-token';
  *   identificar de un vistazo qué token está activo (estilo GitHub PAT).
  * - `createdAt`: ISO timestamp.
  * - `lastUsedAt`: ISO timestamp del último request SCIM autenticado correctamente.
- *   Se actualiza con throttle (1 vez por minuto máximo) para no escribir DB
- *   en cada request — fuera de scope del piloto, queda como TODO.
+ *   Lo escribe `ScimAuthGuard.touchLastUsedAt()` con throttle (ver
+ *   `SCIM_LAST_USED_THROTTLE_MS`) para no meter un UPDATE por request.
  */
 export interface ScimApiTokenRecord {
   tokenHash: string;

--- a/apps/api/tests/scim-contract.test.ts
+++ b/apps/api/tests/scim-contract.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ *
+ * Contrato HTTP de /scim/v2 — arranca una app Fastify REAL con la misma
+ * plomería global que `main.ts` (prefijo global con la exclusión de SCIM,
+ * `HttpExceptionNormalizerFilter` + `LicenseExceptionFilter`, y el
+ * `RateLimitInterceptor` como APP_INTERCEPTOR).
+ *
+ * Por qué e2e y no unit:
+ *   Los cuatro defectos que cubre este fichero NO viven en el controller: viven
+ *   en la INTERACCIÓN entre el controller y la infraestructura global (filtros,
+ *   interceptor, pipes). Un test unitario del controller los da todos por
+ *   verdes porque nunca ve el body que sale por el socket.
+ *
+ * Cubre:
+ *   1. El tráfico SCIM autenticado se contabiliza en el bucket del tenant que
+ *      identifica su token, no en el bucket `'anonymous'` compartido.
+ *   2. Todo error de /scim sale en formato RFC 7644 §3.12 puro (sin
+ *      `statusCode` / `message` del normalizador) y con content-type
+ *      `application/scim+json` — incluidos los que genera la infraestructura
+ *      (402 del LicenseGuard, 429 del rate limiter, 400 de validación Zod).
+ *   3. /scim/v2/Groups responde 501 Not Implemented, que es lo que el panel
+ *      promete.
+ */
+
+import { ConflictException, Controller, Get, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR, NestFactory } from '@nestjs/core';
+import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
+import { LicenseExceptionFilter, LicenseService } from '@didacta/license-sdk';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { HttpExceptionNormalizerFilter } from '../src/common/http-exception-normalizer.filter';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { RateLimitInterceptor } from '../src/rate-limit/rate-limit.interceptor';
+import { RateLimitService } from '../src/rate-limit/rate-limit.service';
+import { ScimAuthGuard, hashScimToken } from '../src/scim/scim-auth.guard';
+import { ScimController } from '../src/scim/scim.controller';
+import { ScimService } from '../src/scim/scim.service';
+import { SCIM_CONTENT_TYPE, SCIM_SCHEMAS, makeScimError } from '../src/scim/scim.types';
+
+const TENANT_A = 'tenant-aaaa-1111';
+const TOKEN_A = 'scim_token_de_tenant_a';
+
+// ---------------------------------------------------------------------------
+// Dobles
+// ---------------------------------------------------------------------------
+
+/** Llamadas capturadas al rate limiter: (tenantId, isPublic) por request. */
+const rateLimitCalls: Array<{ tenantId: string | null | undefined; isPublic: boolean }> = [];
+/** Si es false, el limitador rechaza la siguiente request con 429. */
+let rateLimitAllows = true;
+/** Si es false, el LicenseGuard rechaza con CapabilityRequiredError → 402. */
+let scimLicensed = true;
+/** Escrituras de lastUsedAt capturadas (defecto 2 — se verifica en unit). */
+const tenantSettingUpdates: unknown[] = [];
+
+const fakePrisma = {
+  tenantSetting: {
+    findMany: async () => [
+      {
+        tenantId: TENANT_A,
+        valueJson: {
+          tokenHash: hashScimToken(TOKEN_A),
+          prefix: 'scim_xxxxxxxx',
+          createdAt: '2026-04-01T10:00:00.000Z',
+          lastUsedAt: null,
+        },
+      },
+    ],
+    update: async (args: unknown) => {
+      tenantSettingUpdates.push(args);
+      return {};
+    },
+  },
+};
+
+const fakeRateLimit = {
+  async recordRequest(tenantId: string | null | undefined, isPublic: boolean) {
+    rateLimitCalls.push({ tenantId, isPublic });
+    const resetAt = new Date(Date.now() + 30_000);
+    return rateLimitAllows
+      ? {
+          allowed: true,
+          limit: 100,
+          remaining: 99,
+          resetAt,
+          tier: 'community',
+          bucket: 'authenticated',
+        }
+      : {
+          allowed: false,
+          limit: 100,
+          remaining: 0,
+          resetAt,
+          retryAfterSeconds: 30,
+          tier: 'community',
+          bucket: 'authenticated',
+        };
+  },
+};
+
+const fakeLicense = {
+  isCapabilityEnabled: () => scimLicensed,
+};
+
+/** Si está seteado, `createUser` lo lanza en vez de crear. */
+let createUserThrows: unknown = null;
+
+const fakeScim = {
+  async listUsers(_tenantId: string, query: { startIndex: number; count: number }) {
+    return { totalResults: 0, startIndex: query.startIndex, itemsPerPage: 0, resources: [] };
+  },
+  async createUser() {
+    if (createUserThrows) throw createUserThrows;
+    return {};
+  },
+  async deleteUser() {
+    return undefined;
+  },
+};
+
+/**
+ * Ruta de control: un endpoint normal del API, sin guard, para comprobar que el
+ * arreglo del bucket NO cambia el tráfico realmente anónimo.
+ */
+@Controller('sonda')
+class ProbeController {
+  @Get()
+  ping() {
+    return { ok: true };
+  }
+}
+
+@Module({
+  controllers: [ScimController, ProbeController],
+  providers: [
+    ScimAuthGuard,
+    { provide: PrismaService, useValue: fakePrisma },
+    { provide: ScimService, useValue: fakeScim },
+    { provide: LicenseService, useValue: fakeLicense },
+    { provide: RateLimitService, useValue: fakeRateLimit },
+    { provide: APP_INTERCEPTOR, useClass: RateLimitInterceptor },
+  ],
+})
+class ScimTestAppModule {}
+
+// ---------------------------------------------------------------------------
+
+describe('Contrato HTTP de /scim/v2', () => {
+  let app: NestFastifyApplication;
+
+  const authed = { authorization: `Bearer ${TOKEN_A}` };
+
+  beforeAll(async () => {
+    app = await NestFactory.create<NestFastifyApplication>(
+      ScimTestAppModule,
+      new FastifyAdapter(),
+      { logger: false },
+    );
+    // Mismo prefijo y exclusión que main.ts.
+    app.setGlobalPrefix('api/v1', { exclude: ['scim/v2/{*path}'] });
+    // Mismos filtros globales que main.ts, en el mismo orden.
+    app.useGlobalFilters(new HttpExceptionNormalizerFilter(), new LicenseExceptionFilter());
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    rateLimitCalls.length = 0;
+    tenantSettingUpdates.length = 0;
+    rateLimitAllows = true;
+    scimLicensed = true;
+    createUserThrows = null;
+  });
+
+  // -------------------------------------------------------------------------
+  // Defecto 1 — bucket del rate limiter
+  // -------------------------------------------------------------------------
+
+  describe('rate limit', () => {
+    it('el tráfico SCIM autenticado se cuenta contra el tenant de su token, no contra "anonymous"', async () => {
+      const res = await app.inject({ method: 'GET', url: '/scim/v2/Users', headers: authed });
+
+      expect(res.statusCode).toBe(200);
+      expect(rateLimitCalls).toEqual([{ tenantId: TENANT_A, isPublic: false }]);
+    });
+
+    it('el tráfico realmente anónimo sigue cayendo en el bucket público', async () => {
+      // Endpoint normal del API, sin JWT ni Bearer SCIM → no hay identidad.
+      const res = await app.inject({ method: 'GET', url: '/api/v1/sonda' });
+
+      expect(res.statusCode).toBe(200);
+      expect(rateLimitCalls).toEqual([{ tenantId: 'anonymous', isPublic: true }]);
+    });
+
+    it('el bucket del IdP es el del tenant que emitió su token, no uno compartido', async () => {
+      // Dos requests del mismo IdP + una anónima: las del IdP van al mismo
+      // bucket entre ellas y a uno distinto del anónimo.
+      await app.inject({ method: 'GET', url: '/scim/v2/Users', headers: authed });
+      await app.inject({ method: 'GET', url: '/scim/v2/ServiceProviderConfig', headers: authed });
+      await app.inject({ method: 'GET', url: '/api/v1/sonda' });
+
+      expect(rateLimitCalls.map((c) => c.tenantId)).toEqual([TENANT_A, TENANT_A, 'anonymous']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Defectos 3 y 5 — formato de error
+  // -------------------------------------------------------------------------
+
+  describe('formato de error RFC 7644 §3.12', () => {
+    /** Un error SCIM puro tiene EXACTAMENTE estas claves (scimType opcional). */
+    function expectPureScimError(
+      res: { statusCode: number; headers: Record<string, unknown>; body: string },
+      status: number,
+    ) {
+      expect(res.statusCode).toBe(status);
+      expect(String(res.headers['content-type'])).toContain(SCIM_CONTENT_TYPE);
+      const body = JSON.parse(res.body) as Record<string, unknown>;
+      expect(body['schemas']).toEqual([SCIM_SCHEMAS.ERROR]);
+      expect(body['status']).toBe(String(status));
+      expect(typeof body['detail']).toBe('string');
+      // Lo que NO puede llevar: los campos que mete el normalizador global y
+      // los del filtro de licencia / del rate limiter.
+      expect(Object.keys(body).sort()).toEqual(
+        ['schemas', 'status', 'detail', ...(body['scimType'] ? ['scimType'] : [])].sort(),
+      );
+      return body;
+    }
+
+    it('401 del guard sale como error SCIM puro', async () => {
+      const res = await app.inject({ method: 'GET', url: '/scim/v2/Users' });
+      expectPureScimError(res, 401);
+    });
+
+    it('401 con Bearer no reconocido sale como error SCIM puro', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/scim/v2/Users',
+        headers: { authorization: 'Bearer no-existe' },
+      });
+      expectPureScimError(res, 401);
+    });
+
+    it('402 del LicenseGuard (capability feat:scim) sale como error SCIM', async () => {
+      scimLicensed = false;
+      const res = await app.inject({ method: 'GET', url: '/scim/v2/Users', headers: authed });
+      const body = expectPureScimError(res, 402);
+      // El detail tiene que nombrar la capability para que el admin sepa qué comprar.
+      expect(String(body['detail'])).toContain('feat:scim');
+    });
+
+    it('429 del rate limiter sale como error SCIM y conserva Retry-After', async () => {
+      rateLimitAllows = false;
+      const res = await app.inject({ method: 'GET', url: '/scim/v2/Users', headers: authed });
+      expectPureScimError(res, 429);
+      expect(res.headers['retry-after']).toBe('30');
+    });
+
+    it('400 de validación Zod sale como error SCIM con scimType', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/scim/v2/Users?count=999',
+        headers: authed,
+      });
+      const body = expectPureScimError(res, 400);
+      expect(body['scimType']).toBe('invalidSyntax');
+    });
+
+    it('el scimType que calcula el dominio sobrevive al filtro (409 uniqueness)', async () => {
+      // El service lanza su propio error SCIM con `scimType`. El filtro NO
+      // puede aplanarlo: `uniqueness` es lo que le dice al IdP "ese usuario ya
+      // existe, deja de reintentar el POST".
+      createUserThrows = new ConflictException(
+        makeScimError(409, 'User with userName "ana@x.com" already exists.', 'uniqueness'),
+      );
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/scim/v2/Users',
+        headers: authed,
+        payload: { userName: 'ana@x.com' },
+      });
+
+      const body = expectPureScimError(res, 409);
+      expect(body['scimType']).toBe('uniqueness');
+      expect(body['detail']).toContain('already exists');
+    });
+
+    it('404 de ruta desconocida bajo /scim también sale como error SCIM', async () => {
+      const res = await app.inject({ method: 'GET', url: '/scim/v2/Users/x/y/z', headers: authed });
+      expect(res.statusCode).toBe(404);
+      expect(String(res.headers['content-type'])).toContain(SCIM_CONTENT_TYPE);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Defecto 4 — Groups
+  // -------------------------------------------------------------------------
+
+  describe('/scim/v2/Groups', () => {
+    it('GET responde 501 Not Implemented con error SCIM', async () => {
+      const res = await app.inject({ method: 'GET', url: '/scim/v2/Groups', headers: authed });
+      expect(res.statusCode).toBe(501);
+      expect(String(res.headers['content-type'])).toContain(SCIM_CONTENT_TYPE);
+      const body = JSON.parse(res.body) as Record<string, unknown>;
+      expect(body['schemas']).toEqual([SCIM_SCHEMAS.ERROR]);
+      expect(body['status']).toBe('501');
+    });
+
+    it('POST y las subrutas también responden 501', async () => {
+      const post = await app.inject({
+        method: 'POST',
+        url: '/scim/v2/Groups',
+        headers: authed,
+        payload: { displayName: 'Ventas' },
+      });
+      expect(post.statusCode).toBe(501);
+
+      const sub = await app.inject({
+        method: 'PATCH',
+        url: '/scim/v2/Groups/abc-123',
+        headers: authed,
+        payload: {},
+      });
+      expect(sub.statusCode).toBe(501);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Content-type de las respuestas correctas
+  // -------------------------------------------------------------------------
+
+  it('las respuestas 200 de /scim también van como application/scim+json', async () => {
+    const res = await app.inject({ method: 'GET', url: '/scim/v2/Users', headers: authed });
+    expect(res.statusCode).toBe(200);
+    expect(String(res.headers['content-type'])).toContain(SCIM_CONTENT_TYPE);
+  });
+
+  it('el 204 del DELETE sigue sin cuerpo ni content-type', async () => {
+    // Anunciar un tipo de medio para un cuerpo vacío rompe a los clientes que
+    // intentan parsearlo.
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/scim/v2/Users/abc-123',
+      headers: authed,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
+    expect(res.headers['content-type']).toBeUndefined();
+  });
+
+  it('el ServiceProviderConfig apunta a la página de documentación que existe', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/scim/v2/ServiceProviderConfig',
+      headers: authed,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().documentationUri).toBe('https://docs.didacta.io/enterprise/scim/');
+  });
+});

--- a/apps/api/tests/scim.controller.test.ts
+++ b/apps/api/tests/scim.controller.test.ts
@@ -24,18 +24,36 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { UnauthorizedException } from '@nestjs/common';
-import { hashScimToken, ScimAuthGuard } from '../src/scim/scim-auth.guard';
+import {
+  hashScimToken,
+  ScimAuthGuard,
+  SCIM_LAST_USED_THROTTLE_MS,
+} from '../src/scim/scim-auth.guard';
 import { ScimController } from '../src/scim/scim.controller';
 import { ScimService } from '../src/scim/scim.service';
-import { SCIM_SCHEMAS, SCIM_TOKEN_KEY, SCIM_TOKEN_MODULE_NAME } from '../src/scim/scim.types';
+import {
+  SCIM_SCHEMAS,
+  SCIM_TOKEN_KEY,
+  SCIM_TOKEN_MODULE_NAME,
+  type ScimApiTokenRecord,
+} from '../src/scim/scim.types';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Shape del `prisma.tenantSetting.update` que hace el guard al sellar lastUsedAt. */
+interface ScimSettingUpdateArgs {
+  where: { tenantId_moduleName_key: { tenantId: string; moduleName: string; key: string } };
+  data: { valueJson: ScimApiTokenRecord };
+}
+
 function makePrismaWithTokens(tokens: Array<{ tenantId: string; tokenHash: string }>) {
   return {
     tenantSetting: {
+      // El guard sella `lastUsedAt` con un update tras autenticar. Lo
+      // registramos aquí para poder afirmar sobre él.
+      update: vi.fn(async (_args: ScimSettingUpdateArgs) => ({})),
       findMany: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
         // Devuelve filas con shape { tenantId, valueJson } como espera el guard.
         // Filtramos por module/key si los pasa.
@@ -154,6 +172,123 @@ describe('ScimAuthGuard', () => {
     };
     await guard.canActivate(makeExecutionContext(reqB));
     expect(reqB['scimTenantId']).toBe('tenant-B');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScimAuthGuard · lastUsedAt
+//
+// El panel /admin/scim muestra este campo para responder «¿está sincronizando
+// mi IdP?». Si nadie lo escribe, el panel miente para siempre.
+// ---------------------------------------------------------------------------
+
+describe('ScimAuthGuard · lastUsedAt', () => {
+  const token = 'scim_token_para_last_used';
+
+  function makeGuard(tenantId = 'tenant-1') {
+    const prisma = makePrismaWithTokens([{ tenantId, tokenHash: hashScimToken(token) }]);
+    const guard = new ScimAuthGuard(
+      prisma as unknown as ConstructorParameters<typeof ScimAuthGuard>[0],
+    );
+    return { prisma, guard };
+  }
+
+  function authedCtx() {
+    return makeExecutionContext({ headers: { authorization: `Bearer ${token}` } });
+  }
+
+  it('sella lastUsedAt del token del tenant tras autenticar', async () => {
+    const { prisma, guard } = makeGuard();
+    const before = Date.now();
+
+    await guard.canActivate(authedCtx());
+
+    expect(prisma.tenantSetting.update).toHaveBeenCalledTimes(1);
+    const args = prisma.tenantSetting.update.mock.calls[0]![0];
+    expect(args.where.tenantId_moduleName_key).toEqual({
+      tenantId: 'tenant-1',
+      moduleName: SCIM_TOKEN_MODULE_NAME,
+      key: SCIM_TOKEN_KEY,
+    });
+    // Se sella lastUsedAt SIN perder el resto del registro (si perdiéramos el
+    // tokenHash, el siguiente request del IdP sería un 401).
+    expect(args.data.valueJson.tokenHash).toBe(hashScimToken(token));
+    expect(args.data.valueJson.prefix).toBe('scim_xxxxxxxx');
+    expect(args.data.valueJson.createdAt).toBe('2026-04-01T10:00:00Z');
+    expect(new Date(args.data.valueJson.lastUsedAt ?? '').getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('amortigua: una ráfaga de requests del IdP escribe una sola vez', async () => {
+    const { prisma, guard } = makeGuard();
+
+    for (let i = 0; i < 50; i++) {
+      await guard.canActivate(authedCtx());
+    }
+
+    expect(prisma.tenantSetting.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('vuelve a escribir cuando pasa la ventana de amortiguación', async () => {
+    const { prisma, guard } = makeGuard();
+    await guard.canActivate(authedCtx());
+    expect(prisma.tenantSetting.update).toHaveBeenCalledTimes(1);
+
+    // Avanzamos el reloj más allá de la ventana.
+    const realNow = Date.now;
+    Date.now = () => realNow() + SCIM_LAST_USED_THROTTLE_MS + 1;
+    try {
+      await guard.canActivate(authedCtx());
+    } finally {
+      Date.now = realNow;
+    }
+
+    expect(prisma.tenantSetting.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('la amortiguación es por tenant: dos IdPs distintos escriben cada uno', async () => {
+    const tokenA = 'scim_token_A';
+    const tokenB = 'scim_token_B';
+    const prisma = makePrismaWithTokens([
+      { tenantId: 'tenant-A', tokenHash: hashScimToken(tokenA) },
+      { tenantId: 'tenant-B', tokenHash: hashScimToken(tokenB) },
+    ]);
+    const guard = new ScimAuthGuard(
+      prisma as unknown as ConstructorParameters<typeof ScimAuthGuard>[0],
+    );
+
+    await guard.canActivate(
+      makeExecutionContext({ headers: { authorization: `Bearer ${tokenA}` } }),
+    );
+    await guard.canActivate(
+      makeExecutionContext({ headers: { authorization: `Bearer ${tokenB}` } }),
+    );
+
+    expect(prisma.tenantSetting.update).toHaveBeenCalledTimes(2);
+    const tenants = prisma.tenantSetting.update.mock.calls.map(
+      (c) => c[0].where.tenantId_moduleName_key.tenantId,
+    );
+    expect(tenants).toEqual(['tenant-A', 'tenant-B']);
+  });
+
+  it('un token NO reconocido no escribe nada', async () => {
+    const { prisma, guard } = makeGuard();
+
+    await expect(
+      guard.canActivate(makeExecutionContext({ headers: { authorization: 'Bearer scim_falso' } })),
+    ).rejects.toThrow(UnauthorizedException);
+
+    expect(prisma.tenantSetting.update).not.toHaveBeenCalled();
+  });
+
+  it('si el UPDATE falla, la request del IdP sigue autenticada', async () => {
+    const { prisma, guard } = makeGuard();
+    prisma.tenantSetting.update.mockRejectedValueOnce(new Error('deadlock detected'));
+
+    const req: Record<string, unknown> = {
+      headers: { authorization: `Bearer ${token}` },
+    };
+    await expect(guard.canActivate(makeExecutionContext(req))).resolves.toBe(true);
+    expect(req['scimTenantId']).toBe('tenant-1');
   });
 });
 

--- a/apps/web/src/i18n/messages/en/adminApi.json
+++ b/apps/web/src/i18n/messages/en/adminApi.json
@@ -154,7 +154,7 @@
     "step5Title": "5. Test the connection",
     "step5Description": "The IdP usually has a “Test Connection” button — pressing it makes a <code>GET /scim/v2/ServiceProviderConfig</code>. If it responds 200, you are done.",
     "usersOnlyTitle": "Note: Users only in this pilot",
-    "usersOnlyDescription": "Groups (group sync) is NOT supported yet — IdPs will try it and receive <code>501 Not Implemented</code> or <code>404</code>. Role assignments are still managed from <usersLink>Users</usersLink>.",
+    "usersOnlyDescription": "Groups (group sync) is NOT supported yet — IdPs will try it and receive <code>501 Not Implemented</code>. Role assignments are still managed from <usersLink>Users</usersLink>.",
     "revealedAria": "Newly generated SCIM token",
     "revealedTitle": "Token generated — copy it NOW",
     "copied": "Copied!",

--- a/apps/web/src/i18n/messages/es/adminApi.json
+++ b/apps/web/src/i18n/messages/es/adminApi.json
@@ -154,7 +154,7 @@
     "step5Title": "5. Probar conexión",
     "step5Description": "El IdP suele tener un botón “Test Connection” — al pulsarlo hace un <code>GET /scim/v2/ServiceProviderConfig</code>. Si responde 200, listo.",
     "usersOnlyTitle": "Nota: solo Users en este piloto",
-    "usersOnlyDescription": "Groups (sincronización de grupos) NO está soportado todavía — los IdPs lo intentarán y recibirán <code>501 Not Implemented</code> o <code>404</code>. Las asignaciones de roles las sigues haciendo desde <usersLink>Usuarios</usersLink>.",
+    "usersOnlyDescription": "Groups (sincronización de grupos) NO está soportado todavía — los IdPs lo intentarán y recibirán <code>501 Not Implemented</code>. Las asignaciones de roles las sigues haciendo desde <usersLink>Usuarios</usersLink>.",
     "revealedAria": "Token SCIM recién generado",
     "revealedTitle": "Token generado — cópialo AHORA",
     "copied": "¡Copiado!",


### PR DESCRIPTION
Cierra los 5 defectos reportados en la sección «Discrepancias» de [didacta-docs#2](https://github.com/va360labs/didacta-docs/pull/2). Los cinco son de **plomería**: el `ScimController` ya construía errores SCIM correctos y el guard ya resolvía el tenant, pero entre ellos y el IdP hay tres piezas globales que no saben nada del estándar.

**Verifiqué cada uno antes de tocar nada.** Los cinco eran reales; los detalles y las correcciones al diagnóstico van marcados abajo.

---

## 1 · El tráfico SCIM caía en el bucket `'anonymous'`

**Confirmado.** `ScimAuthGuard` puebla `req.scimTenantId` (`apps/api/src/scim/scim-auth.guard.ts:131`), no `req.user`, y `RateLimitInterceptor` solo miraba `request.user` (`apps/api/src/rate-limit/rate-limit.interceptor.ts:80` antes del cambio) → toda petición del IdP salía como `{ tenantId: 'anonymous', isPublic: true }`.

Medido con la app real arrancada en test (`apps/api/tests/scim-contract.test.ts`), antes del arreglo:

```
GET /scim/v2/Users con Bearer válido
  → llamadas al limitador: [{ tenantId: 'anonymous', isPublic: true }]
```

Lo grave no es el número, es **con quién se comparte**: la clave de Redis es `ratelimit:anonymous:public:<minuto>`, la misma para todos los IdPs de la instancia **y** para todo el tráfico sin autenticar de internet. Un sync inicial se comía 429 por culpa de visitantes que no tienen nada que ver con el tenant.

**Arreglo:** `req.scimTenantId` pasa a ser una identidad de primera para el limitador — bucket del tenant, bucket `authenticated`. `feat:api.rate_limit.elevated` no se toca (es, en efecto, una capability distinta de `feat:scim`; sigue siendo la que decide el tier).

```ts
const identifiedTenantId = user?.tenantId ?? request.scimTenantId;
const isPublic = identifiedTenantId === undefined;
```

**No he tocado ningún valor de cupo**, como pedías. La propuesta razonada, para que decidas:

- **Ahora mismo (lo que hace este PR):** el IdP comparte el bucket `authenticated` del tenant — 100 req/min en Community, 1000 con `feat:api.rate_limit.elevated`. Un sync inicial de 500 usuarios son ~1000 peticiones (1 GET de filtro + 1 POST por usuario): **~10 minutos** a 100/min. Okta y Azure AD respetan `Retry-After` en el 429 y reintentan, así que el sync se vuelve *más lento*, no *roto* — que era el fallo real del bucket anónimo.
- **Si quieres desacoplarlo:** un bucket propio `scim` con `RATE_LIMIT_SCIM_PER_MIN` por defecto **600** (10 req/s). Razonamiento: cubre un alta inicial de 5.000 usuarios (~10.000 peticiones) en **~17 min**, y 10 req/s de `SELECT`/`INSERT` sobre `app_user` es un orden de magnitud menos de lo que aguanta un Postgres sin despeinarse. El coste es un valor de configuración más, y a cambio el sync deja de competir con el tráfico de los usuarios del tenant. **No lo he hecho**: es tu decisión, y meterlo aquí habría sido inventarme el número.

### Hallazgo adyacente que NO he arreglado

Un Bearer SCIM **inválido** no pasa por el limitador en absoluto. Medido:

```
GET /scim/v2/Users con Bearer no reconocido
  → status 401, llamadas al limitador: []
```

Los guards corren **antes** que los interceptores en Nest, así que cuando `ScimAuthGuard` lanza el 401, `RateLimitInterceptor` no llega a ejecutarse. Esto **no es específico de SCIM**: le pasa igual a todo endpoint detrás de `JwtAuthGuard` con un JWT malo. Es una propiedad global del orden guard→interceptor, no un defecto de SCIM, y arreglarla toca el limitador para toda la API. Lo dejo reportado.

## 2 · `lastUsedAt` no se escribía nunca

**Confirmado.** Nadie escribía el campo; `apps/api/src/scim/scim.types.ts:55` lo dejaba explícitamente como TODO.

**Arreglo:** lo sella `ScimAuthGuard.touchLastUsedAt()` tras autenticar, **amortiguado** con constante nombrada:

```ts
export const SCIM_LAST_USED_THROTTLE_MS = 60_000;
```

Un minuto de resolución responde igual de bien a la única pregunta que el panel hace («¿está sincronizando mi IdP?») y acota el coste a **1 UPDATE por tenant y minuto** en vez de uno por request. El contador vive en memoria del proceso: con N réplicas el peor caso son N escrituras por minuto, que sigue siendo despreciable.

Dos decisiones que conviene ver al revisar:

- Se escribe con **Prisma directo**, no vía `PrismaTenantConfigService.set()`. Ese service registra una entrada de auditoría por escritura, y esto no es un cambio de configuración hecho por nadie: es contabilidad de uso. Auditar cada minuto que el IdP sigue vivo llenaría el log que el admin usa para investigar cambios reales.
- Un fallo escribiendo **no tumba la request** (se loguea `warn`). El IdP no puede quedarse sin provisionar porque hayamos fallado al actualizar un campo informativo. Hay test.

## 3 y 5 · El cuerpo de error salía contaminado, y los 402/429/400 ni eran SCIM

**Confirmados los dos, y son el mismo problema.** Medido antes del arreglo — los cinco caminos de error de `/scim` salían con `content-type: application/json; charset=utf-8`:

| origen | fichero:línea | qué salía |
|---|---|---|
| 401 del guard | `apps/api/src/scim/scim-auth.guard.ts:100,107,136` | error SCIM + `statusCode` + `message` del normalizador |
| 402 del LicenseGuard | `packages/license-sdk/src/nest.ts:122` | `{statusCode, error, code, capability, path, timestamp}` |
| 429 del limitador | `apps/api/src/rate-limit/rate-limit.interceptor.ts:101` | `{statusCode, error, code, message, capability, tier, limit, retryAfterSeconds}` |
| 400 de Zod | `apps/api/src/auth/zod-validation.pipe.ts:25` | `{statusCode, message, issues}` |
| 404 de ruta desconocida | router | JSON genérico del API |

**Arreglo:** un `ScimExceptionFilter` (`apps/api/src/scim/scim-exception.filter.ts`) montado con `@UseFilters` **a nivel de controller**. Nest ordena `[globales…, clase…, método…]` y luego invierte, así que un filtro de clase gana a los globales — y `@Catch()` sin argumentos captura todo lo que pase por estas rutas: guards, interceptores globales y pipes incluidos. Fuera de `/scim` no cambia absolutamente nada.

El filtro **respeta el `scimType` que calcula el dominio** (`uniqueness`, `invalidFilter`, `invalidPath`…) cuando la excepción ya trae un error SCIM; solo construye uno nuevo cuando no lo hay. Para los 400 sin `scimType` propio pone `invalidSyntax`, que es lo que significa un fallo de schema. Hay test del 409 `uniqueness` para que nadie aplane eso sin darse cuenta.

**Extensión deliberada del criterio 3:** las respuestas **200 también** salen como `application/scim+json` (`ScimContentTypeInterceptor`). Si el argumento es «un IdP estricto parsea por contrato», servir el estándar en los errores y `application/json` en los 200 es un contrato incoherente; RFC 7644 §3.1 fija el media type para el protocolo, no solo para los errores. El 204 del `DELETE` se queda **sin** content-type a propósito (no lleva cuerpo). Si prefieres no tocar el camino feliz, se revierte quitando el `@UseInterceptors` del controller.

## 4 · Groups: 404 en vez del 501 que promete el panel

**Confirmado** (medido: `GET /scim/v2/Groups` → 404).

**He elegido arreglar el producto, no el texto.** Razón: `/Groups` existe en RFC 7643 §4.2. Un 404 le dice al IdP «esa URL no existe», que es mentira y le hace dudar de si la URL base está mal configurada; 501 Not Implemented dice exactamente lo que pasa. `ResourceTypes` ya declara que el único recurso es `User` — esto es la misma verdad dicha desde la otra punta.

Va **sin gatear** con `feat:scim`: que Groups no esté implementado es una propiedad de este servidor, no de la licencia, igual que los endpoints de discovery.

El texto del panel también se corrige, porque ofrecía dos respuestas posibles y ahora solo hay una: `apps/web/src/i18n/messages/es/adminApi.json` y `apps/web/src/i18n/messages/en/adminApi.json` → `scim.usersOnlyDescription`, «`501 Not Implemented` o `404`» → «`501 Not Implemented`».

De paso, y por el mismo motivo, cualquier ruta desconocida bajo `/scim/v2` responde ahora un **404 en formato SCIM** en vez del JSON genérico del API.

## De paso

`apps/api/src/scim/scim.controller.ts` → `documentationUri` del `ServiceProviderConfig` pasa de `https://docs.didacta.io/enterprise/` a `https://docs.didacta.io/enterprise/scim/`, que es el cambio que pedías en didacta-docs#2. Hay test.

---

## Verificación

**21 tests nuevos, todos comprobados por mutación** — no por «pasan».

`apps/api/tests/scim-contract.test.ts` (nuevo, 15 tests) arranca una app Fastify **real** con la misma plomería global que `main.ts`: el prefijo con la exclusión de `/scim`, `HttpExceptionNormalizerFilter` + `LicenseExceptionFilter` en el mismo orden, y `RateLimitInterceptor` como `APP_INTERCEPTOR`. Los cuatro defectos de plomería no viven en el controller: viven en la interacción, y un test unitario los da todos por verdes porque nunca ve el body que sale por el socket.

| mutación | resultado |
|---|---|
| estado original (antes de tocar nada) | **12 de 12 rojos** en el contrato HTTP |
| quitar `touchLastUsedAt()` del guard | **4 rojos** (los 2 negativos siguen verdes, como deben) |
| quitar la comprobación de `SCIM_LAST_USED_THROTTLE_MS` | **1 rojo** (el de la ráfaga) |
| revertir `?? request.scimTenantId` en el limitador | **2 rojos**, y el control de tráfico anónimo **sigue verde** |

Suites completas:

- `apps/api`: **2344/2344** (baseline 2323 + 21 nuevos)
- `apps/web`: **378/378**
- `bash scripts/dev-check.sh --quick`: **33/33**
- `pnpm tsx scripts/ee-fence.ts`: **0 violaciones** (1412 ficheros)
- E2E: SKIP

> Nota de entorno para quien lo reproduzca: el worktree venía sin `node_modules` ni `dist/`. Además de `pnpm install` + `prisma generate` (el schema vive en `packages/database`, no en `apps/api`), `modules/community` traía un `tsconfig.tsbuildinfo` rancio que emitía `listSpaces(): Promise<any>` y producía 5 errores TS7006 fantasma en `apps/api`. Se arregla borrando el `.tsbuildinfo` y reconstruyendo; nada que ver con este cambio.

---

## Cambios que la documentación tiene que recoger

**No he tocado `didacta-docs`.** Estas son las frases a corregir, con fichero:

**`docs/enterprise/scim.md` y `docs/enterprise/scim.en.md`**

1. **`lastUsedAt`** — la página avisa de que «ese campo no sirve para diagnosticar y remite al log de auditoría». Ya no es cierto: `lastUsedAt` se actualiza con hasta 1 minuto de retraso y **sí** sirve para saber si el IdP está sincronizando. Hay que quitar el aviso y, si se quiere ser preciso, decir que la resolución es de un minuto.

2. **Formato de error** — la página dice que el cuerpo lleva `statusCode` y `message` de más y que se sirve como `application/json`. Ahora el cuerpo es **RFC 7644 §3.12 puro** (`schemas`, `status`, `detail`, `scimType` opcional) y el content-type es **`application/scim+json`**, tanto en errores como en respuestas correctas (el 204 del DELETE no lleva ninguno).

3. **402 / 429 / 400** — la página los documenta como «texto crudo» que el admin puede ver en su IdP. Ya no: los tres salen en formato SCIM. Ese aviso sobra entero.

4. **Groups** — la página documenta el comportamiento real de entonces (404). Ahora es **`501 Not Implemented`** con cuerpo de error SCIM, y también para `/Groups/{id}`. Además, cualquier ruta desconocida bajo `/scim/v2` responde 404 **en formato SCIM**.

5. **Rate limit** — la página avisa de que el tráfico SCIM cae en el cupo público de 30 req/min. Ahora se contabiliza **por tenant en el bucket autenticado**: 100 req/min en Community, 1000 con `feat:api.rate_limit.elevated`. Ya no se comparte cupo con el tráfico anónimo de la instancia. Vale la pena mantener una nota de que un sync grande puede recibir 429 y que los IdPs respetan `Retry-After`.

6. **`documentationUri`** — ya apunta a `https://docs.didacta.io/enterprise/scim/`; la nota de didacta-docs#2 sobre esto queda cerrada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
