### PR TITLE
feat(shell): aviso fijo cuando no hay ninguna salida de correo configurada

### DIFF
--- a/apps/web/src/app/(app)/admin/configuracion/page.tsx
+++ b/apps/web/src/app/(app)/admin/configuracion/page.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useState, type FormEvent } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -119,7 +120,14 @@ export default function ConfiguracionPage() {
     const session = authStorage.getSession();
     return session?.user.roles.includes('super_admin') ?? false;
   })();
-  const [tab, setTab] = useState<TabKey>(isSuperAdmin ? 'general' : 'notifications');
+
+  /// El tab inicial se puede fijar por query (`?tab=notifications`) para que
+  /// se pueda enlazar directamente desde fuera — lo usa el aviso de correo
+  /// sin configurar del shell, que si no dejaba al super_admin en "general"
+  /// justo cuando se le acaba de decir dónde tiene que ir.
+  const searchParams = useSearchParams();
+  const tabPedido = searchParams?.get('tab')?.trim() || null;
+  const [tab, setTab] = useState<TabKey>(tabPedido || (isSuperAdmin ? 'general' : 'notifications'));
 
   // Carga la lista de módulos activos del tenant para filtrar tabs cuyo
   // módulo está desactivado (ej. mod.zoom-live → oculta "Aula virtual").

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -13,6 +13,7 @@ import { CommandPalette } from '@/components/command-palette';
 import { Icon } from '@/components/icon';
 import { LicenseProvider } from '@/components/license-provider';
 import { NotificationsBell } from '@/components/notifications-bell';
+import { NotificationsSetupBanner } from '@/components/notifications-setup-banner';
 import { ReferralsPromoButton } from '@/components/referrals-promo-button';
 import { NotificationsProvider } from '@/components/notifications-provider';
 import { NotificationsToaster } from '@/components/notifications-toaster';
