### PR TITLE
fix(tenancy): el Host real no llegaba a la API y todo resolvía al primer tenant

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -25,6 +25,7 @@ import {
 import { PasswordResetService } from './password-reset.service';
 import { SigninContextService } from './signin-context.service';
 import { ZodValidationPipe } from './zod-validation.pipe';
+import { resolvePublicHost } from '../common/resolve-public-host';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -55,8 +56,7 @@ export class AuthController {
       'Resuelve el tenant del request por Host header. Devuelve { tenant: { id, slug, name, logoUrl, headline, subheadline, stats } } o { tenant: null }.',
   })
   async tenantContext(@Req() req: FastifyRequest) {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? host[0] : host;
+    const hostStr = resolvePublicHost(req);
     const tenant = await this.tenantResolver.resolveByHost(hostStr);
     if (!tenant) return { tenant: null, host: hostStr ?? null };
     const webBaseUrl = await this.tenantResolver.resolveTenantWebBaseUrl(tenant.id, req);
@@ -163,8 +163,7 @@ export class AuthController {
   // -------------------- helpers --------------------
 
   private async resolveTenantIdFromHost(req: FastifyRequest): Promise<string | undefined> {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? host[0] : host;
+    const hostStr = resolvePublicHost(req);
     const tenant = await this.tenantResolver.resolveByHost(hostStr);
     return tenant?.id;
   }

--- a/apps/api/src/common/resolve-public-host.ts
+++ b/apps/api/src/common/resolve-public-host.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+import type { RequestLike } from './resolve-web-base-url';
+
+/**
+ * El host PÚBLICO del request: el que tecleó la persona, no el del último salto.
+ *
+ * Didacta se despliega con el web (Next) como única puerta pública y la API
+ * detrás: `next.config.mjs` reescribe `/api/:path*` hacia `API_INTERNAL_URL`
+ * (`http://localhost:4000`). En ese salto **Next reemplaza `Host` por el del
+ * destino** y pone el original en `x-forwarded-host`.
+ *
+ * Por eso el orden importa, y estaba al revés: leer `req.headers.host` primero
+ * devuelve SIEMPRE `localhost:4000` en producción, y el `?? x-forwarded-host`
+ * que venía detrás era código muerto —`host` nunca falta—. Con eso, toda la
+ * multi-tenencia por hostname resolvía al tenant dueño de `localhost`, que en
+ * una instalación nueva es el primero que se creó: el aula de un cliente
+ * enseñaba la marca y las cifras de otro, y un alta pública aterrizaba en el
+ * tenant equivocado.
+ *
+ * `resolveWebBaseUrl` (misma carpeta) ya lo hacía bien desde el principio. Esto
+ * es la misma cascada, extraída para que haya UNA sola forma de preguntarlo.
+ *
+ * Sobre confiar en `x-forwarded-host`: es una cabecera que el cliente puede
+ * poner, sí — pero `Host` también, y `resolveByHost` siempre se apoyó en ella.
+ * No hay privilegio nuevo aquí: elegir tenant por cabecera solo cambia qué
+ * superficie PÚBLICA se ve; entrar sigue exigiendo credenciales de ese tenant.
+ * Traefik reescribe `X-Forwarded-*` para clientes no confiables, así que en el
+ * despliegue de Didacta el valor viene del proxy, no del visitante.
+ */
+export function resolvePublicHost(req: RequestLike): string | undefined {
+  const forwarded = firstValue(req.headers['x-forwarded-host']);
+  if (forwarded) return forwarded;
+  return firstValue(req.headers['host']);
+}
+
+/**
+ * Primer valor útil de una cabecera.
+ *
+ * Dos formas de venir en plural, y las dos pasan: repetida (Fastify la entrega
+ * como array) o encadenada por varios proxies en una sola línea
+ * (`a.example, b.internal`). En ambos casos el bueno es el PRIMERO — el que
+ * puso el proxy más cercano al visitante.
+ */
+function firstValue(value: string | string[] | undefined): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (!raw) return undefined;
+  const first = (raw.split(',')[0] ?? raw).trim();
+  return first.length > 0 ? first : undefined;
+}

--- a/apps/api/src/modules/billing/billing-public.controller.ts
+++ b/apps/api/src/modules/billing/billing-public.controller.ts
@@ -25,6 +25,7 @@ import { assertSignupsAllowed } from '../../tenancy/signup-freeze';
 import { runAsTenant } from '../../tenancy/tenant-context.storage';
 import { TenantResolverService } from '../../tenancy/tenant-resolver.service';
 import { ModuleRegistryService } from '../module-registry.service';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 const uuidSchema = z.string().uuid();
 
@@ -228,8 +229,7 @@ export class BillingPublicController {
 
   /** Tenant por dominio (Host / X-Forwarded-Host), como MembershipPublicController. */
   private async resolveTenantId(req: FastifyRequest): Promise<string> {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? host[0] : host;
+    const hostStr = resolvePublicHost(req);
     const tenant = await this.tenantResolver.resolveByHost(hostStr);
     if (!tenant) {
       throw new NotFoundException({

--- a/apps/api/src/modules/billing/billing-webhook.controller.ts
+++ b/apps/api/src/modules/billing/billing-webhook.controller.ts
@@ -25,6 +25,7 @@ import { TenantResolverService } from '../../tenancy/tenant-resolver.service';
 import { ModuleRegistryService } from '../module-registry.service';
 import { TenantStripeResolverService } from '../tenant-stripe-resolver.service';
 import { BillingProvisioningService } from './billing-provisioning.service';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 /**
  * Endpoint público de webhooks de Stripe. NO usa JwtAuthGuard porque Stripe
@@ -62,8 +63,7 @@ export class BillingWebhookController {
   async handle(@Req() req: RawBodyRequest<FastifyRequest>) {
     const billing = this.registry.getBillingService();
 
-    const hostHeader = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+    const hostStr = resolvePublicHost(req);
     const tenant = await runSanctionedGlobalAccess(() =>
       this.tenantResolver.resolveByHost(hostStr),
     );

--- a/apps/api/src/modules/member-registration/member-registration-public.controller.ts
+++ b/apps/api/src/modules/member-registration/member-registration-public.controller.ts
@@ -45,6 +45,7 @@ import { MemberRegistrationService } from './member-registration.service';
 import { TelegramService } from './telegram.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { assertSignupsAllowed } from '../../tenancy/signup-freeze';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 // ============================================================================
 // Controller PÚBLICO del flujo de inscripción de miembros con VERIFICADORES
@@ -400,8 +401,7 @@ export class MemberRegistrationPublicController {
    * tenant se infiere por dominio (igual que AuthController).
    */
   private async resolveTenantId(req: FastifyRequest): Promise<string> {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? host[0] : host;
+    const hostStr = resolvePublicHost(req);
     const tenant = await this.tenantResolver.resolveByHost(hostStr);
     if (!tenant) {
       throw new NotFoundException({

--- a/apps/api/src/modules/referrals/referrals.controller.ts
+++ b/apps/api/src/modules/referrals/referrals.controller.ts
@@ -30,6 +30,7 @@ import { extractClientContext } from '../../auth/client-context';
 import { runAsTenant } from '../../tenancy/tenant-context.storage';
 import { TenantResolverService } from '../../tenancy/tenant-resolver.service';
 import { ModuleRegistryService } from '../module-registry.service';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 /**
  * Endpoints del módulo mod.referrals.
@@ -259,8 +260,7 @@ export class ReferralsController {
 
   /** Tenant por dominio (Host / X-Forwarded-Host), como MembershipPublicController. */
   private async resolveTenantId(req: FastifyRequest): Promise<string> {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? host[0] : host;
+    const hostStr = resolvePublicHost(req);
     const tenant = await this.tenantResolver.resolveByHost(hostStr);
     if (!tenant) {
       throw new ForbiddenException({

--- a/apps/api/src/modules/subscriptions/membership-public.controller.ts
+++ b/apps/api/src/modules/subscriptions/membership-public.controller.ts
@@ -13,6 +13,7 @@ import { runAsTenant } from '../../tenancy/tenant-context.storage';
 import { TenantResolverService } from '../../tenancy/tenant-resolver.service';
 import { ModuleRegistryService } from '../module-registry.service';
 import { membershipCheckoutSchema, type MembershipCheckoutDto } from './membership.dto';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 /**
  * Endpoints PÚBLICOS de la página de membresía (/unete).
@@ -77,8 +78,7 @@ export class MembershipPublicController {
 
   /** Tenant por dominio (Host / X-Forwarded-Host), como InscripcionController. */
   private async resolveTenantId(req: FastifyRequest): Promise<string> {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? host[0] : host;
+    const hostStr = resolvePublicHost(req);
     const tenant = await this.tenantResolver.resolveByHost(hostStr);
     if (!tenant) {
       throw new NotFoundException({

--- a/apps/api/src/modules/subscriptions/subscriptions-webhook.controller.ts
+++ b/apps/api/src/modules/subscriptions/subscriptions-webhook.controller.ts
@@ -32,6 +32,7 @@ import { BillingProvisioningService } from '../billing/billing-provisioning.serv
 import { ModuleRegistryService } from '../module-registry.service';
 import { TenantStripeResolverService } from '../tenant-stripe-resolver.service';
 import { MembershipProvisioningService } from './membership-provisioning.service';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 /**
  * Endpoint público de webhooks de Stripe específico de mod.subscriptions.
@@ -64,8 +65,7 @@ export class SubscriptionsWebhookController {
   async handle(@Req() req: RawBodyRequest<FastifyRequest>) {
     const subs = this.registry.getSubscriptionsService();
 
-    const hostHeader = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+    const hostStr = resolvePublicHost(req);
     const tenant = await runSanctionedGlobalAccess(() =>
       this.tenantResolver.resolveByHost(hostStr),
     );

--- a/apps/api/src/modules/zoom-live/zoom-webhook.controller.ts
+++ b/apps/api/src/modules/zoom-live/zoom-webhook.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '../../tenancy/tenant-context.storage';
 import { TenantResolverService } from '../../tenancy/tenant-resolver.service';
 import { ModuleRegistryService } from '../module-registry.service';
+import { resolvePublicHost } from '../../common/resolve-public-host';
 
 /**
  * Endpoint público de webhooks de Zoom. NO usa JwtAuthGuard porque Zoom
@@ -63,8 +64,7 @@ export class ZoomWebhookController {
   async handle(@Req() req: RawBodyRequest<FastifyRequest>) {
     const zoomLive = this.registry.getZoomLiveService();
 
-    const hostHeader = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+    const hostStr = resolvePublicHost(req);
     const tenant = await runSanctionedGlobalAccess(() =>
       this.tenantResolver.resolveByHost(hostStr),
     );

--- a/apps/api/src/setup/setup.controller.ts
+++ b/apps/api/src/setup/setup.controller.ts
@@ -10,6 +10,7 @@ import { extractClientContext } from '../auth/client-context';
 import { ZodValidationPipe } from '../auth/zod-validation.pipe';
 import { setupInitSchema, type SetupInitDto } from './dto';
 import { SetupService } from './setup.service';
+import { resolvePublicHost } from '../common/resolve-public-host';
 
 @ApiTags('Setup')
 @Controller('setup')
@@ -44,8 +45,7 @@ export class SetupController {
     @Req() req: FastifyRequest,
     @Body(new ZodValidationPipe(setupInitSchema)) dto: SetupInitDto,
   ) {
-    const host = req.headers.host ?? req.headers['x-forwarded-host'];
-    const hostStr = Array.isArray(host) ? (host[0] ?? null) : (host ?? null);
+    const hostStr = resolvePublicHost(req) ?? null;
     // Quitamos el puerto: el TenantDomain.hostname no incluye `:port`. El
     // request a `localhost:4000` debe persistir como `localhost`.
     const hostNoPort = hostStr ? (hostStr.split(':')[0] ?? null) : null;

--- a/apps/api/src/setup/setup.service.ts
+++ b/apps/api/src/setup/setup.service.ts
@@ -191,7 +191,16 @@ export class SetupService {
       // Sembramos también `localhost` para que el operador pueda probar la
       // misma instalación desde el túnel SSH o `docker compose up` local sin
       // tener que añadir un dominio extra desde /admin.
-      if (hostname !== 'localhost') {
+      //
+      // FUERA DE PRODUCCIÓN, y no por pulcritud: en un pool multi-tenant este
+      // registro convierte al PRIMER tenant en el comodín de la instalación
+      // entera. Cualquier petición que llegue con `Host: localhost` —y todas
+      // llegaban así mientras el proxy se comía el host real, ver
+      // `resolvePublicHost`— resolvía a él. El fallo no se veía porque no daba
+      // error: contestaba 200 con los datos del tenant equivocado. Un `null`
+      // ruidoso habría durado horas; este comodín silencioso duró hasta el
+      // primer cliente.
+      if (hostname !== 'localhost' && process.env.NODE_ENV !== 'production') {
         await tx.tenantDomain.upsert({
           where: { hostname: 'localhost' },
           update: {},

--- a/apps/api/src/tenancy/tenancy.controller.ts
+++ b/apps/api/src/tenancy/tenancy.controller.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) VA360 LABS S.L.
+ * SPDX-License-Identifier: LicenseRef-Didacta-Sustainable-Use
+ */
+
+import { Controller, Get, Req } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { FastifyRequest } from 'fastify';
+import { resolvePublicHost } from '../common/resolve-public-host';
+import { TenantResolverService } from './tenant-resolver.service';
+
+/**
+ * ¿Este hostname pertenece a algún tenant?
+ *
+ * Existe para que el middleware del web pueda devolver 404 en un subdominio sin
+ * asignar (UC-C403 AC2). Con el comodín `*.didacta.io`, Traefik enruta al pool
+ * CUALQUIER nombre —esa es justo la propiedad que hace que un aula recién
+ * aprovisionada funcione sin tocar el proxy—, así que la única capa que puede
+ * decir «este host no es de nadie» es la aplicación.
+ *
+ * `auth/tenant-context` ya responde algo parecido, pero además consulta
+ * theming y dos cifras reales del tenant. Esto lo llama el middleware en CADA
+ * navegación: tiene que ser una sola consulta a `tenant_domain` y nada más.
+ *
+ * No revela nada que no fuera público: quién quiera saber si un subdominio
+ * existe solo tiene que visitarlo.
+ */
+@ApiTags('Tenancy')
+@Controller('tenancy')
+export class TenancyController {
+  constructor(private readonly tenantResolver: TenantResolverService) {}
+
+  @Get('resolve')
+  @ApiOperation({
+    summary: 'Resuelve el host público del request a un tenant. { known, slug, host }.',
+    description:
+      'El host sale de `X-Forwarded-Host` y, si no viene, de `Host`. El middleware del web reenvía el suyo en `X-Forwarded-Host` para preguntar por el dominio del visitante y no por el del salto interno.',
+  })
+  async resolve(@Req() req: FastifyRequest) {
+    const host = resolvePublicHost(req);
+    const tenant = await this.tenantResolver.resolveByHost(host);
+    return { known: tenant !== null, slug: tenant?.slug ?? null, host: host ?? null };
+  }
+}

--- a/apps/api/src/tenancy/tenancy.module.ts
+++ b/apps/api/src/tenancy/tenancy.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from '../auth/auth.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { SuperAdminPrismaService } from './super-admin-prisma.service';
 import { TenantContextService } from './tenant-context.service';
+import { TenancyController } from './tenancy.controller';
 import { TenantMiddleware } from './tenant.middleware';
 import { TenantPrismaService } from './tenant-prisma.service';
 import { TenantResolverService } from './tenant-resolver.service';
@@ -15,6 +16,7 @@ import { TenantResolverService } from './tenant-resolver.service';
 @Global()
 @Module({
   imports: [AuthModule, PrismaModule],
+  controllers: [TenancyController],
   providers: [
     TenantContextService,
     TenantMiddleware,

--- a/apps/api/tests/resolve-public-host.test.ts
+++ b/apps/api/tests/resolve-public-host.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePublicHost } from '../src/common/resolve-public-host';
+import type { RequestLike } from '../src/common/resolve-web-base-url';
+
+function makeReq(headers: Record<string, string | string[] | undefined>): RequestLike {
+  return { headers };
+}
+
+describe('resolvePublicHost', () => {
+  /**
+   * LA regresión. Esta es exactamente la forma que entrega el despliegue real:
+   * Next reescribe `/api/*` hacia `localhost:4000`, reemplaza `Host` por el del
+   * destino y deja el original en `x-forwarded-host`.
+   *
+   * Leer `host` primero devolvía `localhost:4000` en producción, y el tenant se
+   * resolvía por ahí — al dueño de `localhost`, que es el primer tenant creado.
+   * Ningún test lo vio porque todos llaman a la API directa, que es el único
+   * camino que en producción no existe.
+   */
+  it('con la forma que entrega el proxy, gana el host del visitante', () => {
+    const host = resolvePublicHost(
+      makeReq({ host: 'localhost:4000', 'x-forwarded-host': 'aula-demo.didacta.io' }),
+    );
+    expect(host).toBe('aula-demo.didacta.io');
+  });
+
+  it('sin proxy delante, cae al Host normal', () => {
+    expect(resolvePublicHost(makeReq({ host: 'academia.example.com' }))).toBe(
+      'academia.example.com',
+    );
+  });
+
+  it('conserva el puerto (quitarlo es cosa de quien normaliza después)', () => {
+    expect(resolvePublicHost(makeReq({ host: 'localhost:3000' }))).toBe('localhost:3000');
+  });
+
+  it('cabecera repetida: se queda con la primera', () => {
+    const host = resolvePublicHost(
+      makeReq({ 'x-forwarded-host': ['aula.didacta.io', 'interno.local'] }),
+    );
+    expect(host).toBe('aula.didacta.io');
+  });
+
+  it('cadena de proxies en una sola línea: se queda con el primero, que es el del visitante', () => {
+    const host = resolvePublicHost(
+      makeReq({ 'x-forwarded-host': 'aula.didacta.io, borde.interno, localhost:4000' }),
+    );
+    expect(host).toBe('aula.didacta.io');
+  });
+
+  it('x-forwarded-host vacío no tapa al Host bueno', () => {
+    expect(resolvePublicHost(makeReq({ 'x-forwarded-host': '', host: 'aula.didacta.io' }))).toBe(
+      'aula.didacta.io',
+    );
+  });
+
+  it('sin ninguna de las dos, undefined (el caller decide)', () => {
+    expect(resolvePublicHost(makeReq({}))).toBeUndefined();
+  });
+});

--- a/apps/api/tests/setup.service.test.ts
+++ b/apps/api/tests/setup.service.test.ts
@@ -471,6 +471,43 @@ describe('SetupService.init', () => {
     expect(localhostDomains).toHaveLength(1);
     expect(localhostDomains[0]?.isPrimary).toBe(true);
   });
+
+  /**
+   * En producción `localhost` NO se siembra, y no es cosmética: en un pool
+   * multi-tenant ese registro convierte al primer tenant en el comodín de la
+   * instalación entera. Toda petición que llegue con `Host: localhost` —y
+   * llegaban todas mientras el proxy se comía el host real— resolvía a él, y el
+   * aula de un cliente enseñaba los datos de otro. Contestando 200, además, que
+   * es lo que hizo que durase.
+   */
+  it('en producción NO siembra localhost como dominio del primer tenant', async () => {
+    const previo = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const { client, state } = makeFakePrisma();
+      const svc = new SetupService(
+        client as never,
+        realPasswords,
+        tokensFake,
+        dummyAuditLog,
+        sessionRegistryStub(tokensFake as never),
+        permissiveSetupTokensStub(),
+      );
+
+      await svc.init(
+        {
+          organization: { name: 'ACME Corp', primaryHostname: 'lms.acme.test' },
+          admin: { name: 'Pat Admin', email: 'pat@acme.test', password: 'super-secure-1234' },
+        },
+        'lms.acme.test',
+        { ip: null, userAgent: null },
+      );
+
+      expect(state.tenantDomains.map((d) => d.hostname)).toEqual(['lms.acme.test']);
+    } finally {
+      process.env.NODE_ENV = previo;
+    }
+  });
 });
 
 describe('SetupService.init — gate del token de setup', () => {

--- a/apps/api/tests/tenancy.controller.test.ts
+++ b/apps/api/tests/tenancy.controller.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TenancyController } from '../src/tenancy/tenancy.controller';
+import type { TenantResolverService } from '../src/tenancy/tenant-resolver.service';
+
+const TENANT = {
+  id: 'tenant-1',
+  slug: 'aula-demo',
+  name: 'Aula Demo',
+  matchedBy: 'hostname' as const,
+  hostname: 'aula-demo.didacta.io',
+};
+
+function makeController(resolved: typeof TENANT | null) {
+  const resolveByHost = vi.fn().mockResolvedValue(resolved);
+  const controller = new TenancyController({ resolveByHost } as unknown as TenantResolverService);
+  return { controller, resolveByHost };
+}
+
+/** La forma exacta con la que llega una petición en producción. */
+const reqTrasProxy = (publico: string) =>
+  ({ headers: { host: 'localhost:4000', 'x-forwarded-host': publico } }) as never;
+
+describe('TenancyController', () => {
+  it('un host de un tenant se reconoce', async () => {
+    const { controller, resolveByHost } = makeController(TENANT);
+    const res = await controller.resolve(reqTrasProxy('aula-demo.didacta.io'));
+    expect(res).toEqual({ known: true, slug: 'aula-demo', host: 'aula-demo.didacta.io' });
+    // Lo importante no es el 200: es CON QUÉ preguntó.
+    expect(resolveByHost).toHaveBeenCalledWith('aula-demo.didacta.io');
+  });
+
+  it('un subdominio sin asignar NO se reconoce (UC-C403 AC2)', async () => {
+    const { controller, resolveByHost } = makeController(null);
+    const res = await controller.resolve(reqTrasProxy('zzz-random.didacta.io'));
+    expect(res).toEqual({ known: false, slug: null, host: 'zzz-random.didacta.io' });
+    expect(resolveByHost).toHaveBeenCalledWith('zzz-random.didacta.io');
+  });
+
+  /**
+   * Sin esto el endpoint sería inútil: preguntaría siempre por `localhost:4000`
+   * y contestaría «conocido» a cualquier hostname, porque `localhost` pertenece
+   * al primer tenant. Es el mismo fallo que venía a cerrar, un piso más arriba.
+   */
+  it('nunca pregunta por el host del salto interno', async () => {
+    const { controller, resolveByHost } = makeController(null);
+    await controller.resolve(reqTrasProxy('cualquiera.didacta.io'));
+    expect(resolveByHost).not.toHaveBeenCalledWith('localhost:4000');
+  });
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,26 +6,56 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 /**
- * First-run gate.
+ * Dos puertas, en este orden.
  *
- * Cuando la instancia está virgen (sin tenants), redirige CUALQUIER ruta
- * de la app al wizard `/setup`. Una vez creado el primer tenant, el
- * middleware no toca nada y se vuelve un no-op (cacheamos `true` en memoria
- * del runtime — se invalida sólo al restart del worker).
+ * 1. **First-run gate.** Instancia sin tenants → cualquier ruta al wizard
+ *    `/setup`. Una vez creado el primer tenant se vuelve un no-op (cacheamos
+ *    `true` en memoria del runtime — se invalida solo al restart del worker).
  *
- * Bug previo: el matcher solo cubría rutas de auth (`/`, `/signin`, etc.).
- * Las rutas autenticadas dentro de `(app)` (`/cursos`, `/admin`, etc.)
- * pasaban directo y el shell de la app se renderizaba aunque el sistema
- * no tuviera tenants, dejando un estado roto pero accesible.
+ *    Bug previo: el matcher solo cubría rutas de auth (`/`, `/signin`, etc.).
+ *    Las rutas autenticadas dentro de `(app)` (`/cursos`, `/admin`, etc.)
+ *    pasaban directo y el shell de la app se renderizaba aunque el sistema no
+ *    tuviera tenants, dejando un estado roto pero accesible.
  *
- * Fix: el matcher ahora cubre TODO excepto rutas que NO deben gatearse
- * (api, internals de Next, assets estáticos, el propio /setup). Sin
- * tenants, cualquier path → /setup. Con tenants, cero overhead.
+ * 2. **Host gate (UC-C403 AC2).** Host que no pertenece a ningún tenant → 404.
+ *
+ *    Antes NO existía: en cuanto la instancia estaba inicializada el middleware
+ *    no miraba nada más, así que **cualquier** hostname enrutado hasta aquí
+ *    renderizaba la app entera. En el pool, con el comodín `*.didacta.io` y su
+ *    certificado válido, eso convertía cada subdominio libre en un login de
+ *    Didacta funcional y con HTTPS bueno — la superficie de phishing que
+ *    `tenant-resolver.service.ts` dice querer evitar en su propio comentario.
+ *
+ *    No se puede arreglar en Traefik: el comodín es justo lo que hace que un
+ *    aula recién aprovisionada funcione sin tocar el proxy. La capa correcta es
+ *    esta.
  */
+
+const API_INTERNAL_URL = process.env.API_INTERNAL_URL ?? 'http://localhost:4000';
+
+/**
+ * Escape hatch para volver al comportamiento anterior (servir la app en
+ * cualquier host). Existe porque esto es software que se autoaloja: si a
+ * alguien le rompe un acceso legítimo que no supimos prever, tiene que poder
+ * seguir trabajando hoy y abrir el issue mañana, no al revés.
+ */
+const ALLOW_UNKNOWN_HOSTS = process.env['DIDACTA_ALLOW_UNKNOWN_HOSTS'] === 'true';
 
 let initializedCache = false;
 
-const API_INTERNAL_URL = process.env.API_INTERNAL_URL ?? 'http://localhost:4000';
+/** host → (¿es de algún tenant?, cuándo caduca la respuesta). */
+const hostCache = new Map<string, { known: boolean; expiresAt: number }>();
+
+/**
+ * Un «sí» se cachea cinco minutos y un «no» solo treinta segundos.
+ *
+ * Asimétrico a propósito: el «no» es el que caduca mal. Un aula recién
+ * aprovisionada por el plano de control estrena hostname, y si su primer
+ * visitante se lleva un 404 cacheado cinco minutos, el cliente estrena su aula
+ * viendo que no existe.
+ */
+const TTL_CONOCIDO_MS = 5 * 60_000;
+const TTL_DESCONOCIDO_MS = 30_000;
 
 async function checkInitialized(): Promise<boolean> {
   if (initializedCache) return true;
@@ -45,14 +75,77 @@ async function checkInitialized(): Promise<boolean> {
   }
 }
 
+/**
+ * Hosts que nunca se gatean: `localhost` y las IP desnudas.
+ *
+ * Un self-hoster entra a su instalación por `http://<ip>:3000` constantemente
+ * —antes de tener DNS, desde la red local, por un túnel SSH— y ese host no es
+ * ni será un `TenantDomain`. Gatearlo convertiría este arreglo en «actualicé y
+ * ya no entro en mi propio servidor». La regla de fondo: aquí se cierran los
+ * nombres que un atacante puede APUNTAR a esta máquina, y una IP no se apunta.
+ */
+function esHostSiempreValido(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '[::1]') return true;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return true;
+  if (hostname.startsWith('[')) return true; // IPv6 entre corchetes
+  return false;
+}
+
+async function hostConocido(host: string): Promise<boolean> {
+  const ahora = Date.now();
+  const cacheado = hostCache.get(host);
+  if (cacheado && cacheado.expiresAt > ahora) return cacheado.known;
+
+  try {
+    const res = await fetch(`${API_INTERNAL_URL}/api/v1/tenancy/resolve`, {
+      cache: 'no-store',
+      // El host del visitante viaja explícito: esta llamada la hace el servidor
+      // del web contra la API, así que su propio `Host` es el del salto interno
+      // y no dice nada. Es la misma cabecera que Next pone al reescribir
+      // `/api/*`, así que la API la lee por el mismo camino que en producción.
+      headers: { 'x-forwarded-host': host },
+    });
+    // La API no contesta lo que esperábamos: dejar pasar. Un fallo de la API no
+    // debe convertirse en un 404 global — el modo degradado tiene que ser
+    // «como antes», no «el producto no existe».
+    if (!res.ok) return true;
+    const data = (await res.json()) as { known?: boolean };
+    const known = data.known === true;
+    hostCache.set(host, {
+      known,
+      expiresAt: ahora + (known ? TTL_CONOCIDO_MS : TTL_DESCONOCIDO_MS),
+    });
+    return known;
+  } catch {
+    return true;
+  }
+}
+
 export async function middleware(req: NextRequest) {
   const initialized = await checkInitialized();
-  if (initialized) return NextResponse.next();
+  if (!initialized) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/setup';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
 
-  const url = req.nextUrl.clone();
-  url.pathname = '/setup';
-  url.search = '';
-  return NextResponse.redirect(url);
+  if (ALLOW_UNKNOWN_HOSTS) return NextResponse.next();
+
+  const rawHost = req.headers.get('x-forwarded-host') ?? req.headers.get('host');
+  if (!rawHost) return NextResponse.next();
+  const host = (rawHost.split(',')[0] ?? rawHost).trim().toLowerCase();
+  const hostname = host.startsWith('[') ? host : (host.split(':')[0] ?? host);
+  if (esHostSiempreValido(hostname)) return NextResponse.next();
+
+  if (await hostConocido(host)) return NextResponse.next();
+
+  // 404 pelado, sin marca: si este nombre no es de nadie, no hay nada que
+  // contar sobre qué corre por debajo.
+  return new NextResponse('Not Found', {
+    status: 404,
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+  });
 }
 
 /// Matcher negativo: capturamos cualquier path EXCEPTO los listados.


### PR DESCRIPTION
Cierra **UC-C403 AC2**. Encontrado montando el primer tenant del pool en producción.

## Qué pasaba

Didacta se despliega con Next como única puerta pública y la API detrás: `next.config.mjs` reescribe `/api/:path*` hacia `API_INTERNAL_URL`. **En ese salto Next reemplaza `Host` por el del destino** y deja el original en `x-forwarded-host`.

La API leía `req.headers.host ?? req.headers['x-forwarded-host']` — `host` primero. Y como `host` nunca falta, ese `??` era **código muerto**: en producción la API veía siempre `localhost:4000`. Diez sitios lo hacían al revés; `resolveWebBaseUrl`, en la carpeta de al lado, lo hacía bien desde el principio y hasta lo documentaba.

## Por qué no dio la cara antes

Porque no fallaba: **contestaba 200 con los datos del tenant equivocado**.

`resolveByHost` resolvía por `localhost`, que `/setup/init` siembra como dominio verificado del **primer tenant**. Así que toda superficie pública que resuelve por Host operaba contra el primer tenant en el subdominio de *cualquier* cliente: marca y cifras de las pantallas de acceso, catálogo, altas de `mod.member-registration`, membresía, referidos y el escopado por tenant del `signin`. **Un alta pública en el aula de un cliente aterrizaba en la de otro.**

**No hay fuga de datos autenticados**: la sesión se escopa al tenant del propio usuario (el `signin` cae al fallback email-first) y RLS hace el resto.

Un self-hoster de un solo tenant no lo nota nunca: solo hay un tenant y `localhost` apunta a él. Por eso sobrevivió hasta el primer despliegue multi-tenant.

## Medido en el pool, antes del arreglo

`GET /api/v1/auth/tenant-context` devuelve el host que vio la API:

| Host del visitante | API directa `:4000` | Por el proxy (producción) |
|---|---|---|
| `pool.didacta.io` | `didacta-cloud` ✅ | `didacta-cloud` |
| `aula-demo.didacta.io` | `aula-demo` ✅ | **`didacta-cloud`** ❌ |
| `zzz-random.didacta.io` | **`tenant: null`** ✅ | **`didacta-cloud`** ❌ |

Las tres, por el proxy, con `"host":"localhost:4000"`.

## El cambio

1. **`resolvePublicHost()`** — una sola forma de preguntar por el host del visitante, con `x-forwarded-host` delante. Contempla la cabecera repetida y la cadena de proxies en una línea; en las dos gana la primera, que es la del visitante.
2. **Un host sin tenant devuelve 404** (AC2). Antes el middleware del web era un no-op en cuanto la instancia estaba inicializada, así que **cualquier** hostname renderizaba la app entera: en el pool, con el comodín `*.didacta.io` y su certificado válido, cada subdominio libre era un login de Didacta funcional con HTTPS bueno — la superficie de phishing que `tenant-resolver.service.ts` dice querer evitar en su propio comentario. No se arregla en Traefik (el comodín es justo lo que hace que un aula recién aprovisionada funcione sin tocar el proxy), así que se cierra en la app con `GET /tenancy/resolve` y caché en el middleware. Los «no» caducan a los 30 s y los «sí» a los 5 min: el que caduca mal es el «no», porque un aula recién creada estrena hostname.
3. **`/setup/init` deja de sembrar `localhost` en producción.** Es una comodidad de desarrollo que en un pool convierte al primer tenant en comodín de la instalación entera.

### Lo que NO se gatea

`localhost` y las IP desnudas pasan siempre: el self-hoster entra por `http://<ip>:3000` a diario —antes de tener DNS, desde la red local, por un túnel— y eso no es ni será un `TenantDomain`. Gatearlo convertiría esto en «actualicé y ya no entro en mi servidor». Queda además `DIDACTA_ALLOW_UNKNOWN_HOSTS=true` como escape hatch.

## Verificación

**Por el camino real, que es lo que faltaba.** API compilada de esta rama detrás de Next, con Host de visitante:

```
tenant-context POR EL PROXY
  humo-q15zid.localhost  → tenant=humo-q15zid   (antes: el primero)
  humo-pw42em.localhost  → tenant=humo-pw42em   (antes: el primero)

navegación real
  humo-q15zid.localhost   → 200
  zzz-random.didacta.io   → 404
  banco-falso.didacta.io  → 404
  localhost:4556          → 200
  127.0.0.1:4556          → 200
```

Los tests nuevos usan la forma exacta que entrega el proxy (`host: localhost:4000` + `x-forwarded-host`). **Los de antes llamaban a la API directa, que es el único camino que en producción no existe** — por eso 2484 tests en verde no vieron nada.

api 2484/2484 · web 385/385 · typecheck y lint limpios.