### PR TITLE
fix(licencias): el emisor firmaba el mensaje equivocado

### DIFF
--- a/scripts/dev-issue-license.ts
+++ b/scripts/dev-issue-license.ts
@@ -81,7 +81,12 @@ function base64UrlEncode(input: string | Buffer): string {
 
 function awsKmsSign(message: Buffer, region: string, keyAlias: string): Buffer {
   // Llama a AWS KMS Sign. Devuelve la firma en formato DER.
-  const messageB64 = message.toString('base64');
+  //
+  // El mensaje se escribe en BYTES CRUDOS a propósito. `fileb://` lee el
+  // fichero como binario, así que escribir ahí el base64 del mensaje hacía que
+  // KMS firmase el TEXTO "eyJhbGci…" en vez de los bytes de `header.payload`:
+  // la firma salía válida sobre el mensaje equivocado y el verificador del SDK
+  // la rechazaba. Ninguna licencia emitida así llegó a servir nunca.
   const cmd = [
     'aws',
     'kms',
@@ -91,7 +96,7 @@ function awsKmsSign(message: Buffer, region: string, keyAlias: string): Buffer {
     '--key-id',
     keyAlias,
     '--message',
-    `fileb://${writeTempFile(messageB64, '.b64')}`,
+    `fileb://${writeTempFile(message, '.bin')}`,
     '--message-type',
     'RAW',
     '--signing-algorithm',
@@ -128,9 +133,11 @@ function detectAwsExe(): string {
   throw new Error('AWS CLI not found. Install AWS CLI v2 first.');
 }
 
-function writeTempFile(content: string, ext: string): string {
+function writeTempFile(content: Buffer | string, ext: string): string {
   const path = join(tmpdir(), `.kms-sign-input-${Date.now()}${ext}`);
-  writeFileSync(path, content, 'utf8');
+  // Sin encoding: un Buffer se escribe tal cual. Forzar 'utf8' aquí volvería a
+  // meter una conversión de texto entre el mensaje y lo que firma KMS.
+  writeFileSync(path, content);
   return path;
 }
 


### PR DESCRIPTION
## Qué pasaba

`scripts/dev-issue-license.ts` escribía el **base64** del signing input en un fichero y se lo pasaba a la CLI de AWS como `fileb://`, que lo lee como binario crudo. KMS acababa firmando el texto `eyJhbGci…` en vez de los bytes de `header.payload`.

La firma era válida — sobre el mensaje equivocado. El script imprimía «License issued» y el verificador del SDK la rechazaba con `DIDACTA_LICENSE_SIGNATURE`.

## Por qué no se había visto

**Ninguna licencia emitida con este script ha servido nunca.** Emitir y verificar son dos pasos que nadie había encadenado: el script imprime el JWT y ahí se acababa la comprobación.

## El arreglo

Se escriben los bytes tal cual y `writeTempFile` deja de forzar `'utf8'` — esa conversión a texto era la que se colaba entre el mensaje y lo que firmaba KMS.

## Verificación

Licencia real emitida contra `alias/didacta-issuer-2026` y validada con `verifyLicense()` del propio SDK: pasa. Antes del cambio, esa misma licencia fallaba. La clave pública de KMS coincide byte a byte con la que lleva incrustada el producto en `packages/license-sdk/*/public-keys`.

Esta es la licencia que hoy corre en `pool.didacta.io` (`plan=enterprise-standard`, `capabilities=2`).