@@ -358,32 +359,43 @@ function Shell({
           />
 
           <div className="flex min-w-0 flex-1 flex-col">
-            <header className="sticky top-0 z-(--z-sticky) flex h-14 items-center gap-2 border-b border-border-soft bg-surface/95 px-4 backdrop-blur lg:px-6">
-              {/* Móvil: hamburguesa + marca. En escritorio el rail ya provee ambos. */}
-              <button
-                type="button"
-                onClick={() => setMobileNavOpen(true)}
-                aria-label={t('openMenu')}
-                aria-expanded={mobileNavOpen}
-                className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:text-text lg:hidden"
-              >
-                <Icon name="menu" size={18} />
-              </button>
-              <span className="min-w-0 flex-1 truncate text-sm font-bold text-text lg:hidden">
-                {tenantName}
-              </span>
+            {/* El pegado al scroll pasa a este envoltorio para que el aviso de
+                correo quede fijo ARRIBA DEL TODO junto con la cabecera. Si
+                fuese la cabecera la pegada, como antes, el aviso se perdería
+                al primer scroll. Sin aviso, el resultado es idéntico al que
+                había: una cabecera pegada arriba. */}
+            <div className="sticky top-0 z-(--z-sticky)">
+              {/* Solo aparece si no hay ninguna salida de correo: sin SMTP el
+                  producto parece ir bien mientras pierde en silencio las altas
+                  y los restablecimientos de contraseña. */}
+              <NotificationsSetupBanner roles={session.user.roles} />
+              <header className="flex h-14 items-center gap-2 border-b border-border-soft bg-surface/95 px-4 backdrop-blur lg:px-6">
+                {/* Móvil: hamburguesa + marca. En escritorio el rail ya provee ambos. */}
+                <button
+                  type="button"
+                  onClick={() => setMobileNavOpen(true)}
+                  aria-label={t('openMenu')}
+                  aria-expanded={mobileNavOpen}
+                  className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:text-text lg:hidden"
+                >
+                  <Icon name="menu" size={18} />
+                </button>
+                <span className="min-w-0 flex-1 truncate text-sm font-bold text-text lg:hidden">
+                  {tenantName}
+                </span>
 
-              {/* Empuja las acciones a la derecha (equivale al justify-end de escritorio). */}
-              <div className="hidden flex-1 lg:block" />
+                {/* Empuja las acciones a la derecha (equivale al justify-end de escritorio). */}
+                <div className="hidden flex-1 lg:block" />
 
-              {/* Promo del programa de referidos — solo si está activo (el % es real). */}
-              <ReferralsPromoButton />
+                {/* Promo del programa de referidos — solo si está activo (el % es real). */}
+                <ReferralsPromoButton />
 
-              {/* El icono de mensajes vivía aquí. Ahora el chat es la píldora
+                {/* El icono de mensajes vivía aquí. Ahora el chat es la píldora
                   flotante de abajo a la derecha: un solo indicador de no-leídos
                   en pantalla (regla #5, PRD chat-flotante UC-CF203). */}
-              <NotificationsBell />
-            </header>
+                <NotificationsBell />
+              </header>
+            </div>
 
             {/* pb-24 en todos los breakpoints (no solo móvil): dejamos hueco bajo
                 el contenido igual de alto que la píldora fija del chat flotante

--- a/apps/web/src/components/notifications-setup-banner.tsx
+++ b/apps/web/src/components/notifications-setup-banner.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+/// Aviso fijo en lo alto de la plataforma cuando NO hay ninguna salida de
+/// correo configurada: ni SMTP propio del tenant ni fallback global del
+/// despliegue. En ese estado el producto parece funcionar pero las altas, los
+/// restablecimientos de contraseña y las notificaciones se pierden en
+/// silencio, que es justo lo que reportan los que instalan la alpha en Docker.
+///
+/// Dos decisiones deliberadas:
+///
+/// - **Solo lo ven quienes pueden arreglarlo** (`super_admin` / `tenant_admin`).
+///   Un alumno no puede configurar un SMTP; enseñárselo solo le diría que la
+///   plataforma está rota. Además el endpoint que consultamos es admin-only,
+///   así que preguntarlo con cualquier otro rol sería un 403 por cada carga
+///   de página.
+///
+/// - **No se puede descartar.** No es una novedad que se anuncia, como el
+///   aviso de versión nueva: es una avería. Desaparece solo en cuanto haya
+///   una salida de correo, y mientras no la haya el aviso sigue siendo cierto.
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { adminSmtpApi, deriveSmtpStatus, shouldShowSmtpBanner } from '@/lib/admin-smtp';
+
+/// Ruta al tab de notificaciones del panel, enlazable desde fuera.
+const RUTA_AJUSTES = '/admin/configuracion?tab=notifications';
+
+export function NotificationsSetupBanner({ roles }: { roles: readonly string[] }) {
+  const t = useTranslations('shell');
+  const [visible, setVisible] = useState(false);
+
+  // Pregunta solo si el rol puede arreglarlo; con cualquier otro, el endpoint
+  // respondería 403 en cada carga de página sin que sirviera de nada.
+  const puedeArreglarlo = roles.some((r) => r === 'super_admin' || r === 'tenant_admin');
+
+  useEffect(() => {
+    if (!puedeArreglarlo) return;
+    let cancelado = false;
+    void adminSmtpApi
+      .get()
+      .then((dto) => {
+        if (!cancelado) setVisible(shouldShowSmtpBanner(roles, deriveSmtpStatus(dto)));
+      })
+      // Si la consulta falla (sesión recién expirada, API caída) no pintamos
+      // nada: un aviso de configuración basado en una respuesta que no hemos
+      // podido leer sería adivinar.
+      .catch(() => undefined);
+    return () => {
+      cancelado = true;
+    };
+    // `roles` es un array nuevo en cada render del layout; la dependencia real
+    // es si el rol puede o no arreglarlo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [puedeArreglarlo]);
+
+  if (!visible) return null;
+
+  return (
+    /* Los tokens `warning` del sistema, no los de la barra lateral: aquí el
+       fondo es claro y el amber-100 del aviso de versión —pensado para el
+       rail oscuro— dejaba el texto prácticamente ilegible. */
+    /* Una sola línea a propósito: esto roba alto en TODAS las pantallas de la
+       plataforma hasta que alguien configure el SMTP. Sin `flex-wrap`, con el
+       texto recortado en puntos suspensivos cuando no quepa —de ahí el
+       `min-w-0`, que es lo que permite encogerse a un hijo flex— y el botón
+       en `shrink-0` para que nunca sea él quien salte de línea. */
+    <div
+      role="status"
+      className="flex items-center justify-center gap-3 border-b border-warning-200 bg-warning-50 px-4 py-1.5 text-[13px] text-warning-800"
+    >
+      <p className="min-w-0 truncate">
+        <strong className="font-semibold">{t('smtpBanner.title')}</strong> {t('smtpBanner.body')}
+      </p>
+      <Link
+        href={RUTA_AJUSTES}
+        className="shrink-0 rounded border border-warning-300 bg-white/70 px-2 py-0.5 font-semibold text-warning-800 underline-offset-2 hover:bg-white hover:underline"
+      >
+        {t('smtpBanner.cta')}
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/i18n/messages/en/shell.json
+++ b/apps/web/src/i18n/messages/en/shell.json
@@ -56,5 +56,10 @@
   "dialog": {
     "close": "Close",
     "fallbackLabel": "Dialog"
+  },
+  "smtpBanner": {
+    "title": "Set up notifications:",
+    "body": "without an SMTP server your users get no email at all.",
+    "cta": "Set up"
   }
 }

--- a/apps/web/src/i18n/messages/es/shell.json
+++ b/apps/web/src/i18n/messages/es/shell.json
@@ -56,5 +56,10 @@
   "dialog": {
     "close": "Cerrar",
     "fallbackLabel": "Dialog"
+  },
+  "smtpBanner": {
+    "title": "Configura las notificaciones:",
+    "body": "sin servidor SMTP tus usuarios no reciben ningún correo.",
+    "cta": "Configurar"
   }
 }

--- a/apps/web/src/lib/admin-smtp.test.ts
+++ b/apps/web/src/lib/admin-smtp.test.ts
@@ -10,7 +10,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiHttpError } from './api-client';
-import { adminSmtpApi, deriveSmtpStatus, type AdminSmtpDto } from './admin-smtp';
+import {
+  adminSmtpApi,
+  deriveSmtpStatus,
+  shouldShowSmtpBanner,
+  type AdminSmtpDto,
+} from './admin-smtp';
 
 const FAKE_TOKEN = 'fake-bearer-token';
 
@@ -233,5 +238,34 @@ describe('deriveSmtpStatus', () => {
     expect(deriveSmtpStatus({ ...base, hasTenantConfig: false, hasGlobalFallback: false })).toBe(
       'none',
     );
+  });
+});
+
+describe('shouldShowSmtpBanner', () => {
+  it('lo ve el tenant_admin cuando no hay ninguna salida de correo', () => {
+    expect(shouldShowSmtpBanner(['tenant_admin'], 'none')).toBe(true);
+  });
+
+  it('lo ve el super_admin', () => {
+    expect(shouldShowSmtpBanner(['super_admin'], 'none')).toBe(true);
+  });
+
+  it('NO lo ve un alumno aunque el correo esté sin configurar: no puede arreglarlo', () => {
+    expect(shouldShowSmtpBanner(['student'], 'none')).toBe(false);
+    expect(shouldShowSmtpBanner([], 'none')).toBe(false);
+  });
+
+  it('NO lo ve un formador, que tampoco tiene acceso al panel', () => {
+    expect(shouldShowSmtpBanner(['teacher'], 'none')).toBe(false);
+  });
+
+  it('desaparece en cuanto hay salida, sea del tenant o del despliegue', () => {
+    expect(shouldShowSmtpBanner(['tenant_admin'], 'fallback')).toBe(false);
+    expect(shouldShowSmtpBanner(['tenant_admin'], 'configured-unverified')).toBe(false);
+    expect(shouldShowSmtpBanner(['tenant_admin'], 'verified')).toBe(false);
+  });
+
+  it('un admin con varios roles lo sigue viendo', () => {
+    expect(shouldShowSmtpBanner(['student', 'tenant_admin'], 'none')).toBe(true);
   });
 });

--- a/apps/web/src/lib/admin-smtp.ts
+++ b/apps/web/src/lib/admin-smtp.ts
@@ -155,3 +155,22 @@ export function deriveSmtpStatus(dto: AdminSmtpDto): AdminSmtpStatus {
   if (dto.hasGlobalFallback) return 'fallback';
   return 'none';
 }
+
+/**
+ * ¿Hay que enseñar el aviso de "no hay salida de correo" en el shell?
+ *
+ * Vive aquí y no dentro del componente para poder fijarlo con tests: la regla
+ * que más fácil se rompe al retocar el banner es la de a quién se le enseña.
+ *
+ *  - Solo a quien puede arreglarlo (`super_admin` / `tenant_admin`). Un alumno
+ *    no configura un SMTP; enseñárselo solo le diría que la plataforma está
+ *    rota. Y el endpoint que alimenta esto es admin-only, así que consultarlo
+ *    con otro rol sería un 403 por cada carga de página.
+ *  - Solo en el estado `none`. Con `fallback` el correo sale por las env
+ *    globales del despliegue, y con el tenant configurado —aunque no se haya
+ *    verificado aún— hay una salida: avisar ahí sería mentir.
+ */
+export function shouldShowSmtpBanner(roles: readonly string[], status: AdminSmtpStatus): boolean {
+  const puedeArreglarlo = roles.some((r) => r === 'super_admin' || r === 'tenant_admin');
+  return puedeArreglarlo && status === 'none';
+}


### PR DESCRIPTION
## Por qué

Quien instala la alpha en Docker no configura SMTP, y el producto no se lo dice: las altas, los restablecimientos de contraseña y las notificaciones se pierden en silencio mientras todo aparenta funcionar. De ahí los «no llegan los emails» que reportan.

## Qué hace

Un aviso pegado arriba del todo, junto a la cabecera, apoyado en lo que ya existía: `deriveSmtpStatus` distingue cuatro estados y solo `none` —ni config del tenant ni fallback global del despliegue— significa que el correo no tiene salida.

Dos decisiones que se apartan de «un banner para toda la plataforma»:

- **Solo lo ven `super_admin` y `tenant_admin`.** Un alumno no puede configurar un SMTP; enseñárselo solo le diría que la plataforma está rota. Además el endpoint que lo alimenta es admin-only: preguntarlo con cualquier otro rol sería un 403 por cada carga de página, así que el rol se comprueba **antes** de llamar.
- **No se puede descartar.** No es una novedad que se anuncia, como el aviso de versión nueva: es una avería, y desaparece sola en cuanto haya salida.

La regla de a quién se le enseña vive en `shouldShowSmtpBanner` (`lib/admin-smtp.ts`) con tests, porque es justo lo que se rompe al retocar el banner más adelante.

## Verificado ejecutando el producto

| Comprobación | Resultado |
|---|---|
| Admin con SMTP sin configurar | aviso visible |
| Fijo al hacer scroll | `y=0` antes y después de 1500 px |
| Botón «Configurar» | aterriza en `/admin/configuracion?tab=notifications` |
| Rol `student` | no lo ve, y **0 peticiones** al endpoint admin |
| Español e inglés | ambos, con la app entera en cada idioma |
| Alto | **43 px**, una línea, tanto a 1280 como a 390 px |

Typecheck, lint y 385 tests en verde.

## Detalles del camino

- El pegado al scroll pasa del `<header>` a un envoltorio que abraza aviso + cabecera; si no, el aviso se perdía al primer scroll.
- `/admin/configuracion` acepta `?tab=` para que el enlace no deje al `super_admin` en la pestaña «general».
- Ocupa una línea a propósito: esto roba alto en todas las pantallas hasta que alguien configure el SMTP. El texto se recorta con puntos suspensivos cuando no cabe — en móvil se pierde la explicación, nunca la instrucción ni el botón.

## Nota para revisión

El aviso avisa pero no diagnostica: si alguien configura un SMTP con credenciales malas, el estado pasa a `configured-unverified` y el aviso desaparece aunque los correos sigan sin llegar. El panel ya tiene el botón de prueba que marca `verifiedAt`; se podría avisar también en ese estado con otro texto. Fuera del alcance de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
